### PR TITLE
fix(country): remove remaining Colombia hardcodes from shared UI components

### DIFF
--- a/saberparatodos/src/components/ExamConfigModal.svelte
+++ b/saberparatodos/src/components/ExamConfigModal.svelte
@@ -1339,7 +1339,7 @@
                     {#if examMode === 'simulacro'}
                       <div class="absolute -right-1 -top-1 opacity-20 group-hover:scale-110 transition-transform">🎓</div>
                     {/if}
-                    Simulacro Saber 11
+                    {runtimeCountry?.examAuthority || 'Simulacro Saber 11'}
                   </button>
                   <button
                     onclick={() => examMode = 'period'}
@@ -1382,7 +1382,7 @@
                 <div class="text-lg">🏛️</div>
                 <div class="flex-1 flex items-start justify-between gap-2">
                   <p class="text-[10px] text-yellow-200/80 leading-relaxed">
-                    <strong class="block text-yellow-400 font-bold mb-0.5">Lineamientos M.E.N. Colombia</strong>
+                    <strong class="block text-yellow-400 font-bold mb-0.5">Lineamientos de {runtimeCountry?.examAuthority || 'M.E.N. Colombia'}</strong>
                     Los periodos están alineados con los DBA (Derechos Básicos de Aprendizaje) vigentes. Selecciona el periodo actual de tu colegio.
                   </p>
                   <button

--- a/saberparatodos/src/components/LeaderboardView.svelte
+++ b/saberparatodos/src/components/LeaderboardView.svelte
@@ -2,7 +2,7 @@
   /**
    * LeaderboardView.svelte
    * Componente para mostrar el ranking de estudiantes
-   * Colombia - saberparatodos
+   * Multi-country leaderboard
    *
    * Usa archivos JSON estáticos en /leaderboards/
    */


### PR DESCRIPTION
## Changes
- `LeaderboardView.svelte`: fixed comment referencing Colombia-only ("Colombia - saberparatodos" → generic)
- `ExamConfigModal.svelte`: replaced "Simulacro Saber 11" and "Lineamientos M.E.N. Colombia" with tenant-aware labels using runtimeCountry.examAuthority

## Files
- saberparatodos/src/components/ExamConfigModal.svelte
- saberparatodos/src/components/LeaderboardView.svelte

Closes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exam configuration modal now dynamically displays country-specific exam authority names and labels based on the selected region.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/worldexams/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->