### PR TITLE
Fix Grade 3 Period 4 Exam Generation Anomalies

### DIFF
--- a/saberparatodos/src/pages/api/[country]/[exam]/[grade]/[subject]/[page].json.ts
+++ b/saberparatodos/src/pages/api/[country]/[exam]/[grade]/[subject]/[page].json.ts
@@ -140,6 +140,14 @@ export const GET: APIRoute = async ({ params }) => {
         return parseQuickBundle(body, entry.data.id, startIndex + entryIndex);
       }
 
+      // 🆕 Check for STANDARD BUNDLE format (## Pregunta 1, ## Pregunta 2)
+      // This supports Grade 3 bundles that contain multiple "Standard Protocol" questions
+      const isStandardBundle = body.includes('## Pregunta 1') || body.includes('## Pregunta 2');
+
+      if (isStandardBundle) {
+          return parseStandardBundle(body, entry.data, startIndex + entryIndex);
+      }
+
       // STANDARD Protocol v3 format: ### Enunciado, ### Opciones, ### Explicación
       const questionText = extractSection(body, '### Enunciado', '### Opciones') || entry.data.id;
       const optionsText = extractSection(body, '### Opciones', '### Explicación') || '';
@@ -361,6 +369,87 @@ function parseQuickBundle(
         context_tags: []
       });
     }
+  }
+
+  return results;
+}
+
+/**
+ * 🆕 Parse Standard Bundle format (## Pregunta X)
+ * Used in Grade 3 bundles where multiple standard protocol questions exist in one file.
+ */
+function parseStandardBundle(
+  body: string,
+  data: any,
+  startNumber: number
+): Array<any> {
+  const results: Array<any> = [];
+
+  // Split by ## Pregunta \d+
+  // Use a lookahead to keep the delimiter in the split results?
+  // Actually, standard split consumes delimiter.
+  // We can use capture group to keep it, but easier to just split by lookahead.
+  const sections = body.split(/(?=## Pregunta \d+)/);
+
+  // Extract global context from the preamble (section before ## Pregunta 1)
+  let globalContext = '';
+  if (sections.length > 0 && !sections[0].startsWith('## Pregunta')) {
+    const preamble = sections[0];
+    // Try to find "> **Contexto:**" block
+    const contextMatch = preamble.match(/> \*\*Contexto:\*\*(.+)/);
+    if (contextMatch) {
+        globalContext = contextMatch[1].trim();
+    } else {
+        // Or just any blockquote
+        const quoteMatch = preamble.match(/> (.+)/);
+        if (quoteMatch) {
+            globalContext = quoteMatch[1].trim();
+        }
+    }
+  }
+
+  let qIndex = 0;
+  for (const section of sections) {
+    if (!section.startsWith('## Pregunta')) continue;
+
+    qIndex++;
+
+    // Extract ID from **ID:** `...`
+    const idMatch = section.match(/\*\*ID:\*\*\s*`([^`]+)`/);
+    const questionId = idMatch ? idMatch[1] : `${data.id}-v${qIndex}`;
+
+    // Use existing extractSection logic on this chunk
+    const questionText = extractSection(section, '### Enunciado', '### Opciones');
+    const optionsText = extractSection(section, '### Opciones', '### Explicación');
+    const explanation = extractSection(section, '### Explicación Pedagógica', '---'); // --- might be at end of section
+
+    if (!questionText || !optionsText) continue;
+
+    const options = parseOptions(optionsText);
+    const correctOption = options.find(opt => opt.is_correct);
+
+    // If options are missing or invalid, skip
+    if (options.length < 2) continue;
+
+    results.push({
+      id: questionId,
+      number: startNumber + qIndex, // Note: This might overlap if multiple files are flattened. But 'number' is usually just for display.
+      statement: questionText.trim(),
+      options: options,
+      correct_answer: correctOption?.letter || 'A',
+      explanation: explanation.trim(),
+      difficulty: mapDifficulty(data.dificultad),
+      bundle_id: data.id,
+      source_url: data.source_url || '',
+      tema: data.tema || '',
+      tags: [data.tema, data.asignatura].filter(Boolean),
+      images: [],
+      // Attach extracted context
+      context: globalContext || data.context || undefined,
+      modern_context: data.modern_context || false,
+      context_type: data.context_type || null,
+      context_tags: data.context_tags || []
+    });
   }
 
   return results;


### PR DESCRIPTION
Implemented `parseStandardBundle` in `saberparatodos/src/pages/api/[country]/[exam]/[grade]/[subject]/[page].json.ts`.
This ensures that question files containing multiple questions delimited by `## Pregunta X` (common in Grade 3 bundles like `CO-MAT-3-problemas-001-bundle.md`) are fully parsed, extracting all questions instead of just the first one.
This resolves the "anomaly" where Grade 3 Period 4 exams were failing due to insufficient questions.

---
*PR created automatically by Jules for task [1083011094283638045](https://jules.google.com/task/1083011094283638045) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new question bundle format that improves parsing accuracy and enriches question metadata with contextual information, including difficulty levels, source data, and thematic tags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->