### PR TITLE
⚡ Bolt: Optimize MathRenderer with module-level KaTeX caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,1 @@
+## 2024-07-22 - [MathRenderer Performance Bottleneck]\n**Learning:** Synchronous KaTeX rendering in Svelte components is a significant bottleneck when rendering lists of questions/options.\n**Action:** Implement module-level caching in MathRenderer.svelte using a bounded Map to share memoized results across all component instances.

--- a/saberparatodos/src/components/MathRenderer.svelte
+++ b/saberparatodos/src/components/MathRenderer.svelte
@@ -1,3 +1,10 @@
+<script context="module" lang="ts">
+  // Bounded cache to avoid memory leaks while speeding up frequent re-renders
+  // especially for lists of options or reused contexts across instances.
+  const MAX_CACHE_SIZE = 500;
+  const renderCache = new Map<string, string>();
+</script>
+
 <script lang="ts">
   import { onMount } from 'svelte';
   import katex from 'katex';
@@ -139,7 +146,24 @@
     return result;
   }
 
-  $: renderedHTML = renderMath(content);
+  $: {
+    if (!content) {
+      renderedHTML = '';
+    } else if (renderCache.has(content)) {
+      renderedHTML = renderCache.get(content)!;
+    } else {
+      const result = renderMath(content);
+      if (renderCache.size >= MAX_CACHE_SIZE) {
+        // Delete oldest entry (Map maintains insertion order)
+        const firstKey = renderCache.keys().next().value;
+        if (firstKey !== undefined) {
+          renderCache.delete(firstKey);
+        }
+      }
+      renderCache.set(content, result);
+      renderedHTML = result;
+    }
+  }
 </script>
 
 <svelte:head>


### PR DESCRIPTION
⚡ Bolt: [Optimize MathRenderer.svelte KaTeX Performance]

**💡 What:** Implemented module-level caching using `<script context="module">` with a bounded `Map` in `saberparatodos/src/components/MathRenderer.svelte`.

**🎯 Why:** KaTeX synchronous rendering is computationally expensive and was executing redundantly on identical strings (e.g., duplicated contexts or options) during list renders. 

**📊 Impact:** Prevents duplicate KaTeX string rendering across all instances of the component simultaneously. Speeds up rendering of question lists containing heavy math notation.

**🔬 Measurement:** Verified functionality by running `pnpm lint` and `pnpm test:unit`, ensuring existing logic is perfectly preserved while sharing memoization cleanly.

---
*PR created automatically by Jules for task [1101104401236677016](https://jules.google.com/task/1101104401236677016) started by @iberi22*