### PR TITLE
fix(country): generalize ICFES proxy scoring constants and doc comments

### DIFF
--- a/pr312_body.txt
+++ b/pr312_body.txt
@@ -1,0 +1,13 @@
+## Changes
+- `mmr-system.ts`: renamed `ICFES_PROXY_METHODOLOGY_VERSION` → `MMR_PROXY_METHODOLOGY_VERSION`, `ICFES_PROXY_DISCLAIMER` → `MMR_PROXY_DISCLAIMER`
+- `PerformanceLevels.svelte`: fixed comment referencing "ICFES Saber 11 standard levels"
+- `scoring.ts`: fixed doc comments referencing ICFES
+- `local-intelligence.ts`: added TODO to move benchmark config to tenant config
+
+## Files
+- saberparatodos/src/lib/mmr-system.ts
+- saberparatodos/src/components/dashboard/PerformanceLevels.svelte
+- saberparatodos/src/lib/scoring.ts
+- saberparatodos/src/lib/local-intelligence.ts
+
+Closes #312

--- a/saberparatodos/src/components/dashboard/PerformanceLevels.svelte
+++ b/saberparatodos/src/components/dashboard/PerformanceLevels.svelte
@@ -2,7 +2,7 @@
   export let score: number = 0; // 0 to 100
   export let subject: string = "";
 
-  // ICFES Saber 11 standard levels
+  // Standard score levels (tenant-specific scale)
   // Levels for core subjects (0-100 scale)
   const levels = [
     { id: 1, name: "Insuficiente", min: 0, max: 35, color: "bg-red-500", shadow: "shadow-red-500/20" },

--- a/saberparatodos/src/lib/mmr-system.ts
+++ b/saberparatodos/src/lib/mmr-system.ts
@@ -3,7 +3,7 @@
  * MMR (Matchmaking Rating) System
  * Uses a modified ELO rating system to track student skill levels.
  *
- * Base MMR: 250 (Average Student in 0-500 scale)
+ * Base MMR: 250 (Average Student in normalized 0-500 scale)
  * Min MMR: 0
  * Max MMR: 500
  */
@@ -11,8 +11,8 @@
 export const BASE_MMR = 250;
 const K_FACTOR = 16; // Adjusted for 0-500 range (was 40 for 0-3000)
 
-export const ICFES_PROXY_METHODOLOGY_VERSION = 'icfes-proxy-v1';
-export const ICFES_PROXY_DISCLAIMER =
+export const MMR_PROXY_METHODOLOGY_VERSION = 'icfes-proxy-v1';
+export const MMR_PROXY_DISCLAIMER =
   'Estimacion de practica; no reemplaza el reporte oficial del ICFES.';
 
 export const PAES_PROXY_METHODOLOGY_VERSION = 'paes-proxy-v1';
@@ -101,9 +101,9 @@ export function estimateIcfesScore(signals: IcfesProxySignals): IcfesEstimate {
     confidence,
     label: confidenceLabel(confidence),
     evidenceCount,
-    methodologyVersion: ICFES_PROXY_METHODOLOGY_VERSION,
+    methodologyVersion: MMR_PROXY_METHODOLOGY_VERSION,
     minimumEvidenceMet: evidenceCount >= 20,
-    disclaimer: ICFES_PROXY_DISCLAIMER,
+    disclaimer: MMR_PROXY_DISCLAIMER,
     estimatedModuleScores: signals.estimatedModuleScores,
     examType: 'ICFES'
   };

--- a/saberparatodos/src/lib/scoring.ts
+++ b/saberparatodos/src/lib/scoring.ts
@@ -339,7 +339,7 @@ export function calculateExamScore(
 
 /**
  * Calcula el rango teorico de puntaje para el mismo examen.
- * Sirve para explicar al usuario que esta escala es interna y no equivale a ICFES.
+ * Explains to the user that this is an internal estimate and may not match official exam scores for their country.
  */
 export function calculateExamScoreRange(
   exam: ExamResult,


### PR DESCRIPTION
## Changes
- `mmr-system.ts`: renamed `ICFES_PROXY_METHODOLOGY_VERSION` → `MMR_PROXY_METHODOLOGY_VERSION`, `ICFES_PROXY_DISCLAIMER` → `MMR_PROXY_DISCLAIMER`
- `PerformanceLevels.svelte`: fixed comment referencing "ICFES Saber 11 standard levels"
- `scoring.ts`: fixed doc comments referencing ICFES

## Files
- saberparatodos/src/lib/mmr-system.ts
- saberparatodos/src/components/dashboard/PerformanceLevels.svelte
- saberparatodos/src/lib/scoring.ts

Closes #312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation to clarify that score estimates are internal calculations and may not match official exam scores for your country
  * Clarified that performance scales are configured per tenant
  * Renamed internal constants for consistency with the scoring system

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/worldexams/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->