### PR TITLE
⚡ Bolt: Optimize MathRenderer with module-level KaTeX caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-23 - MathRenderer KaTeX Bottleneck
+**Learning:** KaTeX rendering is a synchronous, CPU-heavy operation. In an app rendering hundreds of equations, this severely blocks the main thread.
+**Action:** Use a module-level Svelte cache (`<script context="module">`) with a bounded `Map` to share memoized results across all component instances to significantly reduce duplicate rendering overhead safely.

--- a/saberparatodos/src/components/MathRenderer.svelte
+++ b/saberparatodos/src/components/MathRenderer.svelte
@@ -1,3 +1,10 @@
+<script context="module" lang="ts">
+  // Module-level cache to share memoized results across all component instances.
+  // Limits size to 500 to prevent unbounded memory growth.
+  const renderCache = new Map<string, string>();
+  const MAX_CACHE_SIZE = 500;
+</script>
+
 <script lang="ts">
   import { onMount } from 'svelte';
   import katex from 'katex';
@@ -20,6 +27,10 @@
    */
   function renderMath(text: string): string {
     if (!text) return '';
+
+    if (renderCache.has(text)) {
+      return renderCache.get(text)!;
+    }
 
     // Trim input to remove leading/trailing whitespace/newlines
     let result = text.trim();
@@ -135,6 +146,12 @@
     if (result.endsWith('<br><br>')) {
         result = result.slice(0, -8);
     }
+
+    if (renderCache.size >= MAX_CACHE_SIZE) {
+      const firstKey = renderCache.keys().next().value;
+      if (firstKey !== undefined) renderCache.delete(firstKey);
+    }
+    renderCache.set(text, result);
 
     return result;
   }


### PR DESCRIPTION
💡 What: Added a module-level Map cache to `MathRenderer.svelte` that memoizes the output string of computed KaTeX math blocks and inline formulas.
🎯 Why: KaTeX rendering is a synchronous and extremely CPU-intensive operation. When many instances of the component render identical text across the application, this drastically spikes blocking time.
📊 Impact: Expected to significantly reduce thread-blocking time and drop redundant re-renders of equivalent mathematical formulas by skipping the Katex synchronous pipeline outright. Memory is safely bounded (FIFO at max size of 500).
🔬 Measurement: Verify via DevTools Performance Tab during heavy mathematical formula component load. Time-to-render blocks will disappear from Flame chart after initial render.

---
*PR created automatically by Jules for task [5549098483669119781](https://jules.google.com/task/5549098483669119781) started by @iberi22*