### PR TITLE
[fix] Unify CEFR level arrays, filters, and transformer fallbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15917,7 +15917,7 @@
         "lightningcss-linux-x64-gnu": "^1.32.0",
         "peerjs": "^1.5.5",
         "remotion": "^4.0.451",
-        "svelte": "^5.55.7",
+        "svelte": "^5.55.9",
         "tailwindcss": "^4.2.2",
         "trystero": "^0.23.1",
         "wrangler": "^4.95.0"
@@ -16700,6 +16700,15 @@
         "node": ">= 18"
       }
     },
+    "saberparatodos/node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
     "saberparatodos/node_modules/@types/connect": {
       "version": "3.4.38",
       "license": "MIT",
@@ -16765,6 +16774,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "saberparatodos/node_modules/esrap": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "saberparatodos/node_modules/glob": {
@@ -17032,21 +17058,23 @@
       }
     },
     "saberparatodos/node_modules/svelte": {
-      "version": "5.54.1",
+      "version": "5.55.10",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.10.tgz",
+      "integrity": "sha512-v9mFVBY1USosyIWdXE7Cg4AN0ywyKCMcAhONvli8doMowEhFhMdNLKD1j7O/UnsrdVTHaUOk/jv8hD/HClVy+g==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.10",
         "@types/estree": "^1.0.5",
         "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.2",
+        "esrap": "^2.2.9",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",

--- a/saberparatodos/src/lib/english-proficiency.test.ts
+++ b/saberparatodos/src/lib/english-proficiency.test.ts
@@ -17,6 +17,7 @@ describe('parseCEFRLevel', () => {
     expect(parseCEFRLevel('B1')).toBe('B1');
     expect(parseCEFRLevel('B2')).toBe('B2');
     expect(parseCEFRLevel('C1')).toBe('C1');
+    expect(parseCEFRLevel('C2')).toBe('C2');
   });
 
   it('should parse plus levels correctly', () => {
@@ -172,7 +173,7 @@ describe('examResultsToQuestionResults', () => {
 describe('60-Question Proficiency Scenarios', () => {
   // Helper to generate questions distributed across levels
   const generateDistributedQuestions = (isCorrectFn: (i: number, level: CEFRLevel) => boolean): QuestionResult[] => {
-    const levels: CEFRLevel[] = ['A1', 'A1+', 'A2', 'A2+', 'B1', 'B1+', 'B2', 'B2+', 'C1'];
+    const levels: CEFRLevel[] = ['A1', 'A1+', 'A2', 'A2+', 'B1', 'B1+', 'B2', 'B2+', 'C1', 'C2'];
     const questionsPerLevel = Math.floor(60 / levels.length); // ~6-7 per level
     const results: QuestionResult[] = [];
     let id = 0;
@@ -199,7 +200,7 @@ describe('60-Question Proficiency Scenarios', () => {
     return results;
   };
 
-  it('SCENARIO 1: 60 questions ALL CORRECT → Should estimate C1 (highest level)', () => {
+  it('SCENARIO 1: 60 questions ALL CORRECT → Should estimate C2 (highest level)', () => {
     const results = generateDistributedQuestions(() => true);
 
     console.log('\n📊 SCENARIO 1: ALL CORRECT');
@@ -215,7 +216,7 @@ describe('60-Question Proficiency Scenarios', () => {
       console.log(`    ${b.level}: ${b.accuracy}% (${b.correct}/${b.total})`);
     });
 
-    expect(proficiency.estimatedLevel).toBe('C1');
+    expect(proficiency.estimatedLevel).toBe('C2');
     expect(proficiency.overallAccuracy).toBe(100);
     expect(proficiency.confidenceLabel).toBe('Very High');
   });

--- a/saberparatodos/src/lib/english-proficiency.ts
+++ b/saberparatodos/src/lib/english-proficiency.ts
@@ -11,19 +11,19 @@
  */
 
 // CEFR Levels ordered from lowest to highest
-export const CEFR_LEVELS = ['A1', 'A1+', 'A2', 'A2+', 'B1', 'B1+', 'B2', 'B2+', 'C1'] as const;
+export const CEFR_LEVELS = ['A1', 'A1+', 'A2', 'A2+', 'B1', 'B1+', 'B2', 'B2+', 'C1', 'C2'] as const;
 export type CEFRLevel = typeof CEFR_LEVELS[number];
 
 // Numeric mapping for calculations
 export const CEFR_LEVEL_NUM: Record<string, number> = {
   'A1': 1, 'A1+': 2, 'A2': 3, 'A2+': 4,
-  'B1': 5, 'B1+': 6, 'B2': 7, 'B2+': 8, 'C1': 9
+  'B1': 5, 'B1+': 6, 'B2': 7, 'B2+': 8, 'C1': 9, 'C2': 10
 };
 
 // Reverse mapping
 export const NUM_TO_CEFR: Record<number, CEFRLevel> = {
   1: 'A1', 2: 'A1+', 3: 'A2', 4: 'A2+',
-  5: 'B1', 6: 'B1+', 7: 'B2', 8: 'B2+', 9: 'C1'
+  5: 'B1', 6: 'B1+', 7: 'B2', 8: 'B2+', 9: 'C1', 10: 'C2'
 };
 
 // Grade to CEFR fallback (when question doesn't have cefr_level)
@@ -252,7 +252,7 @@ function findCeilingLevel(breakdown: LevelStats[]): {
   }
 
   // Cap at C1
-  estimatedNum = Math.min(estimatedNum, 9);
+  estimatedNum = Math.min(estimatedNum, 10);
   estimatedNum = Math.max(estimatedNum, 1);
 
   return {

--- a/saberparatodos/src/lib/question-transformer.ts
+++ b/saberparatodos/src/lib/question-transformer.ts
@@ -265,7 +265,7 @@ export function transformQuestion(apiQuestion: any, grade: number, subject: stri
     topics: (apiQuestion.tema ? [apiQuestion.tema] : []).concat(apiQuestion.topics || apiQuestion.tags || []).filter(Boolean),
     period: apiQuestion.period || apiQuestion.periodo || undefined,
     periodo: apiQuestion.periodo || apiQuestion.period || undefined,
-    cefr_level: apiQuestion.cefr_level || undefined,
+    cefr_level: apiQuestion.cefr_level || apiQuestion.target_cefr || undefined,
     protocol_version: apiQuestion.protocol_version || undefined
   };
 }

--- a/saberparatodos/src/lib/questions/filters.ts
+++ b/saberparatodos/src/lib/questions/filters.ts
@@ -1,4 +1,5 @@
 import type { AppQuestion } from '../api-service';
+import { GRADE_TO_CEFR } from '../english-proficiency';
 import { CURRICULUM_CO, normalizeTopic } from '../../config/curriculum';
 import { subjectsMatch } from './subject';
 import type { QuestionSelectionRequest } from './types';
@@ -26,7 +27,7 @@ export function filterByGradeAndDiagnostic(
   return result;
 }
 
-const CEFR_ORDER = ['A1', 'A1+', 'A2', 'A2+', 'B1', 'B1+', 'B2', 'B2+', 'C1'];
+const CEFR_ORDER = ['A1', 'A1+', 'A2', 'A2+', 'B1', 'B1+', 'B2', 'B2+', 'C1', 'C2'];
 
 export function filterByCefrLevel(questions: AppQuestion[], minCefrLevel?: string): AppQuestion[] {
   if (!minCefrLevel) return questions;
@@ -35,8 +36,9 @@ export function filterByCefrLevel(questions: AppQuestion[], minCefrLevel?: strin
   if (minIndex === -1) return questions; // Invalid cefr level, do not filter
 
   return questions.filter((q) => {
-    if (!q.cefr_level) return true; // If no level is specified, assume it's valid
-    const qIndex = CEFR_ORDER.indexOf(q.cefr_level);
+    const qLevel = q.cefr_level || (q.grade ? GRADE_TO_CEFR[q.grade as keyof typeof GRADE_TO_CEFR] : undefined);
+    if (!qLevel) return true; // fallback only if absolutely no grade/level is known
+    const qIndex = CEFR_ORDER.indexOf(qLevel);
     // 🆕 Allow one level below for "balanced" diagnostic mixes
     return qIndex === -1 || qIndex >= Math.max(0, minIndex - 1);
   });

--- a/saberparatodos/src/lib/questions/selection.ts
+++ b/saberparatodos/src/lib/questions/selection.ts
@@ -9,7 +9,7 @@ function shuffle<T>(items: T[]): T[] {
   return arr;
 }
 
-const CEFR_ORDER = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
+const CEFR_ORDER = ['A1', 'A1+', 'A2', 'A2+', 'B1', 'B1+', 'B2', 'B2+', 'C1', 'C2'];
 
 export function buildDiagnosticMixPool(
   questions: AppQuestion[],


### PR DESCRIPTION
Unified CEFR level arrays across saberparatodos runtime, added 'C2' level support, implemented grade-based fallbacks for missing CEFR levels in filters, and added target_cefr fallback in the question transformer. Updated unit tests to reflect 'C2' as the highest proficiency level.

Fixes #371

---
*PR created automatically by Jules for task [15323382545337609287](https://jules.google.com/task/15323382545337609287) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended English proficiency assessment to support the complete CEFR scale, now including C2 (Mastery) level.

* **Tests**
  * Expanded proficiency level tests to include full C2 coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/worldexams/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->