### PR TITLE
Generate static packs for periods 2, 3, and 4 for Grade 11

### DIFF
--- a/apps/landing-worldexams/package.json
+++ b/apps/landing-worldexams/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@worldexams/landing-worldexams",
   "type": "module",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "description": "World Exams - Practice exams for every nation",
   "scripts": {
     "dev": "astro dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "worldexams",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "worldexams",
-      "version": "0.14.0",
+      "version": "0.15.1",
       "workspaces": [
         "apps/landing-worldexams",
         "saberparatodos",
@@ -33,7 +33,7 @@
     },
     "apps/landing-worldexams": {
       "name": "@worldexams/landing-worldexams",
-      "version": "0.14.0",
+      "version": "0.15.1",
       "dependencies": {
         "@astrojs/check": "^0.9.2",
         "@astrojs/sitemap": "^3.6.0",
@@ -15895,7 +15895,8 @@
       }
     },
     "saberparatodos": {
-      "version": "0.14.0",
+      "version": "0.15.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@astrojs/cloudflare": "^13.1.10",
         "@astrojs/sitemap": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "worldexams",
   "private": true,
   "type": "module",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "description": "WorldExams private prelaunch monorepo",
   "workspaces": [
     "apps/landing-worldexams",

--- a/saberparatodos/package.json
+++ b/saberparatodos/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saberparatodos",
   "type": "module",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "scripts": {
     "predev": "",
     "dev": "astro dev",

--- a/saberparatodos/scripts/generate-static-packs.js
+++ b/saberparatodos/scripts/generate-static-packs.js
@@ -8,7 +8,20 @@ const __dirname = path.dirname(__filename);
 const ROOT = path.join(__dirname, '..');
 const QUESTIONS_DATA_ROOT = path.join(ROOT, '..', 'questions_data');
 const OUTPUT_DIR = path.join(ROOT, 'public', 'api', 'packs');
-const PACK_ID = 'week-1'; // Default pack ID
+
+const args = process.argv.slice(2);
+let targetPeriod = 1;
+const periodIdx = args.indexOf('--period');
+if (periodIdx !== -1 && args[periodIdx + 1]) {
+  targetPeriod = parseInt(args[periodIdx + 1]);
+} else {
+  const periodArg = args.find((arg) => arg.startsWith('--period='));
+  if (periodArg) {
+    targetPeriod = parseInt(periodArg.split('=')[1]);
+  }
+}
+
+const PACK_ID = `week-${targetPeriod}`;
 
 if (!fs.existsSync(OUTPUT_DIR)) {
   fs.mkdirSync(OUTPUT_DIR, { recursive: true });
@@ -173,13 +186,14 @@ for (const file of allFiles) {
       }
     }
 
-    const period = data.periodo || 1;
+    const period = parseInt(data.periodo || 1);
+    if (period !== targetPeriod) continue;
 
     // Normalize country code
     let rawCountry = (data.country || countryFolder).toLowerCase();
     let countryCode = rawCountry;
     const countryMap = {
-      'colombia': 'co',
+      'colombia': 'colombia',
       'mexico': 'mx',
       'peru': 'pe',
       'chile': 'cl',
@@ -243,8 +257,30 @@ for (const [key, data] of Object.entries(packs)) {
   console.log(`Generated ${outputPath} with ${data.questions.length} questions`);
 }
 
-// Generate current.json and metadata.json (minimal versions for compatibility)
-fs.writeFileSync(path.join(OUTPUT_DIR, 'current.json'), JSON.stringify({ version: '1.0.0', last_update: new Date().toISOString() }));
-fs.writeFileSync(path.join(OUTPUT_DIR, 'metadata.json'), JSON.stringify({ packs: Object.keys(packs) }));
+// Generate current.json and metadata.json
+const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+const version = packageJson.version || '1.0.0';
+
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, 'current.json'),
+  JSON.stringify({ version, last_update: new Date().toISOString() }, null, 2)
+);
+
+// Merge with existing metadata if it exists
+let allPacks = Object.keys(packs);
+const metadataPath = path.join(OUTPUT_DIR, 'metadata.json');
+if (fs.existsSync(metadataPath)) {
+  try {
+    const existingMetadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    if (existingMetadata.packs && Array.isArray(existingMetadata.packs)) {
+      const packSet = new Set([...existingMetadata.packs, ...allPacks]);
+      allPacks = Array.from(packSet);
+    }
+  } catch (e) {
+    console.error(`Error reading existing metadata: ${e.message}`);
+  }
+}
+
+fs.writeFileSync(metadataPath, JSON.stringify({ packs: allPacks.sort() }, null, 2));
 
 console.log('Static packs generation completed.');


### PR DESCRIPTION
This PR implements the generation of static JSON packs for Grade 11, covering periods 2, 3, and 4. 

Key changes:
- **Script Update**: `saberparatodos/scripts/generate-static-packs.js` now accepts a `--period` argument, allowing targeted generation of content for specific academic periods.
- **Naming Convention**: The script was adjusted to use the `colombia-` prefix consistently for Colombian content, aligning with the existing structure and user requirements.
- **Versioning**: The project version has been bumped to `0.15.1` in the root `package.json`, `saberparatodos/package.json`, and `apps/landing-worldexams/package.json`.
- **Content Generation**: 11 new packs for Colombia Grade 11 (spanning Ciencias Naturales, Lectura Crítica, Matemáticas, and Sociales Ciudadanas) have been generated and added to `saberparatodos/public/api/packs/`. Global English packs for these periods were also generated.
- **API Metadata**: `current.json` and `metadata.json` were updated to reflect the new version and include references to the newly generated packs, enabling frontend discovery.

The changes were verified by running the generation script for each period, performing a duplicate ID check, and running existing unit tests in the `saberparatodos` directory.

Fixes #388

---
*PR created automatically by Jules for task [16958732372480906521](https://jules.google.com/task/16958732372480906521) started by @iberi22*