### PR TITLE
⚡ Bolt: Memoize KaTeX rendering in MathRenderer.svelte

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-24 - Module-level Caching for Synchronous Operations in Svelte
+**Learning:** Svelte's `<script context="module">` block provides a convenient mechanism to share state across all instances of a component. This is particularly useful for caching the results of computationally expensive synchronous operations like parsing LaTeX with KaTeX, avoiding redundant processing and main thread blocking.
+**Action:** Use module-level caching with bounded Map size for memoizing deterministic expensive rendering operations in Svelte components.


### PR DESCRIPTION
### 💡 What
Implemented a module-level memoization cache (`renderCache`) in `MathRenderer.svelte` for KaTeX rendering using Svelte's `<script context="module">` feature.

### 🎯 Why
Rendering complex mathematical equations synchronously blocks the main thread. In many educational scenarios, the same context or math blocks appear repeatedly across different questions. Caching these results reduces unnecessary re-computations and speeds up UI updates.

### 📊 Impact
Expected to significantly reduce CPU usage and rendering time for previously-seen LaTeX blocks, preventing main thread stutters when rapidly navigating between identical or similarly structured problems.

### 🔬 Measurement
Load a set of questions with the same shared math-heavy context text. Note the initial render time vs subsequent render times when navigating or scrolling; the latter should hit the cache and process almost instantaneously.

---
*PR created automatically by Jules for task [6495448946226016392](https://jules.google.com/task/6495448946226016392) started by @iberi22*