### PR TITLE
Preserve multiline option feedback in generated packs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,12 @@ No abrir PR si `npm run validate` falla.
 Un bundle `.md` validado no queda publicado automaticamente en `saberparatodos.space`.
 Para que la app sirva examenes desde el API publico, los bundles weekly deben convertirse a packs JSON estaticos.
 
+Decision arquitectonica:
+- El bundle fuente y revisable siempre es el archivo `.md` en `questions_data`.
+- Los archivos `.json` en `apps/worldexams-api/public/v1/packs` son artefactos derivados para servir el API; no son bundles fuente ni reemplazan al markdown.
+- No editar packs JSON manualmente para corregir contenido. Corregir primero el `.md`, validar, y regenerar packs.
+- El conversor debe preservar texto, respuesta correcta y feedback de cada opcion aunque el feedback HTML este en la linea siguiente a la opcion.
+
 Comandos canonicos despues de integrar bundles:
 
 ```bash

--- a/saberparatodos/scripts/generate-static-packs.js
+++ b/saberparatodos/scripts/generate-static-packs.js
@@ -151,15 +151,16 @@ function parseQuestions(body) {
     // Extract options
     const options = [];
     const optionRegex =
-      /^\s*-\s*\[([x ])\]\s*(?:\*\*)?([A-Z])(?:\*\*)?(?:\s*[\)\.\-:]\s*)?(.*)$/gm;
+      /^\s*-\s*\[([x ])\]\s*(?:\*\*)?([A-Z])(?:\*\*)?(?:\s*[\)\.\-:]\s*)?([\s\S]*?)(?=^\s*-\s*\[[x ]\]\s*(?:\*\*)?[A-Z](?:\*\*)?(?:\s*[\)\.\-:])|^###\s+|^##\s+|(?![\s\S]))/gim;
     let optMatch;
     let correctId = "A";
 
     while ((optMatch = optionRegex.exec(section)) !== null) {
       const isCorrect = optMatch[1].toLowerCase() === "x";
       const letter = optMatch[2];
-      const feedbackMatch = optMatch[3].match(/<!--\s*feedback:\s*([\s\S]*?)\s*-->/);
-      const text = optMatch[3]
+      const rawOption = optMatch[3].trim();
+      const feedbackMatch = rawOption.match(/<!--\s*feedback:\s*([\s\S]*?)\s*-->/i);
+      const text = rawOption
         .replace(/<!--\s*feedback:[\s\S]*?-->/, "")
         .trim();
       const feedback = feedbackMatch ? feedbackMatch[1].trim() : "";

--- a/scripts/audit-country-readiness.mjs
+++ b/scripts/audit-country-readiness.mjs
@@ -133,16 +133,19 @@ function questionBlocks(content) {
 }
 
 function optionRows(block) {
-  const re = /^- \[[ xX]\]\s*([A-D])\)\s*(.*)$/gm;
-  return [...block.matchAll(re)].map((match) => ({
-    letter: match[1],
-    text: match[2]
-      .replace(/\s*<!-- feedback:[\s\S]*?-->\s*$/, '')
-      .trim()
-      .toLowerCase()
-      .replace(/\s+/g, ' '),
-    feedback: (match[2].match(/<!-- feedback:\s*([\s\S]*?)\s*-->/)?.[1] || '').trim(),
-  }));
+  const re = /^- \[[ xX]\]\s*([A-D])\)\s*([\s\S]*?)(?=^- \[[ xX]\]\s*[A-D]\)|^###\s+|^##\s+|(?![\s\S]))/gm;
+  return [...block.matchAll(re)].map((match) => {
+    const raw = match[2].trim();
+    return {
+      letter: match[1],
+      text: raw
+        .replace(/<!-- feedback:[\s\S]*?-->/i, '')
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, ' '),
+      feedback: (raw.match(/<!-- feedback:\s*([\s\S]*?)\s*-->/i)?.[1] || '').trim(),
+    };
+  });
 }
 
 function expectedQuestionCount(fm) {

--- a/scripts/validate-bundles-v52.mjs
+++ b/scripts/validate-bundles-v52.mjs
@@ -50,12 +50,15 @@ function questionBlocks(content) {
 }
 
 function optionRows(block) {
-  const re = /^- \[[ xX]\]\s*([A-D])\)\s*(.*)$/gm;
-  return [...block.matchAll(re)].map((m) => ({
-    letter: m[1],
-    text: m[2].replace(/\s*<!-- feedback:[\s\S]*?-->\s*$/, '').trim().toLowerCase().replace(/\s+/g, ' '),
-    feedback: (m[2].match(/<!-- feedback:\s*([\s\S]*?)\s*-->/)?.[1] || '').trim(),
-  }));
+  const re = /^- \[[ xX]\]\s*([A-D])\)\s*([\s\S]*?)(?=^- \[[ xX]\]\s*[A-D]\)|^###\s+|^##\s+|(?![\s\S]))/gm;
+  return [...block.matchAll(re)].map((m) => {
+    const raw = m[2].trim();
+    return {
+      letter: m[1],
+      text: raw.replace(/<!-- feedback:[\s\S]*?-->/i, '').trim().toLowerCase().replace(/\s+/g, ' '),
+      feedback: (raw.match(/<!-- feedback:\s*([\s\S]*?)\s*-->/i)?.[1] || '').trim(),
+    };
+  });
 }
 
 function expectedCount(file, fm) {


### PR DESCRIPTION
## Summary
- Clarifies that weekly bundle `.md` files are the source of truth and JSON packs are derived API artifacts.
- Updates strict validation, country readiness audit, and static pack generation to parse option feedback when the HTML feedback comment is on the following line, as allowed by the v5.2 protocol.
- Prevents generated API packs from losing feedback text and emitting blank `feedback` fields when the source markdown is valid.

## Validation
- `node --check scripts/validate-bundles-v52.mjs`
- `node --check scripts/audit-country-readiness.mjs`
- `node --check saberparatodos/scripts/generate-static-packs.js`
- Parser smoke test for same-line and next-line feedback extraction
- `node scripts/validate-bundles-v52.mjs questions_data/colombia/lengua/grado-6/2026/weekly/CO-LEN-6-2026-W06-categorias-gramaticales-ii-001-MASTERY-bundle.md questions_data/colombia/lengua/grado-7/2026/weekly/CO-LEN-7-2026-W27-lenguaje-periodistico-001-MASTERY-bundle.md questions_data/spain/matematicas/grado-11/2026/weekly/ES-MAT-11-2026-W01-numeros-reales-propiedades-001-MASTERY-bundle.md`
- `npm run audit:country-readiness -- --smoke-public`

Note: full `npm run validate` still fails on existing legacy/non-v5.2 content across the repository; this PR does not touch that legacy corpus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified architectural guidelines on content management and validation workflows.

* **Bug Fixes**
  * Improved parsing of question options with multiline feedback to ensure consistent data handling and prevent loss of information during conversion and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->