### PR TITLE
Regenerate invalid Colombia exam bundles - MASTERY format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,7 +266,6 @@
       "version": "0.9.8",
       "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.8.tgz",
       "integrity": "sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@astrojs/language-server": "^2.16.5",
@@ -8485,7 +8484,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -14438,7 +14436,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"

--- a/saberparatodos/src/content/questions/colombia/ciencias-naturales/grado-11/hidrocarburos/CO-CIE-11-P1-hidrocarburos-001-MASTERY-bundle.md
+++ b/saberparatodos/src/content/questions/colombia/ciencias-naturales/grado-11/hidrocarburos/CO-CIE-11-P1-hidrocarburos-001-MASTERY-bundle.md
@@ -1,0 +1,186 @@
+layout: bundle
+subject: ciencias-naturales
+grade: 11
+period: 1
+topic: hidrocarburos
+difficulty: medium
+
+Question 1 (Difficulty 3)
+Los hidrocarburos son compuestos orgánicos formados únicamente por átomos de carbono e hidrógeno. Se clasifican principalmente en alcanos, alquenos y alquinos.
+¿Cuál es la característica principal de los alcanos en cuanto a sus enlaces entre átomos de carbono?
+
+ A) [x] Presentan únicamente enlaces sencillos (sigma).
+ B) Tienen al menos un enlace doble.
+ C) Poseen enlaces triples en su estructura.
+ D) Forman anillos aromáticos con electrones deslocalizados.
+
+Question 2 (Difficulty 3)
+La nomenclatura IUPAC permite nombrar de manera sistemática los compuestos orgánicos basándose en el número de carbonos de la cadena principal.
+¿Cómo se llama el alcano de cadena lineal que tiene cuatro átomos de carbono?
+
+ A) Metano
+ B) Etano
+ C) Propano
+ D) [x] Butano
+
+Question 3 (Difficulty 3)
+Los hidrocarburos tienen diversas aplicaciones industriales, principalmente como combustibles debido a su alta entalpía de combustión.
+¿Cuál de los siguientes hidrocarburos es el componente principal del gas natural utilizado en los hogares?
+
+ A) [x] Metano
+ B) Hexano
+ C) Benceno
+ D) Acetileno
+
+Question 4 (Difficulty 3)
+La hibridación del carbono explica la geometría de las moléculas orgánicas.
+En un alqueno como el eteno (C2H4), ¿cuál es el tipo de hibridación que presentan los átomos de carbono que forman el doble enlace?
+
+ A) sp
+ B) [x] sp2
+ C) sp3
+ D) dsp2
+
+Question 5 (Difficulty 5)
+La isomería es un fenómeno común en química orgánica donde compuestos con la misma fórmula molecular tienen diferentes estructuras.
+Si se considera la fórmula molecular C4H10, ¿cuántos isómeros de cadena (estructurales) se pueden formar?
+
+ A) 1
+ B) [x] 2
+ C) 3
+ D) 4
+
+Question 6 (Difficulty 5)
+Las reacciones de combustión de hidrocarburos liberan energía, pero su eficiencia depende de la disponibilidad de oxígeno.
+Durante una combustión incompleta de un hidrocarburo, debido a la falta de oxígeno, se produce un gas altamente tóxico para los humanos. ¿De qué gas se trata?
+
+ A) Dióxido de carbono
+ B) [x] Monóxido de carbono
+ C) Óxido nitroso
+ D) Metano residual
+
+Question 7 (Difficulty 5)
+Los alquinos presentan reactividades particulares debido a la alta densidad electrónica de su enlace triple.
+¿Cuál es la fórmula general que representa a la familia de los alquinos acíclicos?
+
+ A) CnH2n+2
+ B) CnH2n
+ C) [x] CnH2n-2
+ D) CnHn
+
+Question 8 (Difficulty 5)
+El benceno es el hidrocarburo aromático más simple y sirve como base para muchos otros compuestos.
+¿Por qué el benceno (C6H6) no reacciona típicamente mediante adición, a pesar de representarse a veces con tres enlaces dobles?
+
+ A) Porque es una molécula muy inestable.
+ B) [x] Debido a la resonancia y deslocalización de sus electrones pi.
+ C) Porque no tiene hidrógenos suficientes para la reacción.
+ D) Porque los enlaces entre carbonos son iónicos.
+
+Question 9 (Difficulty 5)
+La refinación del petróleo utiliza la destilación fraccionada para separar mezclas de hidrocarburos basándose en una propiedad física específica.
+¿En qué propiedad física se basa la separación de los componentes del petróleo en una torre de destilación?
+
+ A) Solubilidad en agua
+ B) Densidad relativa
+ C) [x] Punto de ebullición
+ D) Reactividad química
+
+Question 10 (Difficulty 5)
+Los radicales alquilo son grupos de átomos que resultan de quitar un hidrógeno a un alcano.
+¿Cómo se denomina al radical que se obtiene al retirar un átomo de hidrógeno del carbono central del propano?
+
+ A) Propilo
+ B) [x] Isopropilo
+ C) Etilo
+ D) Metilo
+
+Question 11 (Difficulty 7)
+Las reacciones de sustitución radicalaria son típicas de los alcanos bajo ciertas condiciones de energía.
+Para que el metano reaccione con cloro gaseoso y produzca clorometano (CH3Cl), se requiere la presencia de:
+
+ A) Un catalizador metálico de paladio.
+ B) [x] Luz ultravioleta o calor elevado.
+ C) Una base fuerte como el NaOH.
+ D) Un medio ácido muy concentrado.
+
+Question 12 (Difficulty 7)
+La regla de Markovnikov predice el producto principal en reacciones de adición a alquenos asimétricos.
+Si se hace reaccionar propeno (CH3-CH=CH2) con ácido clorhídrico (HCl), ¿cuál será el producto mayoritario?
+
+ A) 1-cloropropano
+ B) [x] 2-cloropropano
+ C) 1,2-dicloropropano
+ D) Propano
+
+Question 13 (Difficulty 7)
+La estabilidad de los carbocationes es fundamental para entender por qué se forman ciertos productos en las reacciones orgánicas.
+¿Cuál es el orden correcto de estabilidad decreciente (de más estable a menos estable) para los siguientes carbocationes?
+
+ A) Primario > Secundario > Terciario
+ B) [x] Terciario > Secundario > Primario
+ C) Secundario > Terciario > Primario
+ D) Todos tienen la misma estabilidad.
+
+Question 14 (Difficulty 7)
+La acidez de los hidrocarburos varía significativamente dependiendo del carácter 's' de los orbitales de hibridación del carbono.
+¿Cuál de los siguientes hidrocarburos presenta el hidrógeno más ácido (más fácil de remover por una base fuerte)?
+
+ A) Etano
+ B) Eteno
+ C) [x] Etino (Acetileno)
+ D) Ciclohexano
+
+Question 15 (Difficulty 7)
+La nomenclatura de compuestos ramificados complejos requiere identificar correctamente la cadena más larga que contenga el grupo funcional principal.
+Al nombrar un compuesto que tiene un doble enlace y varias ramificaciones de metilo, ¿cuál es la prioridad según la IUPAC?
+
+ A) [x] La cadena principal debe contener el doble enlace y este debe recibir el número más bajo posible.
+ B) Las ramificaciones deben recibir siempre los números más bajos, sin importar el doble enlace.
+ C) Se elige la cadena más larga de carbonos, aunque no incluya el doble enlace.
+ D) El nombre se asigna alfabéticamente sin importar la posición de los enlaces.
+
+Question 16 (Difficulty 7)
+El craqueo (cracking) es un proceso químico fundamental en la industria petroquímica.
+¿En qué consiste el proceso de craqueo catalítico aplicado a los hidrocarburos de cadena larga?
+
+ A) En unir moléculas pequeñas para formar polímeros.
+ B) [x] En romper moléculas grandes y complejas en fragmentos más pequeños y útiles (como gasolina).
+ C) En añadir hidrógenos a los alquenos para saturarlos.
+ D) En eliminar el azufre de los combustibles fósiles.
+
+Question 17 (Difficulty 9)
+La combustión completa de 1 mol de un alcano desconocido produce 5 moles de H2O.
+Basándote en la fórmula general de los alcanos (CnH2n+2), ¿cuál es la identidad del alcano y cuántos moles de CO2 se producirán?
+
+ A) Propano; produce 3 moles de CO2.
+ B) [x] Butano; produce 4 moles de CO2.
+ C) Pentano; produce 5 moles de CO2.
+ D) Butano; produce 5 moles de CO2.
+
+Question 18 (Difficulty 9)
+La ozonólisis de un alqueno es una técnica para determinar la posición del doble enlace al romper la molécula en fragmentos carbonílicos.
+Un alqueno desconocido se somete a ozonólisis y los únicos productos obtenidos son propanal (CH3-CH2-CHO) y etanal (CH3-CHO). ¿Cuál era la estructura original del alqueno?
+
+ A) 1-penteno
+ B) [x] 2-penteno
+ C) 2-buteno
+ D) 3-hexeno
+
+Question 19 (Difficulty 9)
+En la sustitución electrofílica aromática (SEA), los grupos ya presentes en el anillo de benceno dirigen la entrada del nuevo sustituyente.
+Si se intenta nitrar el nitrobenceno (C6H5NO2), ¿en qué posición entrará preferencialmente el segundo grupo nitro y por qué?
+
+ A) En posición orto/para, porque el grupo nitro es un activante fuerte.
+ B) En posición para, por impedimento estérico en la posición orto.
+ C) [x] En posición meta, porque el grupo nitro retira electrones del anillo y desactiva las posiciones orto/para.
+ D) No ocurrirá la reacción porque el anillo está totalmente bloqueado.
+
+Question 20 (Difficulty 9)
+Un laboratorio analiza una muestra de gas que contiene una mezcla de un alcano y un alqueno de igual número de carbonos. Se observa que la muestra decolora rápidamente una solución de bromo en tetracloruro de carbono (Br2/CCl4).
+¿Qué conclusión se puede obtener sobre la composición de la mezcla y qué tipo de reacción ocurrió?
+
+ A) La mezcla contiene solo alcanos; ocurrió una reacción de sustitución.
+ B) [x] La presencia del alqueno es confirmada por la decoloración; ocurrió una reacción de adición.
+ C) Ambos hidrocarburos reaccionaron por igual; el bromo es un oxidante general.
+ D) La muestra es aromática; ocurrió una sustitución electrofílica.

--- a/saberparatodos/src/content/questions/colombia/ingles/grado-11/collocations/CO-ING-11-P1-collocations-001-MASTERY-bundle.md
+++ b/saberparatodos/src/content/questions/colombia/ingles/grado-11/collocations/CO-ING-11-P1-collocations-001-MASTERY-bundle.md
@@ -1,0 +1,186 @@
+layout: bundle
+subject: ingles
+grade: 11
+period: 1
+topic: collocations
+difficulty: medium
+
+Question 1 (Difficulty 3)
+Talking about daily habits and household tasks.
+"I always ______ my bed as soon as I wake up in the morning."
+
+ A) do
+ B) [x] make
+ C) take
+ D) put
+
+Question 2 (Difficulty 3)
+Discussing schoolwork and effort.
+"You don't have to be perfect, just ______ your best on the exam."
+
+ A) [x] do
+ B) make
+ C) give
+ D) have
+
+Question 3 (Difficulty 3)
+Planning a surprise for a friend's birthday.
+"We are going to ______ a party for her next Saturday."
+
+ A) do
+ B) make
+ C) [x] throw
+ D) perform
+
+Question 4 (Difficulty 3)
+A teacher giving advice to a student who made many errors.
+"Don't worry; everyone ______ mistakes when they are learning a new language."
+
+ A) does
+ B) [x] makes
+ C) commits
+ D) has
+
+Question 5 (Difficulty 5)
+Discussing career goals and future plans.
+"If you work hard, you will eventually ______ progress toward your goals."
+
+ A) do
+ B) [x] make
+ C) reach
+ D) get
+
+Question 6 (Difficulty 5)
+A conversation about a difficult decision.
+"It's hard to ______ a choice when both options seem equally good."
+
+ A) do
+ B) [x] make
+ C) take
+ D) set
+
+Question 7 (Difficulty 5)
+Talking about travel and transportation.
+"I missed the bus, so I had to ______ a taxi to get to work on time."
+
+ A) go
+ B) [x] take
+ C) catch
+ D) ride
+
+Question 8 (Difficulty 5)
+Discussing environmental issues and business.
+"The company is trying to ______ a good impression on its new environmentally conscious clients."
+
+ A) do
+ B) [x] make
+ C) give
+ D) build
+
+Question 9 (Difficulty 5)
+A doctor giving advice to a patient.
+"You need to ______ more attention to your diet if you want to stay healthy."
+
+ A) give
+ B) make
+ C) [x] pay
+ D) put
+
+Question 10 (Difficulty 5)
+A student complaining about a boring lecture.
+"The professor ______ the same point for nearly twenty minutes; it was very repetitive."
+
+ A) [x] made
+ B) did
+ C) said
+ D) gave
+
+Question 11 (Difficulty 7)
+Describing a fast-paced environment.
+"Living in a big city often feels like a ______ race where everyone is competing for success."
+
+ A) mouse
+ B) dog
+ C) [x] rat
+ D) cat
+
+Question 12 (Difficulty 7)
+A report on economic growth.
+"The new policy is expected to ______ a significant impact on the local economy."
+
+ A) make
+ B) [x] have
+ C) do
+ D) cause
+
+Question 13 (Difficulty 7)
+Discussing financial responsibility.
+"It is important to ______ a budget and stick to it if you want to save money."
+
+ A) do
+ B) [x] draw up
+ C) make up
+ D) get through
+
+Question 14 (Difficulty 7)
+A lawyer discussing a potential lawsuit.
+"We don't have enough evidence to ______ a case against the suspect at this moment."
+
+ A) make
+ B) do
+ C) [x] build
+ D) form
+
+Question 15 (Difficulty 7)
+A scientist describing a breakthrough.
+"This discovery ______ a new light on how we understand the human brain."
+
+ A) gives
+ B) puts
+ C) [x] sheds
+ D) throws
+
+Question 16 (Difficulty 7)
+Describing a very clear and obvious situation.
+"The difference between the two products was ______ clear after we tested them side by side."
+
+ A) strongly
+ B) highly
+ C) [x] crystal
+ D) deep
+
+Question 17 (Difficulty 9)
+An academic paper on social behavior.
+"The study ______ into question the long-held belief that humans are purely rational actors."
+
+ A) takes
+ B) [x] calls
+ C) puts
+ D) brings
+
+Question 18 (Difficulty 9)
+A technical manual for a complex machine.
+"Failure to ______ with the safety regulations may result in the termination of your contract."
+
+ A) follow
+ B) agree
+ C) [x] comply
+ D) submit
+
+Question 19 (Difficulty 9)
+A diplomat discussing international relations.
+"We must work together to ______ the gap between our two nations' conflicting interests."
+
+ A) fill
+ B) [x] bridge
+ C) close
+ D) connect
+
+Question 20 (Difficulty 9)
+A literature professor analyzing a poem.
+"The poet uses vivid imagery to ______ a sense of nostalgia for a lost era."
+
+ A) make
+ B) [x] evoke
+ C) build
+ D) create

--- a/saberparatodos/src/content/questions/colombia/ingles/grado-11/idioms/CO-ING-11-P1-idioms-001-MASTERY-bundle.md
+++ b/saberparatodos/src/content/questions/colombia/ingles/grado-11/idioms/CO-ING-11-P1-idioms-001-MASTERY-bundle.md
@@ -1,0 +1,186 @@
+layout: bundle
+subject: ingles
+grade: 11
+period: 1
+topic: idioms
+difficulty: medium
+
+Question 1 (Difficulty 3)
+Two friends are talking about a secret that was accidentally revealed.
+"I didn't mean to tell her about the surprise party! I accidentally ______."
+
+ A) [x] let the cat out of the bag
+ B) hit the nail on the head
+ C) broke the ice
+ D) turned a blind eye
+
+Question 2 (Difficulty 3)
+A student is very nervous about an upcoming presentation.
+"I have ______ in my stomach every time I have to speak in front of the class."
+
+ A) birds
+ B) [x] butterflies
+ C) bees
+ D) ants
+
+Question 3 (Difficulty 3)
+Someone is describing an item that is very inexpensive.
+"I bought this old camera at the flea market; it was ______."
+
+ A) a piece of cake
+ B) [x] dirt cheap
+ C) under the weather
+ D) out of the blue
+
+Question 4 (Difficulty 3)
+Answering a question perfectly.
+"When you said that the main problem was lack of communication, you really ______."
+
+ A) went the extra mile
+ B) pulled someone's leg
+ C) [x] hit the nail on the head
+ D) saw eye to eye
+
+Question 5 (Difficulty 5)
+Discussing a task that was surprisingly simple to complete.
+"I thought the final project would be difficult, but it turned out to be ______."
+
+ A) a blessing in disguise
+ B) [x] a piece of cake
+ C) the last straw
+ D) a hot potato
+
+Question 6 (Difficulty 5)
+Giving advice to someone who is making a decision too quickly.
+"Don't ______! You should read the contract carefully before you sign anything."
+
+ A) bite the bullet
+ B) beat around the bush
+ C) [x] jump the gun
+ D) call it a day
+
+Question 7 (Difficulty 5)
+A team is working on a project and needs to stop for now.
+"We've been working for ten hours and we're all exhausted. Let's ______."
+
+ A) get out of hand
+ B) [x] call it a day
+ C) break a leg
+ D) cut corners
+
+Question 8 (Difficulty 5)
+Expressing total agreement with another person.
+"My business partner and I don't always ______, but we respect each other's opinions."
+
+ A) [x] see eye to eye
+ B) hear it on the grapevine
+ C) look on the bright side
+ D) keep an eye on
+
+Question 9 (Difficulty 5)
+Dealing with a difficult situation that cannot be avoided.
+"I know the surgery will be painful, but I just have to ______ and get it over with."
+
+ A) spill the beans
+ B) [x] bite the bullet
+ C) burn the midnight oil
+ D) hit the hay
+
+Question 10 (Difficulty 5)
+Feeling slightly sick and not able to go to school.
+"I'm feeling a bit ______ today, so I think I'll stay in bed and rest."
+
+ A) out of the blue
+ B) over the moon
+ C) [x] under the weather
+ D) in the same boat
+
+Question 11 (Difficulty 7)
+A business manager discussing the need for innovation.
+"To stay competitive, our company must ______ and adopt the latest technologies before our rivals do."
+
+ A) sit on the fence
+ B) [x] stay ahead of the curve
+ C) bark up the wrong tree
+ D) go down in flames
+
+Question 12 (Difficulty 7)
+A friend helping another friend who is feeling very sad.
+"I know you're disappointed about the promotion, but remember that every cloud ______."
+
+ A) [x] has a silver lining
+ B) makes a storm
+ C) brings the rain
+ D) is full of water
+
+Question 13 (Difficulty 7)
+Describing someone who is working very hard until very late.
+"She has been ______ every night this week to finish her thesis."
+
+ A) pulling my leg
+ B) taking it with a grain of salt
+ C) [x] burning the midnight oil
+ D) skating on thin ice
+
+Question 14 (Difficulty 7)
+A person who is very rarely seen at social events.
+"He only comes to our parties ______; he prefers staying home with his books."
+
+ A) in the blink of an eye
+ B) [x] once in a blue moon
+ C) at the drop of a hat
+ D) for the time being
+
+Question 15 (Difficulty 7)
+Describing a situation where someone got away without being punished for a mistake.
+"The teacher caught him cheating, but he got ______ with just a warning."
+
+ A) off the track
+ B) [x] off the hook
+ C) on the ball
+ D) under the thumb
+
+Question 16 (Difficulty 7)
+When someone is talking about something they don't really know much about.
+"If you think the problem is the battery, you are ______; the issue is actually the software."
+
+ A) cutting a long story short
+ B) giving the benefit of the doubt
+ C) [x] barking up the wrong tree
+ D) crying over spilt milk
+
+Question 17 (Difficulty 9)
+An analysis of a political scandal.
+"The minister's resignation was merely ______, as the entire department was involved in the corruption."
+
+ A) a blessing in disguise
+ B) a bitter pill to swallow
+ C) [x] the tip of the iceberg
+ D) a storm in a teacup
+
+Question 18 (Difficulty 9)
+A CEO explaining that they need to make a very tough but necessary choice.
+"We are ______: if we lower prices, we lose profit; if we don't, we lose customers."
+
+ A) [x] between a rock and a hard place
+ B) on the same page
+ C) playing second fiddle
+ D) taking the bull by the horns
+
+Question 19 (Difficulty 9)
+A literary critic describing the subtle impact of a writer's style.
+"She doesn't state her opinions directly; instead, she ______ in a way that challenges the reader to think."
+
+ A) lets the cat out of the bag
+ B) [x] beats around the bush
+ C) goes against the grain
+ D) throws caution to the wind
+
+Question 20 (Difficulty 9)
+Discussing the long-term consequences of a small initial mistake.
+"That minor oversight in the accounting department ______ and eventually led to the company's bankruptcy."
+
+ A) added fuel to the fire
+ B) [x] snowballed
+ C) broke the bank
+ D) kept his chin up

--- a/saberparatodos/src/content/questions/colombia/ingles/grado-11/phrasal-verbs/CO-ING-11-P1-phrasal-verbs-001-MASTERY-bundle.md
+++ b/saberparatodos/src/content/questions/colombia/ingles/grado-11/phrasal-verbs/CO-ING-11-P1-phrasal-verbs-001-MASTERY-bundle.md
@@ -1,0 +1,186 @@
+layout: bundle
+subject: ingles
+grade: 11
+period: 1
+topic: phrasal-verbs
+difficulty: medium
+
+Question 1 (Difficulty 3)
+Sarah is talking to her teacher about her missing homework.
+"I'm sorry, teacher. I couldn't ______ my essay on time because my computer crashed."
+
+ A) bring up
+ B) call off
+ C) [x] hand in
+ D) look for
+
+Question 2 (Difficulty 3)
+Two friends are planning to meet at the cinema.
+"Don't worry if you are late; I will ______ for you near the ticket office."
+
+ A) get up
+ B) take off
+ C) [x] wait up
+ D) give in
+
+Question 3 (Difficulty 3)
+A mother is talking to her son about his messy room.
+"Please ______ your toys before you go out to play."
+
+ A) look after
+ B) run out
+ C) [x] put away
+ D) fill in
+
+Question 4 (Difficulty 3)
+A conversation about a broken car.
+"Our car ______ on the way to the airport, so we missed our flight."
+
+ A) [x] broke down
+ B) went off
+ C) came across
+ D) turned up
+
+Question 5 (Difficulty 5)
+An employee discussing a project with their boss.
+"We need to ______ a better solution if we want to finish this project by Friday."
+
+ A) look into
+ B) put up with
+ C) [x] come up with
+ D) carry on
+
+Question 6 (Difficulty 5)
+A news report about a local festival.
+"The organizers decided to ______ the outdoor concert due to the heavy rain forecast."
+
+ A) set up
+ B) [x] call off
+ C) take over
+ D) keep on
+
+Question 7 (Difficulty 5)
+A student is struggling with a difficult math problem.
+"Don't ______ yet! I'm sure you can solve it if you try one more time."
+
+ A) [x] give up
+ B) work out
+ C) get over
+ D) bring about
+
+Question 8 (Difficulty 5)
+Talking about a child's resemblance to their parents.
+"Mark really ______ his father; they both have the same sense of humor and love for music."
+
+ A) looks for
+ B) [x] takes after
+ C) grows up
+ D) gets along
+
+Question 9 (Difficulty 5)
+A flight attendant is giving instructions to passengers.
+"Please ensure your seatbelts are fastened as the plane is about to ______."
+
+ A) get in
+ B) [x] take off
+ C) check out
+ D) hold on
+
+Question 10 (Difficulty 5)
+Someone looking for information in a dictionary.
+"If you don't know the meaning of the word, you should ______ in the dictionary."
+
+ A) look after
+ B) look for
+ C) [x] look up
+ D) look into
+
+Question 11 (Difficulty 7)
+A business meeting discussing a new market strategy.
+"We must ______ the implications of this merger before we sign the final agreement."
+
+ A) bring up
+ B) [x] think through
+ C) pass out
+ D) fall through
+
+Question 12 (Difficulty 7)
+Discussing a historical event that caused a revolution.
+"The high taxes ______ the uprising of the peasants in the 18th century."
+
+ A) [x] brought about
+ B) came across
+ C) got away with
+ D) put off
+
+Question 13 (Difficulty 7)
+A scientist explaining a complex experiment.
+"The research team will ______ several tests to verify the initial hypothesis."
+
+ A) count on
+ B) go through
+ C) [x] carry out
+ D) set out
+
+Question 14 (Difficulty 7)
+A person recovering from a difficult breakup.
+"It took her a long time to ______ the end of her long-term relationship."
+
+ A) get by
+ B) [x] get over
+ C) get ahead
+ D) get back
+
+Question 15 (Difficulty 7)
+An argument between two colleagues.
+"I can no longer ______ your constant interruptions during our weekly meetings."
+
+ A) stand for
+ B) [x] put up with
+ C) back down
+ D) face up to
+
+Question 16 (Difficulty 7)
+A detective investigating a mysterious disappearance.
+"The police are ______ new leads that might explain where the missing person went."
+
+ A) [x] following up on
+ B) making up for
+ C) looking up to
+ D) getting away with
+
+Question 17 (Difficulty 9)
+A philosophical discussion about personal growth and environmental influence.
+"One's core values often ______ the sociocultural environment in which they were raised."
+
+ A) result from
+ B) [x] stem from
+ C) break out of
+ D) lead up to
+
+Question 18 (Difficulty 9)
+A legal expert explaining a court's decision.
+"The judge's ruling ______ the principle that all citizens are equal before the law."
+
+ A) [x] rests on
+ B) plays along with
+ C) falls back on
+ D) adds up to
+
+Question 19 (Difficulty 9)
+A critique of a poorly written novel.
+"The plot is so convoluted that the final chapters fail to ______ the various subplots introduced earlier."
+
+ A) wrap around
+ B) [x] tie in
+ C) set off
+ D) stand out
+
+Question 20 (Difficulty 9)
+An economist analyzing the impact of a new policy.
+"We must not ______ the possibility that these measures could exacerbate existing inequalities."
+
+ A) count out
+ B) [x] rule out
+ C) turn down
+ D) cut off


### PR DESCRIPTION
This PR initiates the regeneration of invalid exam bundles for the WorldExams ICFES Colombia project. It provides a set of high-quality, 20-question bundles that adhere strictly to the requested Markdown format and difficulty progression. Key improvements include the use of explicit marking for correct answers, standardized frontmatter, and correct placement within the monorepo structure.

Fixes #247

---
*PR created automatically by Jules for task [17478349291848875624](https://jules.google.com/task/17478349291848875624) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 20 mastery-level hydrocarbon practice questions for Grade 11 Natural Sciences, covering alkanes, nomenclature, combustion, and reactions.
  * Added 80 Grade 11 English learning resources: 20 collocation questions, 20 idioms questions, and 20 phrasal verbs questions for enhanced language practice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->