### PR TITLE
🎨 Palette: Add ARIA labels to close buttons for improved accessibility

### DIFF
--- a/saberparatodos/src/components/LocalReportsView.svelte
+++ b/saberparatodos/src/components/LocalReportsView.svelte
@@ -1952,7 +1952,7 @@
         <h3 class="text-lg font-black text-white uppercase tracking-widest flex items-center gap-2">
           <span class="text-emerald-400">📊</span> Entendiendo tu Rating (MMR)
         </h3>
-        <button onclick={() => showHelpModal = false} class="text-white/40 hover:text-white transition-colors">
+        <button onclick={() => showHelpModal = false} class="text-white/40 hover:text-white transition-colors" aria-label="Cerrar ayuda">
           <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
         </button>
       </div>

--- a/saberparatodos/src/components/OfflineProfile.svelte
+++ b/saberparatodos/src/components/OfflineProfile.svelte
@@ -63,6 +63,7 @@
       <button
         on:click={onClose}
         class="absolute top-4 right-4 p-2 text-white/40 hover:text-white z-10 transition-colors"
+        aria-label="Cerrar perfil offline"
       >
         <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/saberparatodos/src/components/ReportModal.svelte
+++ b/saberparatodos/src/components/ReportModal.svelte
@@ -110,7 +110,7 @@
             <span>{questionId ? '🚩 Reportar Problema' : '💬 Enviar Feedback'}</span>
           {/if}
         </h3>
-        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors">
+        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors" aria-label="Cerrar modal">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>


### PR DESCRIPTION
This pull request addresses accessibility issues on icon-only close buttons. Specifically, it:
- Adds `aria-label="Cerrar modal"` to the close button in `ReportModal.svelte`.
- Adds `aria-label="Cerrar perfil offline"` to the close button in `OfflineProfile.svelte`.
- Adds `aria-label="Cerrar ayuda"` to the close button for the MMR help modal in `LocalReportsView.svelte`.

These changes ensure screen readers can properly announce the purpose of these buttons to users.

---
*PR created automatically by Jules for task [1587785485768202830](https://jules.google.com/task/1587785485768202830) started by @iberi22*