### PR TITLE
Implement API Token Validation in API Gateway

### DIFF
--- a/saberparatodos/supabase/functions/api-gateway/index.ts
+++ b/saberparatodos/supabase/functions/api-gateway/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -28,9 +29,23 @@ serve(async (req: Request) => {
       )
     }
 
-    // TODO: Validate the token against the database
-    // const token = authHeader.replace('Bearer ', '')
-    // const { data, error } = await supabase.from('api_keys').select('*').eq('key', token).single()
+    // Validate the token against the database
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    const token = authHeader.replace('Bearer ', '')
+    const { data, error } = await supabase.from('api_keys').select('*').eq('key', token).single()
+
+    if (error || !data) {
+      return new Response(
+        JSON.stringify({ error: "Unauthorized", message: "Invalid API Key" }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      )
+    }
 
     // Mock response for valid token
     const mockQuestions = [


### PR DESCRIPTION
Implemented Supabase database validation for API tokens in the api-gateway Edge Function. The function now verifies the bearer token against the `api_keys` table using the service role key.

---
*PR created automatically by Jules for task [194802884097318025](https://jules.google.com/task/194802884097318025) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded API gateway authentication with real token validation using database lookups instead of placeholder checks
  * Invalid or improperly formatted tokens now correctly return 401 Unauthorized status
  * Missing tokens continue to return 402 Payment Required status

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->