### PR TITLE
Implement Shared Context (Passage-Based) in Parser and Protocols

### DIFF
--- a/docs/ENGLISH_LEARNING_PROTOCOL.md
+++ b/docs/ENGLISH_LEARNING_PROTOCOL.md
@@ -75,35 +75,33 @@ Usamos textos de temas interesantes (Ciencia, Historia, Tecnología) y aplicamos
 *   **Negative Factual:** "¿Cuál de estas NO se menciona?"
 *   **Reference:** "¿A qué se refiere la palabra 'they' en la línea 12?"
 
-### ⚠️ Regla Crítica: Contexto para Preguntas Cloze Pareadas (Q5-Q6 y Q9-Q10)
+### 📖 Contexto Compartido (Passage-Based Questions)
 
-> [!CAUTION]
-> **OBLIGATORIO:** Las preguntas 6 y 10 (que comparten el mismo texto Cloze con las preguntas 5 y 9 respectivamente) **DEBEN incluir su propio bloque `### Contexto`** con el texto completo.
->
-> **Razón:** El parser/UI procesa cada pregunta de forma independiente. Si Q6 o Q10 no tienen `### Contexto`, se mostrarán sin el pasaje de lectura, haciendo la pregunta irresoluble.
+> [!TIP]
+> **Novedad 2026:** El parser ahora soporta **Contexto Compartido**. No es necesario duplicar el texto en cada pregunta si se utiliza una cabecera de nivel 2 para definir el contexto de una sección.
 
-**Ejemplo CORRECTO:**
+Para preguntas que comparten un mismo pasaje de lectura (ej. Partes 4, 5, 6 y 7), se debe usar la siguiente estructura:
+
+1.  **## PART X:** Define el inicio de una sección con contexto compartido. Todo el texto entre esta cabecera y la siguiente cabecera `##` (ya sea otra PART o una Question) se inyectará automáticamente en la propiedad `context` de todas las preguntas siguientes.
+2.  **### Shared Context:** Directiva alternativa para casos donde no se desee usar la etiqueta "PART".
+
+**Ejemplo RECOMENDADO (Optimizado):**
 ```markdown
-## Question 6 (Part 4 - Cloze I - Difficulty 3)
-ID: UNI-ENG-07-city-001-v6
+## PART 4: Cloze Test
+The (5) ______ is blue. It (6) ______ very large.
 
-### Contexto
-**Text (same as above):**
-(5) ______ are many buildings. The (6) ______ one is the museum.
-
+## Question 5 (Part 4 - Difficulty 2)
+ID: UNI-ENG-07-city-001-v5
 ### Enunciado
-Choose the correct superlative for (6).
+Choose for (5).
+
+## Question 6 (Part 4 - Difficulty 2)
+ID: UNI-ENG-07-city-001-v6
+### Enunciado
+Choose for (6).
 ```
 
-**Ejemplo INCORRECTO (NO HACER):**
-```markdown
-## Question 6 (Part 4 - Cloze I - Difficulty 3)
-ID: UNI-ENG-07-city-001-v6
-
-### Enunciado
-Choose the correct superlative for (6).
-<!-- FALTA EL CONTEXTO! -->
-```
+*Nota: Si una pregunta específica requiere contexto adicional además del compartido, se puede seguir usando `### Contexto` dentro de la pregunta; el parser los combinará (Global + Part + Specific).*
 
 ---
 

--- a/docs/QUESTION_GENERATION_PROTOCOL_V4.md
+++ b/docs/QUESTION_GENERATION_PROTOCOL_V4.md
@@ -104,10 +104,24 @@ source_license: "CC BY-SA 4.0"
 **Bloom:** Remember
 
 ### Contexto
-[Breve contexto o texto de lectura]
+[Opcional si se usa Shared Context] Breve contexto o texto de lectura.
 
 ### Enunciado
 [Pregunta clara y específica]
+```
+
+### 4.2.1 Contexto Compartido (Novedad v4.1)
+Para grupos de preguntas que comparten un mismo estímulo (ej. Lectura Crítica, Cloze), se recomienda definir el contexto una sola vez:
+
+```markdown
+## PART X: [Título de la sección]
+[Texto de lectura compartido por las siguientes preguntas]
+
+## Question N ...
+ID: ...
+### Enunciado
+...
+```
 
 ### Options
 - [x] A) Respuesta correcta

--- a/saberparatodos/src/utils/questionParser.test.ts
+++ b/saberparatodos/src/utils/questionParser.test.ts
@@ -152,5 +152,69 @@ What is the answer?
       const questions = parseBundleQuestions(mockEntry);
       expect(questions[0].context).toBe('Only specific context.');
     });
+
+    it('should handle shared context from ## PART headers', () => {
+      const mockEntry: QuestionEntry = {
+        id: 'BUN-004',
+        body: `
+# Global Intro
+This is global.
+
+---
+
+## PART 1: Vocabulary
+This is context for Part 1.
+
+## Question 1 (Original - Dificultad 3)
+ID: BUN-004-v1
+### Enunciado
+Question 1?
+
+### Opciones
+- [x] A) Yes
+- [ ] B) No
+
+### Explicación Pedagógica
+Exp 1
+
+## PART 2: Reading
+This is context for Part 2.
+
+## Question 2 (Original - Dificultad 3)
+ID: BUN-004-v2
+### Enunciado
+Question 2?
+
+### Opciones
+- [x] A) Yes
+- [ ] B) No
+
+### Explicación Pedagógica
+Exp 2
+`,
+        data: {
+          id: 'BUN-004',
+          grado: 11,
+          asignatura: 'ingles',
+          tema: 'test'
+        }
+      };
+
+      const questions = parseBundleQuestions(mockEntry);
+      expect(questions.length).toBe(2);
+
+      // Global context should be present in both
+      expect(questions[0].context).toContain('Global Intro');
+      expect(questions[1].context).toContain('Global Intro');
+
+      // Part 1 context should be in Q1
+      expect(questions[0].context).toContain('This is context for Part 1.');
+
+      // Part 2 context should be in Q2
+      expect(questions[1].context).toContain('This is context for Part 2.');
+
+      // Q2 should NOT have Part 1 context if it's been superseded
+      expect(questions[1].context).not.toContain('This is context for Part 1.');
+    });
   });
 });

--- a/saberparatodos/src/utils/questionParser.ts
+++ b/saberparatodos/src/utils/questionParser.ts
@@ -36,6 +36,38 @@ export function isEntryQuarantined(entry: QuestionEntry): boolean {
 }
 
 /**
+ * Clean context text by removing metadata and other internal annotations
+ */
+export function cleanContext(context: string | undefined): string {
+  if (!context) return '';
+
+  let cleaned = context;
+
+  // Remove === METADATA GLOBAL === and any content until next # header or end
+  cleaned = cleaned.replace(/===\s*METADATA\s*GLOBAL\s*===[\s\S]*?(?=#|$)/gi, '');
+  // Remove markdown tables (| ... |)
+  cleaned = cleaned.replace(/^\|.*\|$/gm, '');
+  // Remove table separators |---|---|
+  cleaned = cleaned.replace(/^\|[-:\s|]+\|$/gm, '');
+  // Remove horizontal rules
+  cleaned = cleaned.replace(/^---+$/gm, '');
+  // Remove # Bundle: headers
+  cleaned = cleaned.replace(/^#\s*Bundle:.*$/gm, '');
+  // Remove > **Fuente:** lines
+  cleaned = cleaned.replace(/^>\s*\*\*Fuente:\*\*.*$/gm, '');
+  // Remove > **Componente:** lines
+  cleaned = cleaned.replace(/^>\s*\*\*Componente:\*\*.*$/gm, '');
+  // Remove > **Competencias:** lines
+  cleaned = cleaned.replace(/^>\s*\*\*Competencias:\*\*.*$/gm, '');
+  // Remove standalone (Grade N) patterns from remaining text
+  cleaned = cleaned.replace(/\s*\(Grade\s*\d+\)/gi, '');
+  // Clean excessive whitespace
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n').trim();
+
+  return cleaned;
+}
+
+/**
  * Clean metadata from explanation text
  * Removes validation metadata tables and other internal annotations
  */
@@ -196,58 +228,56 @@ export function parseBundleQuestions(entry: QuestionEntry): ParsedBundleQuestion
   const body = entry.body;
   const questions: ParsedBundleQuestion[] = [];
 
-  // Extract shared context (everything before the first question)
-  // This captures "Texto A", "Texto B", etc.
-  const firstQuestionMatch = body.match(/## (?:Pregunta|Question)\s+\d+/i);
-  const contextEndIndex = firstQuestionMatch ? firstQuestionMatch.index : 0;
-  let context = contextEndIndex ? body.substring(0, contextEndIndex).trim() : '';
+  // 1. Extract Global Context (everything before the first major section)
+  const firstSectionMatch = body.match(/(?:^|\n)## (?:PART|Pregunta|Question|Questão)\b/i) ||
+                           body.match(/(?:^|\n)### Shared Context\b/i);
+  const globalContextEndIndex = firstSectionMatch ? firstSectionMatch.index : 0;
+  const globalContext = cleanContext(body.substring(0, globalContextEndIndex));
 
-  // Clean context: Remove metadata sections
-  if (context) {
-    // Remove === METADATA GLOBAL === and any content until next # header or end
-    context = context.replace(/===\s*METADATA\s*GLOBAL\s*===[\s\S]*?(?=#|$)/gi, '');
-    // Remove markdown tables (| ... |)
-    context = context.replace(/^\|.*\|$/gm, '');
-    // Remove table separators |---|---|
-    context = context.replace(/^\|[-:\s|]+\|$/gm, '');
-    // Remove horizontal rules
-    context = context.replace(/^---+$/gm, '');
-    // Remove # Bundle: headers
-    context = context.replace(/^#\s*Bundle:.*$/gm, '');
-    // Remove > **Fuente:** lines
-    context = context.replace(/^>\s*\*\*Fuente:\*\*.*$/gm, '');
-    // Remove > **Componente:** lines
-    context = context.replace(/^>\s*\*\*Componente:\*\*.*$/gm, '');
-    // Remove > **Competencias:** lines
-    context = context.replace(/^>\s*\*\*Competencias:\*\*.*$/gm, '');
-    // Remove # Topic: lines (e.g., "# Topic: Social Media Awareness (Grade 8)")
-    // context = context.replace(/^#\s*Topic:.*$/gm, '');
-    // Remove standalone (Grade N) patterns from remaining text
-    context = context.replace(/\s*\(Grade\s*\d+\)/gi, '');
-    // Clean excessive whitespace
-    context = context.replace(/\n{3,}/g, '\n\n').trim();
-  }
+  // 2. Define Regex to match sections: Questions, PARTS, or Shared Context
+  // We match headers and capture content until the next major header or metadata block
+  const sectionRegex = /(?:^|\n)(## (?:Pregunta|Question|Questão)\s+(\d+)\s*\(([^)]+)\)|## PART\s+.*|### Shared Context\s+.*)[\s\S]*?(?=(?:^|\n)(## (?:Pregunta|Question|Questão)\s+\d+|## PART\s+|### Shared Context\s+|## 📊 (?:Metadata|Metadados)|---\s*$)|$)/gi;
 
-  // Match ## Pregunta N or ## Question N sections
-  // We use ^|\n to ensure we match start of lines, preventing matches on inline text
-  // We specifically look for "## " to avoid matching "### "
-  const sectionRegex = /(?:^|\n)## (?:Pregunta|Question|Questão)\s+(\d+)\s*\(([^)]+)\)[\s\S]*?(?=(?:^|\n)## (?:Pregunta|Question|Questão)\s+\d+|(?:^|\n)## 📊 (?:Metadata|Metadados)|---\s*$|$)/gi;
-
+  let currentSharedContext = '';
   let match;
-  while ((match = sectionRegex.exec(body)) !== null) {
-    const sectionNumber = parseInt(match[1]);
-    const sectionType = match[2].trim();
-    const sectionContent = match[0];
 
-    const question = parseQuestionSection(sectionContent, sectionNumber, sectionType, entry.data.id);
-    if (question) {
-      // Merge global context with question-specific context if both exist
-      if (context) {
-        question.context = question.context
-          ? `${context}\n\n${question.context}`
-          : context;
+  while ((match = sectionRegex.exec(body)) !== null) {
+    const sectionHeader = match[1].trim();
+    const sectionContent = match[0].trim();
+
+    if (sectionHeader.toUpperCase().startsWith('## PART') ||
+        sectionHeader.toUpperCase().startsWith('### SHARED CONTEXT')) {
+      // Update the active shared context
+      currentSharedContext = cleanContext(sectionContent);
+    } else {
+      // It's a question section
+      const sectionNumber = parseInt(match[2]);
+      const sectionType = match[3].trim();
+
+      const question = parseQuestionSection(sectionContent, sectionNumber, sectionType, entry.data.id);
+      if (question) {
+        // Build the hierarchical context
+        let finalContext = '';
+
+        if (globalContext) {
+          finalContext = globalContext;
+        }
+
+        if (currentSharedContext) {
+          finalContext = finalContext
+            ? `${finalContext}\n\n${currentSharedContext}`
+            : currentSharedContext;
+        }
+
+        if (question.context) {
+          finalContext = finalContext
+            ? `${finalContext}\n\n${question.context}`
+            : question.context;
+        }
+
+        question.context = finalContext || undefined;
+        questions.push(question);
       }
-      questions.push(question);
     }
   }
 

--- a/scripts/audit_shared_context.js
+++ b/scripts/audit_shared_context.js
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { parseBundleQuestions } from '../saberparatodos/src/utils/questionParser.ts';
+
+const questionsDataPath = './questions_data';
+
+function walk(dir) {
+  let results = [];
+  if (!fs.existsSync(dir)) return [];
+  const list = fs.readdirSync(dir);
+  list.forEach(file => {
+    file = path.join(dir, file);
+    const stat = fs.statSync(file);
+    if (stat && stat.isDirectory()) {
+      results = results.concat(walk(file));
+    } else if (file.endsWith('.md')) {
+      results.push(file);
+    }
+  });
+  return results;
+}
+
+const bundles = walk(questionsDataPath);
+console.log(`Found ${bundles.length} bundles.`);
+
+let bundlesWithParts = 0;
+let errors = 0;
+
+bundles.forEach(bundlePath => {
+  const content = fs.readFileSync(bundlePath, 'utf8');
+  if (content.includes('## PART') || content.includes('### Shared Context')) {
+    bundlesWithParts++;
+    try {
+      const { data, content: body } = matter(content);
+      const entry = {
+        id: data.id || path.basename(bundlePath),
+        body,
+        data: {
+            ...data,
+            grado: data.grado || 11,
+            asignatura: data.asignatura || 'unknown',
+            tema: data.tema || 'unknown',
+            id: data.id || 'unknown'
+        }
+      };
+      const questions = parseBundleQuestions(entry);
+
+      const partHeaders = body.split('\n').filter(l => l.trim().startsWith('## PART') || l.trim().startsWith('### Shared Context'));
+
+      if (questions.length > 0) {
+          questions.forEach(q => {
+              if (partHeaders.length > 0 && !q.context) {
+                  console.error(`Error in ${bundlePath}: Question ${q.id} has no context but bundle has PARTS.`);
+                  errors++;
+              }
+          });
+      }
+
+    } catch (e) {
+      console.error(`Error parsing ${bundlePath}: ${e.message}`);
+      errors++;
+    }
+  }
+});
+
+console.log(`Audited ${bundlesWithParts} bundles with PARTS.`);
+console.log(`Found ${errors} potential issues.`);
+
+if (errors > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
This PR implements a hierarchical context injection mechanism in the bundle parser. Questions following a `## PART` or `### Shared Context` header will now automatically inherit the text defined in that section, eliminating the need for manual text duplication in passage-based bundles (e.g., English reading sections).

Key changes:
- `saberparatodos/src/utils/questionParser.ts`: Updated `parseBundleQuestions` to track and inject shared context.
- `saberparatodos/src/utils/questionParser.test.ts`: Added tests for multi-part context inheritance and global context preservation.
- Documentation updates to reflect the new standard and deprecate the previous mandatory duplication rule.

Fixes #376

---
*PR created automatically by Jules for task [17431766573579595622](https://jules.google.com/task/17431766573579595622) started by @iberi22*