### PR TITLE
fix: properly enforce CEFR filtering and fallback mapping in selection pool

### DIFF
--- a/saberparatodos/src/lib/questions/orchestrator.ts
+++ b/saberparatodos/src/lib/questions/orchestrator.ts
@@ -105,7 +105,7 @@ export async function prepareSoloExamQuestions(
       const cefrNum = request.minCefrLevel ? CEFR_LEVEL_NUM[request.minCefrLevel] : undefined;
       const diagnosticPool = await deps.repository.fetchEnglishQuestionsAllGrades(100, true, cefrNum);
       pool = dedupeById([...pool, ...diagnosticPool]);
-      filtered = filterBySubject(pool, request.subject);
+      filtered = filterByCefrLevel(filterBySubject(pool, request.subject), request.minCefrLevel);
     }
   }
 

--- a/saberparatodos/src/lib/questions/selection.ts
+++ b/saberparatodos/src/lib/questions/selection.ts
@@ -1,4 +1,5 @@
 import type { AppQuestion } from '../api-service';
+import { GRADE_TO_CEFR } from '../english-proficiency';
 
 function shuffle<T>(items: T[]): T[] {
   const arr = [...items];
@@ -51,12 +52,16 @@ export function buildDiagnosticMixPool(
       const lowerLevel = CEFR_ORDER[minIndex - 1];
 
       const mainPool = pool.filter((q) => {
-        if (!q.cefr_level) return true;
-        const qIndex = CEFR_ORDER.indexOf(q.cefr_level);
+        const qLevel = q.cefr_level || (q.grade ? GRADE_TO_CEFR[q.grade as keyof typeof GRADE_TO_CEFR] : undefined);
+        if (!qLevel) return true;
+        const qIndex = CEFR_ORDER.indexOf(qLevel);
         return qIndex === -1 || qIndex >= minIndex;
       });
 
-      const lowerPool = pool.filter((q) => q.cefr_level === lowerLevel);
+      const lowerPool = pool.filter((q) => {
+        const qLevel = q.cefr_level || (q.grade ? GRADE_TO_CEFR[q.grade as keyof typeof GRADE_TO_CEFR] : undefined);
+        return qLevel === lowerLevel;
+      });
 
       if (mainPool.length > 0 && lowerPool.length > 0) {
         const mixPercent = 15; // "pocas"


### PR DESCRIPTION
This PR fixes a bug where CEFR level selection was completely ignored when pulling multi-grade English questions, leading to B2+ questions being shown when A1 was selected.