### PR TITLE
Fix weekly bundle detection in static pack generator

### DIFF
--- a/saberparatodos/scripts/generate-static-packs.js
+++ b/saberparatodos/scripts/generate-static-packs.js
@@ -347,11 +347,21 @@ for (const file of allFiles) {
       const rawPeriod = String(data.periodo || "").toLowerCase();
       // Support both 'week' (canonical) and 'semana' (v5.2) frontmatter fields
       const weekField = data.week || data.semana || "";
-      const isWeeklyBundle = rawPeriod === "weekly" || data.bundle_type === "weekly" || weekField !== "";
+      const isWeeklyBundle =
+        rawPeriod === "weekly" ||
+        data.bundle_type === "weekly" ||
+        weekField !== "";
+
+      let period = NaN;
       const weekMatch = String(weekField).match(/^W(\d{2})$/i);
-      const period = isWeeklyBundle
-        ? (weekMatch ? Number(weekMatch[1]) : NaN)
-        : parseInt(data.periodo || 1);
+      if (weekMatch) {
+        period = Number(weekMatch[1]);
+      } else if (weekField !== "" && !isNaN(parseInt(weekField))) {
+        period = parseInt(weekField);
+      } else {
+        const parsed = parseInt(data.periodo);
+        period = isNaN(parsed) ? 1 : parsed;
+      }
     if (!Number.isFinite(period)) continue;
     if (!generateAllWeekly && period !== targetPeriod) continue;
     if (generateAllWeekly && !isWeeklyBundle) continue;

--- a/saberparatodos/scripts/test-weekly-logic.js
+++ b/saberparatodos/scripts/test-weekly-logic.js
@@ -1,0 +1,90 @@
+function getBundleLogic(data) {
+  const rawPeriod = String(data.periodo || "").toLowerCase();
+  const weekField = data.week || data.semana || "";
+  const isWeeklyBundle =
+    rawPeriod === "weekly" ||
+    data.bundle_type === "weekly" ||
+    weekField !== "";
+
+  let period = NaN;
+  const weekMatch = String(weekField).match(/^W(\d{2})$/i);
+  if (weekMatch) {
+    period = Number(weekMatch[1]);
+  } else if (weekField !== "" && !isNaN(parseInt(weekField))) {
+    period = parseInt(weekField);
+  } else {
+    const parsed = parseInt(data.periodo);
+    period = isNaN(parsed) ? 1 : parsed;
+  }
+  return { isWeeklyBundle, period };
+}
+
+const testCases = [
+  {
+    name: "Legacy Weekly",
+    data: { periodo: "weekly" },
+    expected: { isWeeklyBundle: true, period: 1 }
+  },
+  {
+    name: "Legacy Weekly with numeric periodo",
+    data: { periodo: "weekly", week: "W07" },
+    expected: { isWeeklyBundle: true, period: 7 }
+  },
+  {
+    name: "v5.2 Weekly with Wxx (week field)",
+    data: { week: "W12" },
+    expected: { isWeeklyBundle: true, period: 12 }
+  },
+  {
+    name: "v5.2 Weekly with Wxx (semana field)",
+    data: { semana: "W25" },
+    expected: { isWeeklyBundle: true, period: 25 }
+  },
+  {
+    name: "Numeric week (Dominican Republic style)",
+    data: { semana: 7 },
+    expected: { isWeeklyBundle: true, period: 7 }
+  },
+  {
+    name: "Numeric week string",
+    data: { week: "15" },
+    expected: { isWeeklyBundle: true, period: 15 }
+  },
+  {
+    name: "Bundle type weekly",
+    data: { bundle_type: "weekly", periodo: 3 },
+    expected: { isWeeklyBundle: true, period: 3 }
+  },
+  {
+    name: "Not a weekly bundle (diagnostic or other)",
+    data: { periodo: 1 },
+    expected: { isWeeklyBundle: false, period: 1 }
+  },
+  {
+    name: "Empty data",
+    data: {},
+    expected: { isWeeklyBundle: false, period: 1 }
+  }
+];
+
+let failures = 0;
+testCases.forEach(tc => {
+  const result = getBundleLogic(tc.data);
+  const passed = result.isWeeklyBundle === tc.expected.isWeeklyBundle && result.period === tc.expected.period;
+  if (passed) {
+    console.log(`PASS: ${tc.name}`);
+  } else {
+    console.log(`FAIL: ${tc.name}`);
+    console.log(`  Expected: ${JSON.stringify(tc.expected)}`);
+    console.log(`  Got:      ${JSON.stringify(result)}`);
+    failures++;
+  }
+});
+
+if (failures === 0) {
+  console.log("\nAll tests passed!");
+  process.exit(0);
+} else {
+  console.log(`\n${failures} tests failed.`);
+  process.exit(1);
+}


### PR DESCRIPTION
The static pack generator was missing weekly bundles that used the newer `semana: Wxx` or numeric week formats. I've updated the detection logic to be more robust and added a unit test to verify various frontmatter configurations (legacy, v5.2, and numeric).

Fixes #743

---
*PR created automatically by Jules for task [2975968554913315179](https://jules.google.com/task/2975968554913315179) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced period determination logic for weekly bundle processing with improved week field parsing.

* **Tests**
  * Added test suite to validate weekly bundle metadata handling across various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->