### PR TITLE
English Section Subject/Grade Isolation Fix

### DIFF
--- a/saberparatodos/scripts/generate-static-packs.js
+++ b/saberparatodos/scripts/generate-static-packs.js
@@ -434,6 +434,9 @@ for (const file of allFiles) {
         periodo: period,
         protocol_version: String(protocol),
         cefr_level: data.cefr_level || null,
+        subject: packs[packKey].metadata.subject,
+        grade: packs[packKey].metadata.grade,
+        country: packs[packKey].metadata.country,
       });
     });
   } catch (e) {

--- a/saberparatodos/src/lib/api-service.ts
+++ b/saberparatodos/src/lib/api-service.ts
@@ -36,6 +36,8 @@ export interface APIQuestion {
   context_tags?: string[];
   protocol_version?: string;
   cefr_level?: string;
+  country?: string;
+  subject?: string;
 }
 
 export interface AppQuestion {
@@ -67,6 +69,7 @@ export interface AppQuestion {
   };
   protocol_version?: string;
   cefr_level?: string;
+  country?: string;
   meta?: {
     cefr_level?: string;
     cefrLevel?: string;

--- a/saberparatodos/src/lib/pack-storage.ts
+++ b/saberparatodos/src/lib/pack-storage.ts
@@ -21,6 +21,7 @@ export interface StoredPack {
   packId: string;
   grade: number;
   subject: string;
+  country: string;
   questions: APIQuestion[];
   downloadedAt: number;
   questionCount: number;
@@ -192,7 +193,12 @@ export function getQuestionPool(grade: number): APIQuestion[] {
       // Avoid duplicates (same question might be in multiple packs)
       if (!seenIds.has(question.id)) {
         seenIds.add(question.id);
-        allQuestions.push(question);
+        allQuestions.push({
+          ...question,
+          subject: question.subject || pack.subject,
+          grade: question.grade || pack.grade,
+          country: (question as any).country || pack.country
+        });
       }
     }
   }
@@ -224,7 +230,12 @@ export function getQuestionPoolBySubject(grade: number, subject: string): APIQue
     for (const question of pack.questions) {
       if (!seenIds.has(question.id)) {
         seenIds.add(question.id);
-        allQuestions.push(question);
+        allQuestions.push({
+          ...question,
+          subject: question.subject || pack.subject,
+          grade: question.grade || pack.grade,
+          country: (question as any).country || pack.country
+        });
       }
     }
   }

--- a/saberparatodos/src/lib/question-transformer.ts
+++ b/saberparatodos/src/lib/question-transformer.ts
@@ -198,6 +198,7 @@ export interface AppQuestion {
   };
   protocol_version?: string;
   cefr_level?: string;
+  country?: string;
 }
 
 /**
@@ -266,6 +267,7 @@ export function transformQuestion(apiQuestion: any, grade: number, subject: stri
     period: apiQuestion.period || apiQuestion.periodo || undefined,
     periodo: apiQuestion.periodo || apiQuestion.period || undefined,
     cefr_level: apiQuestion.cefr_level || apiQuestion.target_cefr || undefined,
-    protocol_version: apiQuestion.protocol_version || undefined
+    protocol_version: apiQuestion.protocol_version || undefined,
+    country: apiQuestion.country || undefined
   };
 }

--- a/saberparatodos/src/lib/questions/filters.ts
+++ b/saberparatodos/src/lib/questions/filters.ts
@@ -39,8 +39,18 @@ export function filterByCefrLevel(questions: AppQuestion[], minCefrLevel?: strin
     const qLevel = q.cefr_level || (q.grade ? GRADE_TO_CEFR[q.grade as keyof typeof GRADE_TO_CEFR] : undefined);
     if (!qLevel) return true; // fallback only if absolutely no grade/level is known
     const qIndex = CEFR_ORDER.indexOf(qLevel);
-    // 🆕 Allow +/- one level for "balanced" diagnostic mixes, prevent showing way too hard or too easy questions
-    return qIndex === -1 || Math.abs(qIndex - minIndex) <= 1;
+    if (qIndex === -1) return true;
+
+    // Exact match or higher is always okay for non-balanced scenarios
+    // But for the current logic, we maintain the +/- 1 behavior BUT fix the "below" part
+    // The previous code: Math.abs(qIndex - minIndex) <= 1
+    // This allows minIndex-1, minIndex, minIndex+1.
+    // So if minIndex is B1 (4), it allowed A2+ (3), B1 (4), B1+ (5).
+    // If qIndex was C1 (8), Math.abs(8-4) = 4, so it was filtered out!
+    // That's why C1 was filtered out when B1 was min level.
+
+    // Fixed logic: Allow if it's within +/- 1 OR if it's higher than minIndex
+    return qIndex >= minIndex - 1;
   });
 }
 

--- a/saberparatodos/src/lib/questions/orchestrator.ts
+++ b/saberparatodos/src/lib/questions/orchestrator.ts
@@ -97,9 +97,10 @@ export async function prepareSoloExamQuestions(
   }
 
   let filtered = filterBySubject(pool, request.subject);
+  filtered = filterByGradeAndDiagnostic(filtered, request.grade, Boolean(request.useDiagnostic), Boolean(request.englishDiagnostic));
 
   // 🆕 For English, if current pool has insufficient questions of the selected CEFR level, load multi-grade level-aware pool
-  if (subjectsMatch(request.subject, 'ingles')) {
+  if (subjectsMatch(request.subject, 'ingles') && (request.useDiagnostic || request.englishDiagnostic)) {
     const matchingCount = filterByCefrLevel(filtered, request.minCefrLevel).length;
     if (matchingCount < request.count) {
       const cefrNum = request.minCefrLevel ? CEFR_LEVEL_NUM[request.minCefrLevel] : undefined;


### PR DESCRIPTION
This PR addresses English section subject/grade isolation issues by ensuring that all question objects carry their original subject, grade, and country metadata. It also refines the exam preparation pipeline in the orchestrator to enforce grade isolation for English except when explicitly in diagnostic mode.

Key changes:
1. **Metadata propagation**: Modified `generate-static-packs.js` and `pack-storage.ts` to include and propagate `subject`, `grade`, and `country` metadata inside each question object.
2. **Strict Grade Filtering**: Integrated `filterByGradeAndDiagnostic` into `orchestrator.ts` to ensure that questions are correctly isolated by grade during regular exam runs.
3. **Restricted English Fallback**: The logic that pulls English questions from all grades when the pool is small is now restricted to `useDiagnostic` or `englishDiagnostic` modes.
4. **CEFR Filtering Fix**: Adjusted `filterByCefrLevel` to permit questions that are higher than the requested minimum level, fixing a bug where advanced questions were being filtered out during CEFR-targeted runs.
5. **Interface Consistency**: Updated `APIQuestion` and `AppQuestion` interfaces in `api-service.ts` and `question-transformer.ts` to include the new metadata fields.

Fixes #763

---
*PR created automatically by Jules for task [4758144569600332401](https://jules.google.com/task/4758144569600332401) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Questions now enriched with country metadata for improved categorization and filtering
  * Enhanced question filtering system that considers grade level and diagnostic mode settings
  * Improved English language question selection with better multi-grade support
  
* **Bug Fixes**
  * Fixed CEFR proficiency level filtering to prevent unintended question exclusion at mid-range levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->