### PR TITLE
Harden Jules bundle v5.2 validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/jules-bundle-generation.md
+++ b/.github/ISSUE_TEMPLATE/jules-bundle-generation.md
@@ -1,0 +1,151 @@
+---
+name: "Jules: Generacion de Bundles v5.2"
+about: "Issue para que Jules genere bundles semanales MASTERY"
+title: "[JULES] {PAIS} - {ASIGNATURA} {GRADO} - W{NN}-W{NN} ({NUM_BUNDLES} bundles)"
+labels: ["jules", "generate-questions"]
+assignees: []
+---
+
+## Reglas criticas para Jules
+
+### Limite de capacidad
+
+- Maximo: 15 bundles por issue.
+- Ideal: 5-12 bundles por issue.
+- Si el lote supera 15 bundles, crear issues separados.
+- Si algun bundle ya existe, no regenerarlo salvo que este issue diga explicitamente `REPLACE`.
+
+### Flujo obligatorio
+
+1. Leer `AGENTS.md`.
+2. Leer `skills/worldexams-bundle-generator/SKILL.md`.
+3. Leer `skills/bundle-creator/SKILL.md`.
+4. Leer `skills/bundle-creator/rules/{CODE}.md`.
+5. Generar solo archivos `.md` finales en `questions_data`.
+6. No crear scripts, logs, prompts ni archivos en `.worldexams`.
+7. No borrar bundles existentes no listados como reemplazo.
+8. Ejecutar `npm run validate -- {archivos_generados}`.
+9. Corregir hasta que la validacion pase.
+10. Comentar este issue con `[OK] Generados N bundles: {lista de IDs}`.
+
+## Objetivo
+
+{Descripcion concreta del lote}
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | {PAIS_NOMBRE} |
+| Codigo | {CODE} |
+| Asignatura | {asignatura} |
+| Subject code | {SUBJ} |
+| Grado | {N o 3EM} |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Tipo | weekly |
+| Preguntas/bundle | {8, 10, 12 o 20} |
+| Alignment | {curriculo/examen oficial} |
+| Ruta | `questions_data/{pais}/{asignatura}/grado-{N}/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | {tema-01} | `{CODE}-{SUBJ}-{GRADE}-2026-W01-{tema-01}-001-MASTERY-bundle.md` |
+| 2 | W02 | {tema-02} | `{CODE}-{SUBJ}-{GRADE}-2026-W02-{tema-02}-001-MASTERY-bundle.md` |
+
+## Frontmatter exacto
+
+Cada archivo debe empezar con:
+
+```yaml
+---
+id: "{CODE}-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle"
+country: "{pais}"
+grado: {N}
+asignatura: "{asignatura}"
+tema: "{tema}"
+periodo: "weekly"
+week: "W{NN}"
+year: 2026
+bundle_type: "weekly"
+protocol_version: "5.2"
+total_questions: {NUM_PREGUNTAS}
+bundle_size: {NUM_PREGUNTAS}
+alignment: "{alignment}"
+license: "FREE"
+tier: "legacy"
+creador: "Jules-Agent"
+---
+```
+
+Prohibido usar `semana` en reemplazo de `week`. Prohibido omitir `total_questions`, `bundle_type`, `license`, `tier` o `creador`.
+
+## Formato exacto de pregunta
+
+```markdown
+## Question 1 [D3]
+**ID:** {BUNDLE_ID}-v1
+**Bloom:** Remember
+**ICFES:** {competencia/eje}
+**Expected_Success:** 0.90
+**Contexto:** Contexto local util.
+
+### Enunciado
+Texto de la pregunta.
+
+### Opciones
+- [x] A) Respuesta correcta
+  <!-- feedback: Explicacion de por que es correcta. -->
+- [ ] B) Distractor
+  <!-- feedback: Error conceptual que representa. -->
+- [ ] C) Distractor
+  <!-- feedback: Error conceptual que representa. -->
+- [ ] D) Distractor
+  <!-- feedback: Error conceptual que representa. -->
+
+### Explicacion Pedagogica
+Explicacion completa del concepto.
+```
+
+## Reglas anti-error
+
+- No usar `## Pregunta`; usar `## Question`.
+- No usar `**Context:**`; usar `**Contexto:**`.
+- No usar `### Options`; usar `### Opciones`.
+- No usar explicacion en negrita; usar `### Explicacion Pedagogica`.
+- Exactamente una opcion `[x]` por pregunta.
+- Cuatro opciones A-D con texto unico.
+- Todas las opciones tienen feedback HTML.
+- No usar "todas las anteriores", "ninguna de las anteriores", "A y B", ni equivalentes.
+- No incluir `<think>`, `<process>`, prompts, logs ni markdown fences alrededor del bundle.
+
+## Contexto regional
+
+- Pais: {PAIS_NOMBRE}
+- Moneda: {MONEDA}
+- Ciudades/regiones: {CIUDADES}
+- Curriculo: {CURRICULO}
+- Examen/eje: {EXAMEN}
+- Variante idiomatica: {VARIANTE}
+
+## Validacion obligatoria
+
+Antes de abrir PR:
+
+```bash
+npm run validate -- {archivo_1} {archivo_2}
+```
+
+## Criterios de aceptacion
+
+- [ ] {NUM_BUNDLES} archivos creados en la ruta correcta.
+- [ ] Ningun script, prompt, log o archivo temporal agregado.
+- [ ] Ningun bundle existente eliminado salvo reemplazo explicito.
+- [ ] Frontmatter v5.2 exacto.
+- [ ] Nombre de archivo coincide con `id`.
+- [ ] Conteo de preguntas correcto.
+- [ ] Formato de preguntas exacto.
+- [ ] Contexto regional correcto.
+- [ ] `npm run validate -- {archivos}` pasa sin errores.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "tests"
   ],
   "scripts": {
+    "validate": "node scripts/validate-bundles-v52.mjs",
     "dev": "npm run dev:landing-worldexams",
     "dev:landing-worldexams": "npm run dev -w @worldexams/landing-worldexams",
     "dev:saberparatodos": "npm run dev -w saberparatodos",

--- a/scripts/validate-bundles-v52.mjs
+++ b/scripts/validate-bundles-v52.mjs
@@ -1,0 +1,171 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const QUESTION_COUNTS = new Map([
+  [3, 8],
+  [4, 8],
+  [5, 8],
+  [6, 10],
+  [7, 10],
+  [8, 12],
+  [9, 12],
+  [10, 12],
+  [11, 20],
+]);
+
+function walk(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.isFile() && entry.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+  const data = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (!m) continue;
+    let value = m[2].trim().replace(/^['"]|['"]$/g, '');
+    if (/^\d+$/.test(value)) value = Number(value);
+    data[m[1]] = value;
+  }
+  return data;
+}
+
+function questionBlocks(content) {
+  const re = /^##\s+(Question|Pregunta)\s+(\d+)\s*\[([^\]]+)\]/gim;
+  const matches = [...content.matchAll(re)];
+  return matches.map((m, i) => ({
+    label: m[1],
+    number: Number(m[2]),
+    difficulty: m[3],
+    text: content.slice(m.index, i + 1 < matches.length ? matches[i + 1].index : content.length),
+  }));
+}
+
+function optionRows(block) {
+  const re = /^- \[[ xX]\]\s*([A-D])\)\s*([^\n<]+)(?:\s*<!-- feedback:\s*([\s\S]*?)\s*-->)?/gm;
+  return [...block.matchAll(re)].map((m) => ({
+    letter: m[1],
+    text: m[2].trim().toLowerCase().replace(/\s+/g, ' '),
+    feedback: (m[3] || '').trim(),
+  }));
+}
+
+function expectedCount(file, fm) {
+  const base = path.basename(file);
+  if (base.includes('-3EM-') || String(fm.grado).toUpperCase() === '3EM') return 20;
+  const grade = Number(String(fm.grado ?? '').match(/\d+/)?.[0]);
+  return QUESTION_COUNTS.get(grade);
+}
+
+function rel(file) {
+  return path.relative(ROOT, file).replace(/\\/g, '/');
+}
+
+function validateFile(file) {
+  const errors = [];
+  if (!fs.existsSync(file)) {
+    return { file: rel(file), errors: ['File does not exist'] };
+  }
+  const content = fs.readFileSync(file, 'utf8');
+  const relative = rel(file);
+  const base = path.basename(file);
+  const fm = parseFrontmatter(content);
+
+  if (!relative.startsWith('questions_data/')) errors.push('File is outside questions_data/');
+  if (!/-001-MASTERY-bundle\.md$/.test(base)) errors.push('Filename must end with -001-MASTERY-bundle.md');
+  if (!fm) return { file: relative, errors: ['Missing YAML frontmatter'] };
+
+  const required = [
+    'id',
+    'country',
+    'grado',
+    'asignatura',
+    'tema',
+    'periodo',
+    'week',
+    'year',
+    'bundle_type',
+    'protocol_version',
+    'total_questions',
+    'bundle_size',
+    'alignment',
+    'license',
+    'tier',
+    'creador',
+  ];
+  for (const key of required) {
+    if (fm[key] === undefined || fm[key] === '') errors.push(`Missing frontmatter field: ${key}`);
+  }
+
+  if (fm.id && `${fm.id}.md` !== base) errors.push('frontmatter id must match filename without .md');
+  if (fm.periodo !== 'weekly') errors.push('periodo must be "weekly"');
+  if (fm.bundle_type !== 'weekly') errors.push('bundle_type must be "weekly"');
+  if (fm.protocol_version !== '5.2') errors.push('protocol_version must be "5.2"');
+  if (fm.year !== 2026) errors.push('year must be 2026');
+  if (!/^W\d{2}$/.test(String(fm.week || ''))) errors.push('week must use WNN format');
+  if (fm.license !== 'FREE') errors.push('license must be FREE');
+  if (fm.tier !== 'legacy') errors.push('tier must be legacy');
+  if (fm.creador !== 'Jules-Agent') errors.push('creador must be Jules-Agent');
+
+  const expected = expectedCount(file, fm);
+  if (!expected) errors.push(`Unsupported grade for question count: ${fm.grado}`);
+  if (expected && fm.total_questions !== expected) errors.push(`total_questions must be ${expected}`);
+  if (expected && fm.bundle_size !== expected) errors.push(`bundle_size must be ${expected}`);
+
+  if (/<think>|<process>|```yaml|```markdown/i.test(content)) errors.push('AI leakage or markdown fence detected');
+  if (/todas las anteriores|ninguna de las anteriores|all of the above|none of the above|a y b son correctas/i.test(content)) {
+    errors.push('Forbidden all/none/multiple-combination option detected');
+  }
+
+  const questions = questionBlocks(content);
+  if (expected && questions.length !== expected) errors.push(`Expected ${expected} questions, found ${questions.length}`);
+
+  questions.forEach((q, index) => {
+    const prefix = `Question ${index + 1}`;
+    if (q.label !== 'Question') errors.push(`${prefix}: heading must use "Question"`);
+    if (q.number !== index + 1) errors.push(`${prefix}: question numbering is not sequential`);
+    if (!/^D\d+(?:-D?\d+)?$/.test(q.difficulty)) errors.push(`${prefix}: invalid difficulty label`);
+    if (!/\*\*ID:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing ID`);
+    if (!/\*\*Bloom:\*\*\s*(Remember|Understand|Apply|Analyze|Evaluate)/.test(q.text)) errors.push(`${prefix}: invalid Bloom`);
+    if (!/\*\*ICFES:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing ICFES/eje field`);
+    if (!/\*\*Expected_Success:\*\*\s*0\.\d+/.test(q.text)) errors.push(`${prefix}: missing Expected_Success`);
+    if (!/\*\*Contexto:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing Contexto`);
+    if (/\*\*Context:\*\*/.test(q.text)) errors.push(`${prefix}: use Contexto, not Context`);
+    if (!/###\s+Enunciado/.test(q.text)) errors.push(`${prefix}: missing ### Enunciado`);
+    if (!/###\s+Opciones/.test(q.text)) errors.push(`${prefix}: missing ### Opciones`);
+    if (!/###\s+Explicaci[oó]n Pedag[oó]gica/.test(q.text)) errors.push(`${prefix}: missing ### Explicacion Pedagogica`);
+
+    const options = optionRows(q.text);
+    if (options.length !== 4) errors.push(`${prefix}: expected 4 options, found ${options.length}`);
+    const correct = (q.text.match(/^- \[[xX]\]\s*[A-D]\)/gm) || []).length;
+    if (correct !== 1) errors.push(`${prefix}: expected exactly one correct option, found ${correct}`);
+    if (options.some((option) => !option.feedback)) errors.push(`${prefix}: every option needs feedback`);
+    if (new Set(options.map((option) => option.text)).size !== options.length) errors.push(`${prefix}: duplicate option text`);
+  });
+
+  return { file: relative, errors };
+}
+
+const args = process.argv.slice(2);
+const files = args.length
+  ? args.map((arg) => path.resolve(ROOT, arg))
+  : walk(path.join(ROOT, 'questions_data'));
+
+const results = files.filter((file) => file.endsWith('.md')).map(validateFile);
+const failed = results.filter((result) => result.errors.length);
+
+for (const result of failed) {
+  console.error(`\n${result.file}`);
+  for (const error of result.errors) console.error(`  - ${error}`);
+}
+
+console.log(`\nValidated ${results.length} bundle file(s). Failures: ${failed.length}.`);
+process.exit(failed.length ? 1 : 0);

--- a/skills/bundle-creator/SKILL.md
+++ b/skills/bundle-creator/SKILL.md
@@ -1,79 +1,150 @@
-# 🌎 SaberParaTodos Bundle Creator Skill
+# SaberParaTodos Bundle Creator Skill - v5.2
 
 ## Purpose
-Create MASTERY bundles (protocol_version: "5.1") for the SaberParaTodos multi-tenant exam prep platform. Each bundle = 20 multiple-choice questions aligned to a specific country's official exam framework.
 
-## Bundle Protocol (5.1) Format
+Create weekly MASTERY bundles for SaberParaTodos using `protocol_version: "5.2"`.
+
+This skill is country-aware. Always read the matching file in `skills/bundle-creator/rules/` before generating.
+
+## Canonical ID
+
+```text
+{COUNTRY_CODE}-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle
+```
+
+Examples:
+
+```text
+CO-LEN-7-2026-W14-subordinacion-001-MASTERY-bundle
+MX-MAT-11-2026-W01-algebra-numeros-reales-001-MASTERY-bundle
+BR-MAT-3EM-2026-W01-conjuntos-numericos-001-MASTERY-bundle
+```
+
+The filename must be `{id}.md`.
+
+## Required Route
+
+```text
+questions_data/{country}/{subject}/grado-{N}/2026/weekly/{id}.md
+```
+
+Brazil 3EM:
+
+```text
+questions_data/brasil/matematica/3o-ano/2026/weekly/{id}.md
+```
+
+## Required Frontmatter
+
+```yaml
+---
+id: "{id}"
+country: "{country}"
+grado: {grade}
+asignatura: "{subject}"
+tema: "{topic}"
+periodo: "weekly"
+week: "W{NN}"
+year: 2026
+bundle_type: "weekly"
+protocol_version: "5.2"
+total_questions: {question_count}
+bundle_size: {question_count}
+alignment: "{official_alignment}"
+license: "FREE"
+tier: "legacy"
+creador: "Jules-Agent"
+---
+```
+
+## Question Counts
+
+- G3-G5: 8
+- G6-G7: 10
+- G8-G10: 12
+- G11 and BR 3EM: 20
+
+## Difficulty Distribution
+
+For 10 questions:
+
+- Q1-Q2: D3-D4
+- Q3-Q5: D5-D6
+- Q6-Q8: D7-D8
+- Q9-Q10: D9-D10
+
+For 20 questions:
+
+- Q1-Q4: D3-D4
+- Q5-Q10: D5-D6
+- Q11-Q16: D7-D8
+- Q17-Q20: D9-D10
+
+## Bloom Distribution
+
+For 10 questions:
+
+- Remember: 2
+- Understand: 2
+- Apply: 3
+- Analyze: 2
+- Evaluate: 1
+
+For 20 questions:
+
+- Remember: 2
+- Understand: 4
+- Apply: 6
+- Analyze: 4
+- Evaluate: 4
+
+For 8 or 12 questions, keep the same progression and avoid overloading expert questions.
+
+## Exact Question Format
+
 ```markdown
----
-id: "CO-AREA-11-P1-topic-001-MASTERY"
-country: "colombia"
-grado: 11
-asignatura: "area"
-tema: "topic"
-periodo: 1
-protocol_version: "5.1"
-bundle_index: 1
-bundle_size: 20
-alignment: "ICFES Saber 11°"
-modern_context: true
-distractor_profile: "misconception_based"
-calibration:
-  expected_success_rate: 0.50
-  discrimination_index_target: ">= 0.22"
-  simulated_responses: 100
----
-...
-
-## Question N [Difficulty]
-
-**ID:** `CO-AREA-11-P1-topic-001-vN`
-**Bloom:** [Remember|Understand|Apply|Analyze|Evaluate]
-**Context:** Brief context.
+## Question N [D{level}]
+**ID:** {id}-v{N}
+**Bloom:** {Remember|Understand|Apply|Analyze|Evaluate}
+**ICFES:** {competency_or_exam_axis}
+**Expected_Success:** 0.80
+**Contexto:** Local country context.
 
 ### Enunciado
 Question text.
 
-### Options
-- [ ] A) Option <!-- feedback: Explanation. -->
-- [ ] B) Option <!-- feedback: Explanation. -->
-- [x] C) Option <!-- feedback: CORRECT. Explanation. -->
-- [ ] D) Option <!-- feedback: Explanation. -->
+### Opciones
+- [ ] A) Distractor
+  <!-- feedback: Explanation of the misconception. -->
+- [x] B) Correct answer
+  <!-- feedback: Explanation of why it is correct. -->
+- [ ] C) Distractor
+  <!-- feedback: Explanation of the misconception. -->
+- [ ] D) Distractor
+  <!-- feedback: Explanation of the misconception. -->
 
-### Explicación Pedagógica
-Step-by-step explanation.
+### Explicacion Pedagogica
+Step-by-step pedagogical explanation.
 ```
 
-## ID Convention
-`{COUNTRY_CODE}-{SUBJECT}-{GRADE}-{PERIOD}-{TOPIC}-{INDEX}-MASTERY`
-- COUNTRY_CODE: MX, AR, BR, CL, PE, EC, CO, ES, PR, GQ, PA, CR, GT, DO, SV, HN, NI, UY, PY, BO
-- SUBJECT: MAT, LEN, CIE, SOC, etc.
-- GRADE: 11 (last year), optionally 10, 9
-- PERIOD: 1 (first semester/period)
-- TOPIC: subtopic (algebra, geometria, biologia, lectura, etc.)
-- INDEX: 001, 002, etc.
-
-## Difficulty Distribution (per 20 questions)
-- D3-D4 (Basic): 4 questions (Q1-Q4)
-- D5-D6 (Intermediate): 6 questions (Q5-Q10)
-- D7-D8 (Advanced): 6 questions (Q11-Q16)
-- D9-D10 (Expert): 4 questions (Q17-Q20)
-
-## Bloom's Taxonomy Distribution
-- Remember: 2 questions
-- Understand: 4 questions
-- Apply: 6 questions
-- Analyze: 4 questions
-- Evaluate: 4 questions
-
 ## Critical Rules
-1. EACH question MUST have EXACTLY ONE `[x]` answer (correct)
-2. Never have two `[x]` in same question
-3. Each question MUST have a `### Explicación Pedagógica` section
-4. IDs must be UNIQUE across all bundles
-5. 20 questions per bundle, no more, no less
-6. feedback in HTML comments: correct goes to `[x]`, incorrect feedback explains the misconception
-7. `context:` should reference real-life scenarios when possible
 
-## Per-Country Rules
-Each country has its own skill rule file in `skills/bundle-creator/rules/`. ALWAYS consult the corresponding rule file before creating bundles for that country.
+1. Use exact Spanish structural labels: `Contexto`, `Enunciado`, `Opciones`, `Explicacion Pedagogica`.
+2. Use `## Question`, not `## Pregunta`.
+3. Exactly one `[x]`.
+4. Four unique options A-D.
+5. Feedback for every option.
+6. No all/none-of-the-above options.
+7. No prompt leakage or markdown code fences around the bundle.
+8. Do not create scripts, logs, prompts or temporary generation directories in content PRs.
+9. Do not delete unrelated bundles.
+
+## Validation
+
+Run:
+
+```bash
+npm run validate -- {generated_files}
+```
+
+The PR is not ready until validation passes.

--- a/skills/worldexams-bundle-generator/SKILL.md
+++ b/skills/worldexams-bundle-generator/SKILL.md
@@ -1,93 +1,125 @@
 ---
 name: worldexams-bundle-generator
-description: Sistema de generación masiva de bundles de alta calidad para WorldExams. Implementa el Protocolo v5.1, asegura neutralidad regional y calidad psicométrica superior.
+description: Sistema de generacion de bundles semanales WorldExams v5.2 para Jules.
 ---
 
-# WorldExams Bundle Generator Skill (Protocol v5.1)
+# WorldExams Bundle Generator Skill - Protocol v5.2
 
-Este skill otorga la capacidad de generar bundles de preguntas de alta calidad para la plataforma WorldExams, cumpliendo estrictamente con los estándares del ICFES (Colombia) y otros marcos nacionales.
+Este skill reemplaza cualquier instruccion v5.1 anterior. Jules debe generar bundles semanales v5.2, no bundles por periodo `P1`.
 
-## 🎯 Objetivo
-Generar bundles de **20 preguntas** con dificultad progresiva, alineación curricular perfecta y sin errores técnicos (duplicados, alucinaciones o fugas de IA).
+## Objective
 
-## 🛠️ Requisitos de Jules
-Cuando este skill se active vía GitHub Issue, Jules debe:
-1. Identificar el **País**, **Asignatura**, **Grado**, **Periodo** y **Tema**.
-2. Verificar si es una **Regeneración** (si ya existe un archivo previo).
-3. Generar el contenido siguiendo el **Workflow de Generación v5.1**.
+Generar bundles MASTERY semanales de alta calidad para WorldExams/SaberParaTodos, alineados al pais, grado, asignatura y semana solicitados en el issue.
 
+## Canonical Output
+
+Un bundle final debe estar en:
+
+```text
+questions_data/{country}/{subject}/grado-{N}/2026/weekly/{CODE}-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle.md
+```
+
+Brasil 3o ano usa:
+
+```text
+questions_data/brasil/matematica/3o-ano/2026/weekly/BR-MAT-3EM-2026-W{NN}-{topic}-001-MASTERY-bundle.md
+```
+
+No crear scripts, prompts, logs ni archivos temporales en el PR final.
+
+## Required Frontmatter
+
+```yaml
 ---
-
-## 📜 Protocolo de Generación v5.1
-
-### 1. Estructura del Bundle
-- **Archivo**: `[COUNTRY]-[SUBJ]-[GRADE]-P[N]-[TOPIC]-[###]-MASTERY-bundle.md`
-- **Frontmatter**: YAML completo con `protocol_version: "5.1"`.
-- **Cantidad**: EXACTAMENTE 20 preguntas.
-
-### 2. Dificultad Progresiva (MASTERY)
-| Rango | Dificultad | Nivel Bloom |
-|-------|------------|-------------|
-| 1-4   | D3-D4      | Remember / Understand |
-| 5-10  | D5-D6      | Apply |
-| 11-16 | D7-D8      | Analyze |
-| 17-20 | D9-D10     | Evaluate / Create |
-
-### 3. Anatomía de la Pregunta
-Cada pregunta DEBE incluir:
-- **ID**: `[BUNDLE_ID]-vN`
-- **Bloom**: Nivel taxonómico.
-- **ICFES**: Competencia específica según el marco oficial.
-- **Contexto**: Situación relevante y moderna (evitar contextos genéricos).
-- **Enunciado**: Claro, sin ambigüedades.
-- **4 Opciones**: A, B, C, D.
-  - **[x]** para la correcta.
-  - **[ ]** para los distractores.
-  - **feedback**: Explicación de por qué es correcta/incorrecta para CADA opción.
-- **Explicación Pedagógica**: Resumen del concepto evaluado.
-
+id: "{CODE}-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle"
+country: "{country}"
+grado: {grade}
+asignatura: "{subject}"
+tema: "{topic}"
+periodo: "weekly"
+week: "W{NN}"
+year: 2026
+bundle_type: "weekly"
+protocol_version: "5.2"
+total_questions: {question_count}
+bundle_size: {question_count}
+alignment: "{official_alignment}"
+license: "FREE"
+tier: "legacy"
+creador: "Jules-Agent"
 ---
+```
 
-## 🚫 Reglas Anti-Errores (CRÍTICO)
+Do not use `semana` instead of `week`. The `id` includes `-bundle` and must match the file basename without `.md`.
 
-1. **PROHIBIDO Distractores Duplicados**: El texto de las 4 opciones debe ser único. NUNCA repetir la opción correcta como un distractor.
-2. **PROHIBIDO AI Leakage**: Eliminar bloques de `<think>`, `<process>` o cualquier residuo de la generación del modelo. El archivo debe empezar directamente con el frontmatter.
-3. **PROHIBIDO Alucinaciones Científicas**: Validar símbolos químicos, fórmulas físicas y constantes universales. No inventar notación (ej: no usar `₇⁹Au`).
-4. **PROHIBIDO "Todas las anteriores"**: No usar opciones tipo "todas las anteriores", "ninguna de las anteriores", "A y B son correctas".
-5. **Contexto Útil**: El contexto debe ser necesario para resolver la pregunta o para dar marco situacional ICFES, no relleno decorativo.
+## Question Counts
 
----
+- G3-G5: 8
+- G6-G7: 10
+- G8-G10: 12
+- G11 and Brazil 3EM: 20
 
-## 📂 Ubicación Canónica
-Los bundles deben guardarse en:
-`questions_data/[country]/[asignatura]/grado-[N]/periodo-[P]/[tema]/[ID]-bundle.md`
+## Exact Question Anatomy
 
-## 🗺️ Reglas de Contextualización Regional
+```markdown
+## Question N [D3]
+**ID:** {BUNDLE_ID}-v{N}
+**Bloom:** Remember
+**ICFES:** Numerico
+**Expected_Success:** 0.90
+**Contexto:** Local, useful scenario.
 
-Jules debe adaptar el contenido según el país (`country`) definido en el issue:
-- **Moneda**: Usar la moneda local (ej: `COP $` para Colombia, `CLP $` para Chile, `BRL R$` para Brasil).
-- **Geografía**: Usar ciudades y regiones del país destino.
-- **Nombres**: Usar nombres comunes en la cultura local.
-- **Curriculum**: Mapear los temas a los exámenes nacionales (SIMCE en Chile, ECE en Perú, etc.).
-- **Variante Idiomática**: Usar voseo (`vos`) para Argentina/Uruguay/Paraguay.
+### Enunciado
+Question text.
 
-## ✅ Fase de Verificación (Obligatoria para Jules)
+### Opciones
+- [x] A) Correct answer
+  <!-- feedback: Why this is correct. -->
+- [ ] B) Distractor
+  <!-- feedback: Misconception explanation. -->
+- [ ] C) Distractor
+  <!-- feedback: Misconception explanation. -->
+- [ ] D) Distractor
+  <!-- feedback: Misconception explanation. -->
 
-Antes de realizar el commit de un bundle, Jules DEBE:
-1.  **Ejecutar el Auditor Local**:
-    ```bash
-    npx ts-node scripts/review-bundle.ts --bundle=[ruta_al_bundle]
-    ```
-2.  **Validar el resultado**: Si el auditor arroja `errors` o flags como `DUPLICATE_DISTRACTORS`, Jules debe corregir el archivo y volver a auditar.
-3.  **Comprobar `bundle_size`**: Asegurarse de que el número de preguntas coincide con el frontmatter.
+### Explicacion Pedagogica
+Pedagogical explanation.
+```
 
-## 🤖 Instrucciones para Jules (System Prompt Integration)
-"Eres Jules, el agente de generación de contenido de WorldExams. Tu misión es la excelencia pedagógica. Al recibir un issue con el label `jules` y una solicitud de bundle:
-1. Lee este skill (`skills/worldexams-bundle-generator/SKILL.md`).
-2. Genera el bundle siguiendo el protocolo v5.1.
-3. **AUDITA** tu propio trabajo usando `scripts/review-bundle.ts` antes de subirlo.
-4. Si el auditor falla, **CORRIGE** hasta que el reporte de revisión esté limpio.
-5. Si es una regeneración de un bundle `minimax-m2.7`, asegúrate de que el nuevo contenido sea 100% original y superior en calidad."
+Mandatory exact labels:
+- `## Question`, not `## Pregunta`
+- `**Contexto:**`, not `**Context:**`
+- `### Opciones`, not `### Options`
+- `### Explicacion Pedagogica`, not bold text
 
----
-*Versión 1.1 | Mayo 2026*
+## Quality Rules
+
+1. Exactly one `[x]` option per question.
+2. Exactly four options A-D.
+3. Every option has `<!-- feedback: ... -->`.
+4. No duplicated option text inside a question.
+5. No "all/none of the above" patterns in any language.
+6. No `<think>`, `<process>`, prompt text, markdown fences around the bundle, or internal notes.
+7. No unverified formulas, dates, constants, laws or exam claims.
+8. Contexts must fit the target country and language.
+9. Do not delete existing bundles unless the issue explicitly says replace and lists the files.
+
+## Validation
+
+Before opening a PR, run:
+
+```bash
+npm run validate -- {generated_file_1} {generated_file_2}
+```
+
+If validation fails, fix the files and run it again.
+
+## Jules Issue Workflow
+
+1. Read `AGENTS.md`.
+2. Read this skill.
+3. Read `skills/bundle-creator/SKILL.md`.
+4. Read the target country rule file.
+5. Generate only the requested `.md` files.
+6. Validate.
+7. Comment the issue with generated IDs.


### PR DESCRIPTION
## Summary
- tighten Jules bundle generation docs around weekly protocol v5.2
- add a strict Jules issue template for content batches
- add `npm run validate` via `scripts/validate-bundles-v52.mjs`

## Validation
- `node --check scripts/validate-bundles-v52.mjs`

## Notes
This PR intentionally excludes the locally modified `AGENTS.md` because it contains broader uncommitted workspace changes outside this scoped validation update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bundle validation tool accessible via `npm run validate` command to enforce protocol standards and bundle integrity checks.

* **Documentation**
  * Updated bundle generation specifications to support protocol v5.2 with new weekly bundle format requirements.
  * Added GitHub issue template for standardized bundle generation workflow requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->