### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons for accessibility

### DIFF
--- a/saberparatodos/src/components/LocalReportsView.svelte
+++ b/saberparatodos/src/components/LocalReportsView.svelte
@@ -1761,6 +1761,7 @@
             <span class="text-xs text-white/40 uppercase tracking-widest">Tu prompt personalizado</span>
             <button
               onclick={copyPromptToClipboard}
+              aria-label="Copiar prompt personalizado"
               class="px-3 py-1.5 bg-purple-500/20 hover:bg-purple-500/30 border border-purple-500/30 rounded-lg text-xs text-purple-400 hover:text-purple-300 transition-colors flex items-center gap-1"
             >
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1952,7 +1953,7 @@
         <h3 class="text-lg font-black text-white uppercase tracking-widest flex items-center gap-2">
           <span class="text-emerald-400">📊</span> Entendiendo tu Rating (MMR)
         </h3>
-        <button onclick={() => showHelpModal = false} class="text-white/40 hover:text-white transition-colors">
+        <button onclick={() => showHelpModal = false} aria-label="Cerrar modal" class="text-white/40 hover:text-white transition-colors">
           <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
         </button>
       </div>

--- a/saberparatodos/src/components/ReportModal.svelte
+++ b/saberparatodos/src/components/ReportModal.svelte
@@ -110,7 +110,7 @@
             <span>{questionId ? '🚩 Reportar Problema' : '💬 Enviar Feedback'}</span>
           {/if}
         </h3>
-        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors">
+        <button on:click={onClose} aria-label="Cerrar modal" class="text-white/40 hover:text-white transition-colors">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>


### PR DESCRIPTION
This PR adds missing `aria-label` attributes to various icon-only buttons across Svelte components, specifically `ReportModal.svelte` and `LocalReportsView.svelte`. This micro-UX improvement ensures that screen reader users can understand the purpose of these buttons, fixing a common accessibility issue.

---
*PR created automatically by Jules for task [4299212703813629716](https://jules.google.com/task/4299212703813629716) started by @iberi22*