### PR TITLE
[codex] Deduplicate served API questions

### DIFF
--- a/apps/worldexams-api/src/index.ts
+++ b/apps/worldexams-api/src/index.ts
@@ -198,23 +198,22 @@ function normalizePackQuestion(question: any) {
 }
 
 function normalizeQuestionText(value: unknown) {
-  return String(value || "")
+  return String(value ?? "")
     .toLowerCase()
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/<!--[\s\S]*?-->/g, " ")
-    .replace(/\\\(|\\\)|\\\[|\\\]/g, " ")
     .replace(/[^a-z0-9]+/g, " ")
     .replace(/\s+/g, " ")
     .trim()
 }
 
 function questionIdentityKey(question: any) {
-  const id = normalizeQuestionText(question?.id || question?.question_id)
+  const id = normalizeQuestionText(question?.id ?? question?.question_id)
   if (id) return `id:${id}`
 
-  const bundleId = normalizeQuestionText(question?.bundle_id || question?.bundleId)
-  const localId = normalizeQuestionText(question?.local_id || question?.questionId)
+  const bundleId = normalizeQuestionText(question?.bundle_id ?? question?.bundleId)
+  const localId = normalizeQuestionText(question?.local_id ?? question?.questionId)
   if (bundleId && localId) return `bundle:${bundleId}:${localId}`
 
   return ""
@@ -232,7 +231,7 @@ function questionSemanticKey(question: any) {
 
   const options = Array.isArray(question?.options)
     ? question.options
-        .map((option: any) => normalizeQuestionText(option?.text || option?.label || option))
+        .map((option: any) => normalizeQuestionText(option?.text ?? option?.label ?? option))
         .filter(Boolean)
         .sort()
         .join("|")

--- a/apps/worldexams-api/src/index.ts
+++ b/apps/worldexams-api/src/index.ts
@@ -197,6 +197,76 @@ function normalizePackQuestion(question: any) {
   }
 }
 
+function normalizeQuestionText(value: unknown) {
+  return String(value || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/\\\(|\\\)|\\\[|\\\]/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function questionIdentityKey(question: any) {
+  const id = normalizeQuestionText(question?.id || question?.question_id)
+  if (id) return `id:${id}`
+
+  const bundleId = normalizeQuestionText(question?.bundle_id || question?.bundleId)
+  const localId = normalizeQuestionText(question?.local_id || question?.questionId)
+  if (bundleId && localId) return `bundle:${bundleId}:${localId}`
+
+  return ""
+}
+
+function questionSemanticKey(question: any) {
+  const statement = normalizeQuestionText(
+    question?.statement ||
+      question?.enunciado ||
+      question?.question ||
+      question?.text ||
+      question?.prompt,
+  )
+  if (!statement) return ""
+
+  const options = Array.isArray(question?.options)
+    ? question.options
+        .map((option: any) => normalizeQuestionText(option?.text || option?.label || option))
+        .filter(Boolean)
+        .sort()
+        .join("|")
+    : ""
+
+  return `semantic:${statement.slice(0, 240)}::${options.slice(0, 240)}`
+}
+
+function dedupeQuestions<T>(questions: T[]) {
+  const seenIdentity = new Set<string>()
+  const seenSemantic = new Set<string>()
+  const deduped: T[] = []
+  let duplicateCount = 0
+
+  for (const question of questions as any[]) {
+    const identityKey = questionIdentityKey(question)
+    const semanticKey = questionSemanticKey(question)
+    const isDuplicate =
+      (identityKey && seenIdentity.has(identityKey)) ||
+      (semanticKey && seenSemantic.has(semanticKey))
+
+    if (isDuplicate) {
+      duplicateCount += 1
+      continue
+    }
+
+    if (identityKey) seenIdentity.add(identityKey)
+    if (semanticKey) seenSemantic.add(semanticKey)
+    deduped.push(question as T)
+  }
+
+  return { questions: deduped, duplicateCount }
+}
+
 async function fetchPublicQuestions(request: Request, env: Env) {
   const url = new URL(request.url)
   const grade = url.searchParams.get("grade") || "11"
@@ -228,8 +298,10 @@ async function fetchPublicQuestions(request: Request, env: Env) {
 
     const pack = await assetResponse.json<any>()
     const allQuestions = Array.isArray(pack?.questions) ? pack.questions : []
+    const normalizedQuestions = allQuestions.map(normalizePackQuestion)
+    const deduped = dedupeQuestions(normalizedQuestions)
     const startIndex = (page - 1) * pageSize
-    const questions = allQuestions.slice(startIndex, startIndex + pageSize).map(normalizePackQuestion)
+    const questions = deduped.questions.slice(startIndex, startIndex + pageSize)
 
     return json({
       success: true,
@@ -243,7 +315,9 @@ async function fetchPublicQuestions(request: Request, env: Env) {
       page,
       meta: {
         available_questions: allQuestions.length,
-        filtered_out: 0,
+        deduplicated_questions: deduped.questions.length,
+        duplicate_filtered: deduped.duplicateCount,
+        filtered_out: deduped.duplicateCount,
         source: "worker-assets",
         pack_path: path,
       },

--- a/saberparatodos/src/pages/api/questions.ts
+++ b/saberparatodos/src/pages/api/questions.ts
@@ -146,6 +146,76 @@ function normalizePackQuestion(question: any) {
   };
 }
 
+function normalizeQuestionText(value: unknown) {
+  return String(value || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/\\\(|\\\)|\\\[|\\\]/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function questionIdentityKey(question: any) {
+  const id = normalizeQuestionText(question?.id || question?.question_id);
+  if (id) return `id:${id}`;
+
+  const bundleId = normalizeQuestionText(question?.bundle_id || question?.bundleId);
+  const localId = normalizeQuestionText(question?.local_id || question?.questionId);
+  if (bundleId && localId) return `bundle:${bundleId}:${localId}`;
+
+  return "";
+}
+
+function questionSemanticKey(question: any) {
+  const statement = normalizeQuestionText(
+    question?.statement ||
+      question?.enunciado ||
+      question?.question ||
+      question?.text ||
+      question?.prompt,
+  );
+  if (!statement) return "";
+
+  const options = Array.isArray(question?.options)
+    ? question.options
+        .map((option: any) => normalizeQuestionText(option?.text || option?.label || option))
+        .filter(Boolean)
+        .sort()
+        .join("|")
+    : "";
+
+  return `semantic:${statement.slice(0, 240)}::${options.slice(0, 240)}`;
+}
+
+function dedupeQuestions<T>(questions: T[]) {
+  const seenIdentity = new Set<string>();
+  const seenSemantic = new Set<string>();
+  const deduped: T[] = [];
+  let duplicateCount = 0;
+
+  for (const question of questions as any[]) {
+    const identityKey = questionIdentityKey(question);
+    const semanticKey = questionSemanticKey(question);
+    const isDuplicate =
+      (identityKey && seenIdentity.has(identityKey)) ||
+      (semanticKey && seenSemantic.has(semanticKey));
+
+    if (isDuplicate) {
+      duplicateCount += 1;
+      continue;
+    }
+
+    if (identityKey) seenIdentity.add(identityKey);
+    if (semanticKey) seenSemantic.add(semanticKey);
+    deduped.push(question as T);
+  }
+
+  return { questions: deduped, duplicateCount };
+}
+
 async function fetchUpstreamJson(
   url: URL,
   headers: Headers,
@@ -316,12 +386,13 @@ export const GET: APIRoute = async ({ request, locals }) => {
       if (country === "co" && exam === "icfes") {
         const localQuestions = getLocalGrade11Questions(subject);
         if (localQuestions.length > 0) {
-          const visibleLocalQuestions =
-            filterQuarantinedQuestions(localQuestions);
+          const visibleLocalQuestions = dedupeQuestions(
+            filterQuarantinedQuestions(localQuestions).map(normalizePackQuestion),
+          );
           return buildJsonResponse({
             success: true,
-            questions: visibleLocalQuestions,
-            total_questions: visibleLocalQuestions.length,
+            questions: visibleLocalQuestions.questions,
+            total_questions: visibleLocalQuestions.questions.length,
             grade: 11,
             subject: subject || null,
             country,
@@ -329,6 +400,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
             page: "all",
             meta: {
               aggregated_pages: 1,
+              duplicate_filtered: visibleLocalQuestions.duplicateCount,
               source: "local-grade11-bank",
             },
           });
@@ -374,29 +446,25 @@ export const GET: APIRoute = async ({ request, locals }) => {
         if (pageQuestions.length < 10) break;
       }
 
-      const uniqueQuestions = filterQuarantinedQuestions(
-        Array.from(
-          new Map(
-            aggregatedQuestions.map((question) => [
-              String(question?.id || ""),
-              question,
-            ]),
-          ).values(),
-        ),
-      ).filter((question) => Boolean(question?.id));
+      const dedupedQuestions = dedupeQuestions(
+        filterQuarantinedQuestions(
+          aggregatedQuestions.map(normalizePackQuestion),
+        ).filter((question) => Boolean(question?.id)),
+      );
 
       return buildJsonResponse(
         {
           success: true,
-          questions: uniqueQuestions,
-          total_questions: uniqueQuestions.length,
+          questions: dedupedQuestions.questions,
+          total_questions: dedupedQuestions.questions.length,
           grade: 11,
           subject: requestUrl.searchParams.get("subject") || null,
           country: defaultCountry || null,
           exam_type: defaultExam || null,
           page: "all",
           meta: {
-            aggregated_pages: Math.ceil(uniqueQuestions.length / 10),
+            aggregated_pages: Math.ceil(dedupedQuestions.questions.length / 10),
+            duplicate_filtered: dedupedQuestions.duplicateCount,
             source: "free-api-grade11-expanded",
           },
         },
@@ -421,11 +489,15 @@ export const GET: APIRoute = async ({ request, locals }) => {
         Number(requestUrl.searchParams.get("page") || "1") || 1,
       );
       const pageSize = 10;
+      const dedupedQuestions = dedupeQuestions(
+        filterQuarantinedQuestions(
+          packQuestions.map(normalizePackQuestion),
+        ),
+      );
       const startIndex = (page - 1) * pageSize;
-      const visibleQuestions = filterQuarantinedQuestions(
-        packQuestions
-          .slice(startIndex, startIndex + pageSize)
-          .map(normalizePackQuestion),
+      const visibleQuestions = dedupedQuestions.questions.slice(
+        startIndex,
+        startIndex + pageSize,
       );
 
       return buildJsonResponse(
@@ -441,6 +513,8 @@ export const GET: APIRoute = async ({ request, locals }) => {
           page,
           meta: {
             available_questions: packQuestions.length,
+            deduplicated_questions: dedupedQuestions.questions.length,
+            duplicate_filtered: dedupedQuestions.duplicateCount,
             source: "same-origin-pack-proxy",
           },
         },
@@ -468,13 +542,19 @@ export const GET: APIRoute = async ({ request, locals }) => {
     const upstreamQuestions = Array.isArray(upstreamPayload?.questions)
       ? upstreamPayload.questions
       : [];
-    const visibleQuestions = filterQuarantinedQuestions(upstreamQuestions);
+    const visibleQuestions = dedupeQuestions(
+      filterQuarantinedQuestions(upstreamQuestions.map(normalizePackQuestion)),
+    );
 
     return buildJsonResponse(
       {
         ...upstreamPayload,
-        questions: visibleQuestions,
-        total_questions: visibleQuestions.length,
+        questions: visibleQuestions.questions,
+        total_questions: visibleQuestions.questions.length,
+        meta: {
+          ...(upstreamPayload?.meta || {}),
+          duplicate_filtered: visibleQuestions.duplicateCount,
+        },
       },
       upstreamResponse,
     );

--- a/saberparatodos/src/pages/api/questions.ts
+++ b/saberparatodos/src/pages/api/questions.ts
@@ -147,23 +147,22 @@ function normalizePackQuestion(question: any) {
 }
 
 function normalizeQuestionText(value: unknown) {
-  return String(value || "")
+  return String(value ?? "")
     .toLowerCase()
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/<!--[\s\S]*?-->/g, " ")
-    .replace(/\\\(|\\\)|\\\[|\\\]/g, " ")
     .replace(/[^a-z0-9]+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
 }
 
 function questionIdentityKey(question: any) {
-  const id = normalizeQuestionText(question?.id || question?.question_id);
+  const id = normalizeQuestionText(question?.id ?? question?.question_id);
   if (id) return `id:${id}`;
 
-  const bundleId = normalizeQuestionText(question?.bundle_id || question?.bundleId);
-  const localId = normalizeQuestionText(question?.local_id || question?.questionId);
+  const bundleId = normalizeQuestionText(question?.bundle_id ?? question?.bundleId);
+  const localId = normalizeQuestionText(question?.local_id ?? question?.questionId);
   if (bundleId && localId) return `bundle:${bundleId}:${localId}`;
 
   return "";
@@ -181,7 +180,7 @@ function questionSemanticKey(question: any) {
 
   const options = Array.isArray(question?.options)
     ? question.options
-        .map((option: any) => normalizeQuestionText(option?.text || option?.label || option))
+        .map((option: any) => normalizeQuestionText(option?.text ?? option?.label ?? option))
         .filter(Boolean)
         .sort()
         .join("|")
@@ -542,18 +541,18 @@ export const GET: APIRoute = async ({ request, locals }) => {
     const upstreamQuestions = Array.isArray(upstreamPayload?.questions)
       ? upstreamPayload.questions
       : [];
-    const visibleQuestions = dedupeQuestions(
+    const dedupedQuestions = dedupeQuestions(
       filterQuarantinedQuestions(upstreamQuestions.map(normalizePackQuestion)),
     );
 
     return buildJsonResponse(
       {
         ...upstreamPayload,
-        questions: visibleQuestions.questions,
-        total_questions: visibleQuestions.questions.length,
+        questions: dedupedQuestions.questions,
+        total_questions: dedupedQuestions.questions.length,
         meta: {
           ...(upstreamPayload?.meta || {}),
-          duplicate_filtered: visibleQuestions.duplicateCount,
+          duplicate_filtered: dedupedQuestions.duplicateCount,
         },
       },
       upstreamResponse,


### PR DESCRIPTION
## Summary
- Adds response-level deduplication for public API questions before pagination.
- Uses both stable identity keys (`id`, `question_id`, bundle/local IDs) and semantic keys from normalized statement + option text.
- Applies the same filtering to the Cloudflare worker API and the same-origin `saberparatodos.space/api/questions` route.
- Adds response metadata for `deduplicated_questions` and `duplicate_filtered` so repeated-question filtering is observable.

## Why
The API can serve repeated questions when upstream/internal sources include the same item across pages or when repeated items have different IDs. The old logic sliced pages before dedupe in pack-based flows and only deduped grade 11 aggregation by `id`.

## Validation
- Public API smoke before this change showed production still serving generic CO fallback for MX/AR until deployment of #590 reaches production.
- `node scripts/husky-guard.mjs --staged` passed.
- Artificial semantic duplicate smoke passed: two questions with different IDs but same normalized statement/options collapse to one.
- Real pack smoke on MX W01, MX W24, CO G7 W24 showed no current semantic duplicates.

## Notes
- `pnpm check` in `apps/worldexams-api` and `pnpm lint` in `saberparatodos` could not run locally because this workspace has no `node_modules`; `tsc`, `astro`, and `vitest` are unavailable without installing dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated duplicate questions from public questions endpoints and all API routes.
  * Enhanced question deduplication to identify semantic duplicates based on normalized text, not just exact ID matches.

* **New Features**
  * Response metadata now includes deduplication statistics showing filtered duplicate counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->