### PR TITLE
🎨 Palette: Add ARIA label to close button in ReportModal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-23 - Added ARIA Label to Report Modal Close Button
+**Learning:** Found a pattern of missing ARIA labels on icon-only close buttons in modal components, which negatively impacts screen reader accessibility.
+**Action:** Ensure all icon-only interactive elements (like SVG buttons) have appropriate `aria-label` attributes.

--- a/saberparatodos/src/components/ReportModal.svelte
+++ b/saberparatodos/src/components/ReportModal.svelte
@@ -110,7 +110,7 @@
             <span>{questionId ? '🚩 Reportar Problema' : '💬 Enviar Feedback'}</span>
           {/if}
         </h3>
-        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors">
+        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors" aria-label="Cerrar">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>


### PR DESCRIPTION
💡 **What**: Added an `aria-label="Cerrar"` to the icon-only close button in `ReportModal.svelte`.
🎯 **Why**: Improves screen reader accessibility, as the button previously lacked semantic text to indicate its purpose.
♿ **Accessibility**: Makes the close action explicit to assistive technologies.

---
*PR created automatically by Jules for task [4699478580948953054](https://jules.google.com/task/4699478580948953054) started by @iberi22*