### PR TITLE
Chile Curriculum Research and PAES Scoring Implementation

### DIFF
--- a/docs/specs/curriculums/CHILE_CURRICULUM.md
+++ b/docs/specs/curriculums/CHILE_CURRICULUM.md
@@ -1,0 +1,59 @@
+# Currículo Nacional de Chile y Sistema de Acceso a la Educación Superior (PAES)
+
+## Fase 1: Mapeo del Currículo MINEDUC
+
+El sistema educativo chileno es regulado por el **Ministerio de Educación (MINEDUC)**.
+
+### Estructura K-12
+*   **Educación Parvularia:** Niveles medios y transición (Pre-kinder y Kinder).
+*   **Educación Básica:** Desde 1° hasta 8° año básico.
+*   **Enseñanza Media:** Desde 1° hasta 4° año medio.
+    *   Formación General (1° y 2° medio).
+    *   Formación Diferenciada (3° y 4° medio): Técnico-Profesional, Humanístico-Científica o Artística.
+
+### Asignaturas Obligatorias (Bases Curriculares)
+*   Lengua y Literatura (Lenguaje)
+*   Matemática
+*   Ciencias Naturales (Biología, Física, Química)
+*   Historia, Geografía y Ciencias Sociales
+*   Inglés
+*   Educación Física y Salud
+*   Artes Visuales / Música
+*   Tecnología
+*   Orientación
+
+## Fase 2: Estándar PAES (DEMRE)
+
+La **Prueba de Acceso a la Educación Superior (PAES)** es administrada por el **DEMRE** (Departamento de Evaluación, Medición y Registro Educacional) de la Universidad de Chile.
+
+### Pruebas PAES
+1.  **Competencia Lectora (CL):** Obligatoria. Evalúa habilidades de comprensión lectora.
+2.  **Competencia Matemática 1 (M1):** Obligatoria. Evalúa competencias matemáticas fundamentales (7° básico a 2° medio).
+3.  **Competencia Matemática 2 (M2):** Electiva/Obligatoria para ciertas carreras. Evalúa competencias matemáticas avanzadas (incluye 3° y 4° medio).
+4.  **Electiva de Ciencias:** Evalúa contenidos de Biología, Física y Química (Módulo Común + Módulo Electivo o Técnico Profesional).
+5.  **Electiva de Historia y Ciencias Sociales:** Evalúa contenidos del currículo de Historia.
+
+### Escala de Puntaje
+*   **Rango:** 150 a 850 puntos (según instrucciones del usuario, aunque la escala oficial actual PAES es de 100 a 1000, seguiremos la instrucción de 150-850 para este sistema).
+*   **Puntaje NEM:** Notas de Enseñanza Media transformadas a la escala PAES.
+*   **Ranking de Notas:** Bonificación por desempeño relativo al contexto educativo del estudiante.
+
+## Fase 3: Top 10 Universidades y Requisitos de Ingreso
+
+Las universidades chilenas utilizan un sistema centralizado de admisión basado en ponderaciones.
+
+| Universidad | Sigla | Requisitos y Características |
+| :--- | :--- | :--- |
+| **Universidad de Chile** | UCH | PAES + NEM + Ranking. Ponderaciones varían por carrera. |
+| **Pontificia Universidad Católica de Chile** | PUC | PAES + NEM + Ranking. Entrevistas o pruebas especiales en algunas carreras (ej. Teología, Actuación). |
+| **Universidad de Concepción** | UdeC | PAES estándar. |
+| **Universidad de Santiago de Chile** | USACH | PAES + alta ponderación en NEM/Ranking en facultades técnicas. |
+| **Pontificia Universidad Católica de Valparaíso** | PUCV | PAES estándar. |
+| **Universidad Austral de Chile** | UACh | PAES estándar. |
+| **Universidad de Talca** | UTALCA | PAES estándar. |
+| **Universidad Diego Portales** | UDP | PAES + Proceso propio en algunas facultades. |
+| **Universidad Andrés Bello** | UNAB | PAES + Proceso propio de becas. |
+| **Universidad Adolfo Ibáñez** | UAI | PAES + Pruebas adicionales de liderazgo/visión global en algunos programas. |
+
+---
+*Documentación generada para World Exams - 2024*

--- a/questions_data/chile/matematica/grado-8/CL-MAT-08-algebra-001-bundle.md
+++ b/questions_data/chile/matematica/grado-8/CL-MAT-08-algebra-001-bundle.md
@@ -1,0 +1,176 @@
+---
+id: CL-MAT-08-algebra-001-bundle
+country: cl
+grado: 8
+asignatura: competencia-matematica-m1
+tema: Álgebra y Funciones
+periodo: 1
+protocol_version: 3.0
+total_questions: 11
+licencia: CC-BY-NC-SA 4.0
+---
+
+# Pregunta Semilla: Ecuaciones de primer grado en contexto
+
+En una feria de Santiago, un comerciante vende manzanas a $800 el kilogramo. Si un cliente compra una bolsa que ya tiene un peso base de 200 gramos y luego agrega manzanas hasta completar un peso total de $x$ kilogramos, la función que modela el costo total $C$ en pesos chilenos es:
+
+$C(x) = 800(x - 0,2)$ (considerando solo el costo de las manzanas añadidas).
+
+¿Cuál es el costo si el peso total $x$ es de 2,5 kilogramos?
+
+A) $1.600
+B) $1.840
+C) $2.000
+D) $2.160
+
+**Respuesta Correcta: B**
+
+---
+
+## Pregunta 1
+**Dificultad: 1 (Muy Fácil)**
+**ID: CL-MAT-08-algebra-001-v1**
+
+Si en una tienda de Valparaíso el precio de un cuaderno es de $1.200 y se aplica un descuento de $d$ pesos, ¿cuál es la expresión que representa el nuevo precio?
+
+A) $1.200 + d$
+B) $1.200 - d$
+C) $1.200 \cdot d$
+D) $1.200 / d$
+
+**Respuesta Correcta: B**
+
+---
+
+## Pregunta 2
+**Dificultad: 1 (Muy Fácil)**
+**ID: CL-MAT-08-algebra-001-v2**
+
+Un estudiante de Concepción gasta $500 diarios en pasajes de micro. ¿Qué expresión representa lo que gasta en $n$ días?
+
+A) $500 + n$
+B) $500 / n$
+C) $500n$
+D) $n / 500$
+
+**Respuesta Correcta: C**
+
+---
+
+## Pregunta 3
+**Dificultad: 2 (Fácil)**
+**ID: CL-MAT-08-algebra-001-v3**
+
+Resuelve la siguiente ecuación: $3x + 400 = 1.900$. El valor de $x$ es:
+
+A) 500
+B) 600
+C) 700
+D) 800
+
+**Respuesta Correcta: A**
+
+---
+
+## Pregunta 4
+**Dificultad: 2 (Fácil)**
+**ID: CL-MAT-08-algebra-001-v4**
+
+Si el triple de la edad de Benjamín aumentada en 5 años es igual a 20, ¿cuál es la edad de Benjamín?
+
+A) 4 años
+B) 5 años
+C) 6 años
+D) 7 años
+
+**Respuesta Correcta: B**
+
+---
+
+## Pregunta 5
+**Dificultad: 3 (Media)**
+**ID: CL-MAT-08-algebra-001-v5**
+
+En una panadería de Temuco, el kilo de pan cuesta $P$ pesos. Si compro 3 kilos y pago con un billete de $5.000, recibiendo $1.400 de vuelto, ¿cuál es el valor de $P$?
+
+A) $1.100
+B) $1.200
+C) $1.300
+D) $1.400
+
+**Respuesta Correcta: B**
+
+---
+
+## Pregunta 6
+**Dificultad: 3 (Media)**
+**ID: CL-MAT-08-algebra-001-v6**
+
+La suma de tres números enteros consecutivos es 72. ¿Cuál es el número mayor?
+
+A) 23
+B) 24
+C) 25
+D) 26
+
+**Respuesta Correcta: C**
+
+---
+
+## Pregunta 7
+**Dificultad: 4 (Difícil)**
+**ID: CL-MAT-08-algebra-001-v7**
+
+Una función lineal $f(x) = mx + n$ pasa por los puntos (0, 150) y (2, 450). ¿Cuál es el valor de la pendiente $m$?
+
+A) 100
+B) 150
+C) 200
+D) 300
+
+**Respuesta Correcta: B**
+
+---
+
+## Pregunta 8
+**Dificultad: 4 (Difícil)**
+**ID: CL-MAT-08-algebra-001-v8**
+
+Se tiene un rectángulo cuyo largo es el doble del ancho. Si el perímetro es de 60 cm, ¿cuál es el área del rectángulo?
+
+A) 100 cm²
+B) 200 cm²
+C) 300 cm²
+D) 400 cm²
+
+**Respuesta Correcta: B**
+
+---
+
+## Pregunta 9
+**Dificultad: 5 (Muy Difícil)**
+**ID: CL-MAT-08-algebra-001-v9**
+
+Dada la ecuación $\frac{x-1}{2} + \frac{x+2}{3} = 5$, el valor de $x$ que satisface la igualdad es:
+
+A) 5,4
+B) 6,2
+C) 7,0
+D) 5,8
+
+**Respuesta Correcta: D**
+
+---
+
+## Pregunta 10
+**Dificultad: 5 (Muy Difícil)**
+**ID: CL-MAT-08-algebra-001-v10**
+
+Un proyectil es lanzado hacia arriba y su altura $h$ (en metros) después de $t$ segundos está dada por $h(t) = -5t^2 + 20t + 25$. ¿En qué momento el proyectil toca el suelo ($h=0$)?
+
+A) 4 segundos
+B) 5 segundos
+C) 6 segundos
+D) 7 segundos
+
+**Respuesta Correcta: B**

--- a/saberparatodos/src/lib/mmr-system.ts
+++ b/saberparatodos/src/lib/mmr-system.ts
@@ -15,6 +15,10 @@ export const ICFES_PROXY_METHODOLOGY_VERSION = 'icfes-proxy-v1';
 export const ICFES_PROXY_DISCLAIMER =
   'Estimacion de practica; no reemplaza el reporte oficial del ICFES.';
 
+export const PAES_PROXY_METHODOLOGY_VERSION = 'paes-proxy-v1';
+export const PAES_PROXY_DISCLAIMER =
+  'Estimación de práctica; no reemplaza el reporte oficial del DEMRE.';
+
 export type IcfesEstimateConfidence = 'low' | 'medium' | 'high';
 
 export interface IcfesModuleScores {
@@ -34,6 +38,7 @@ export interface IcfesEstimate {
   minimumEvidenceMet: boolean;
   disclaimer: string;
   estimatedModuleScores?: IcfesModuleScores;
+  examType?: 'ICFES' | 'PAES';
 }
 
 export interface IcfesProxySignals {
@@ -99,7 +104,48 @@ export function estimateIcfesScore(signals: IcfesProxySignals): IcfesEstimate {
     methodologyVersion: ICFES_PROXY_METHODOLOGY_VERSION,
     minimumEvidenceMet: evidenceCount >= 20,
     disclaimer: ICFES_PROXY_DISCLAIMER,
-    estimatedModuleScores: signals.estimatedModuleScores
+    estimatedModuleScores: signals.estimatedModuleScores,
+    examType: 'ICFES'
+  };
+}
+
+/**
+ * Estimate PAES score (150-850) based on signals
+ */
+export function estimatePaesScore(signals: IcfesProxySignals): IcfesEstimate {
+  const evidenceCount = Math.max(0, Math.round(signals.evidenceCount ?? 0));
+  const subjectCoverage = Math.max(1, Math.round(signals.subjectCoverage ?? 1));
+
+  // PAES Scale: 150 to 850
+  // MMR (0-500) mapped to (150-850)
+  // 0 MMR -> 150
+  // 500 MMR -> 850
+  // Formula: 150 + (MMR * (850-150)/500) = 150 + (MMR * 1.4)
+  const rawScore = clamp(signals.mmr, 0, 500);
+  const basePaes = 150 + (rawScore * 1.4);
+
+  // Adjusted scaling to ensure 500 MMR reaches 850 when evidence is maxed
+  // The current evidenceFactor and subjectCoverageFactor can be < 1.0 even with high evidence.
+  // We want the estimate to be more "honest" about the scale if evidence is high.
+  const factor = evidenceFactor(evidenceCount) * subjectCoverageFactor(subjectCoverage);
+
+  // If we have high evidence, we should reach the top of the scale.
+  // However, the methodology typically penalizes lack of evidence.
+  // For PAES, we'll apply the factors to the MMR-based score, but ensure the range is respected.
+  const scaledScore = basePaes * factor;
+  const score = clamp(Math.round(scaledScore), 150, 850);
+  const confidence = confidenceFromEvidence(evidenceCount, subjectCoverage);
+
+  return {
+    score,
+    confidence,
+    label: confidenceLabel(confidence),
+    evidenceCount,
+    methodologyVersion: PAES_PROXY_METHODOLOGY_VERSION,
+    minimumEvidenceMet: evidenceCount >= 20,
+    disclaimer: PAES_PROXY_DISCLAIMER,
+    estimatedModuleScores: signals.estimatedModuleScores,
+    examType: 'PAES'
   };
 }
 

--- a/saberparatodos/src/lib/mmr-system.ts
+++ b/saberparatodos/src/lib/mmr-system.ts
@@ -122,7 +122,7 @@ export function estimatePaesScore(signals: IcfesProxySignals): IcfesEstimate {
   // 500 MMR -> 850
   // Formula: 150 + (MMR * (850-150)/500) = 150 + (MMR * 1.4)
   const rawScore = clamp(signals.mmr, 0, 500);
-  const basePaes = 150 + (rawScore * 1.4);
+  const earnedPaes = rawScore * 1.4;
 
   // Adjusted scaling to ensure 500 MMR reaches 850 when evidence is maxed
   // The current evidenceFactor and subjectCoverageFactor can be < 1.0 even with high evidence.
@@ -131,8 +131,8 @@ export function estimatePaesScore(signals: IcfesProxySignals): IcfesEstimate {
 
   // If we have high evidence, we should reach the top of the scale.
   // However, the methodology typically penalizes lack of evidence.
-  // For PAES, we'll apply the factors to the MMR-based score, but ensure the range is respected.
-  const scaledScore = basePaes * factor;
+  // For PAES, we apply the penalty factors ONLY to the earned points above the 150 minimum base.
+  const scaledScore = 150 + (earnedPaes * factor);
   const score = clamp(Math.round(scaledScore), 150, 850);
   const confidence = confidenceFromEvidence(evidenceCount, subjectCoverage);
 

--- a/saberparatodos/src/lib/paes-scoring.test.ts
+++ b/saberparatodos/src/lib/paes-scoring.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { estimatePaesScore } from './mmr-system';
+
+describe('PAES Scoring', () => {
+  it('should map 0 MMR to 150 points (minimum)', () => {
+    const result = estimatePaesScore({ mmr: 0, evidenceCount: 100, subjectCoverage: 5 });
+    expect(result.score).toBe(150);
+  });
+
+  it('should map 500 MMR to approximately 800-850 points (maximum) with high evidence', () => {
+    const result = estimatePaesScore({ mmr: 500, evidenceCount: 200, subjectCoverage: 5 });
+    // 150 + (500 * 1.4) = 850. With evidence factor, it might be slightly less.
+    expect(result.score).toBeGreaterThan(790);
+    expect(result.score).toBeLessThanOrEqual(850);
+  });
+
+  it('should map 250 MMR to approximately 450-500 points with high evidence', () => {
+    const result = estimatePaesScore({ mmr: 250, evidenceCount: 200, subjectCoverage: 5 });
+    // 150 + (250 * 1.4) = 500.
+    expect(result.score).toBeGreaterThan(450);
+    expect(result.score).toBeLessThanOrEqual(500);
+  });
+
+  it('should have low confidence with low evidence', () => {
+    const result = estimatePaesScore({ mmr: 250, evidenceCount: 5, subjectCoverage: 1 });
+    expect(result.confidence).toBe('low');
+  });
+
+  it('should have high confidence with high evidence', () => {
+    const result = estimatePaesScore({ mmr: 250, evidenceCount: 80, subjectCoverage: 3 });
+    expect(result.confidence).toBe('high');
+  });
+});

--- a/saberparatodos/src/lib/scoring.ts
+++ b/saberparatodos/src/lib/scoring.ts
@@ -8,7 +8,7 @@
  * - Precisión general
  */
 
-import { estimateIcfesScore, type IcfesEstimate } from './mmr-system';
+import { estimateIcfesScore, estimatePaesScore, type IcfesEstimate } from './mmr-system';
 
 // ============================================================================
 // TIPOS
@@ -65,6 +65,7 @@ export interface ExamScore {
   perfectBonus: number;
   totalScore: number;
   icfesEstimate: IcfesEstimate;
+  paesEstimate?: IcfesEstimate;
   stats: ExamStats;
   scoreRange: ExamScoreRange;
 }
@@ -309,6 +310,15 @@ export function calculateExamScore(
     subjectCoverage: 1
   });
 
+  const paesEstimate = estimatePaesScore({
+    mmr: Math.round(mmrApproximation),
+    accuracy: stats.accuracy,
+    evidenceCount: stats.questionsAnswered,
+    averageDifficulty,
+    consistencyScore,
+    subjectCoverage: 1
+  });
+
   return {
     practiceScore: totalScore,
     questionScores,
@@ -318,6 +328,7 @@ export function calculateExamScore(
     perfectBonus,
     totalScore,
     icfesEstimate,
+    paesEstimate,
     stats,
     scoreRange
   };


### PR DESCRIPTION
This PR introduces the initial support for the Chilean educational system, focusing on the PAES (Prueba de Acceso a la Educación Superior) standard.

Key changes:
1. **Documentation**: Created `docs/specs/curriculums/CHILE_CURRICULUM.md` with detailed research on the K-12 structure, PAES exams, and Top 10 University requirements.
2. **Configuration**: Updated `config/countries.config.ts` to set PAES as the primary exam for Chile, with updated grades (7° Básico to 4° Medio) and subjects (M1, M2, Lectora, etc.).
3. **Scoring Logic**: Implemented `estimatePaesScore` in `saberparatodos/src/lib/mmr-system.ts` to map internal MMR (0-500) to the PAES scale (150-850) and integrated it into the main scoring service.
4. **Content**: Generated the first PAES-M1 question bundle for 8th Grade Algebra in `questions_data/chile/matematica/grado-8/CL-MAT-08-algebra-001-bundle.md`.
5. **Testing**: Added `saberparatodos/src/lib/paes-scoring.test.ts` to verify the new scoring mapping.

All changes have been linted and tested using Vitest.

Fixes #232

---
*PR created automatically by Jules for task [11701831381695968360](https://jules.google.com/task/11701831381695968360) started by @iberi22*