### PR TITLE
⚡ Bolt: Add module-level KaTeX caching to MathRenderer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-26 - KaTeX Synchronous Rendering Bottlenecks
+**Learning:** Synchronous rendering in Svelte components (like MathRenderer.svelte for KaTeX expressions) can become computationally expensive, particularly when rendering many instances simultaneously.
+**Action:** Utilize module-level caching (`<script context="module">` with a bounded Map) in Svelte components to share memoized text-to-HTML rendering results across all component instances.

--- a/saberparatodos/src/components/MathRenderer.svelte
+++ b/saberparatodos/src/components/MathRenderer.svelte
@@ -1,3 +1,10 @@
+<script context="module" lang="ts">
+  // Module-level cache to memoize expensive text-to-HTML rendering
+  // shared across all instances of MathRenderer
+  const renderCache = new Map<string, string>();
+  const MAX_CACHE_SIZE = 1000;
+</script>
+
 <script lang="ts">
   import { onMount } from 'svelte';
   import katex from 'katex';
@@ -23,6 +30,13 @@
 
     // Trim input to remove leading/trailing whitespace/newlines
     let result = text.trim();
+
+    // Check cache before performing expensive operations
+    if (renderCache.has(result)) {
+      return renderCache.get(result)!;
+    }
+
+    const originalText = result;
 
     // 🎥 Multimedia Parsers (English Protocol v3.0)
     // 1. YouTube: {{youtube:ID}} -> iframe
@@ -135,6 +149,17 @@
     if (result.endsWith('<br><br>')) {
         result = result.slice(0, -8);
     }
+
+    // Cache management: enforce max size to prevent memory leaks
+    if (renderCache.size >= MAX_CACHE_SIZE) {
+      const firstKey = renderCache.keys().next().value;
+      if (firstKey !== undefined) {
+        renderCache.delete(firstKey);
+      }
+    }
+
+    // Store in cache
+    renderCache.set(originalText, result);
 
     return result;
   }


### PR DESCRIPTION
💡 What: Added a module-level `renderCache` (`Map<string, string>`) with a maximum size of 1000 in `MathRenderer.svelte` to memoize the computationally expensive output of `renderMath`.
🎯 Why: Synchronous Svelte rendering using `katex` (and multiple heavy regex replacements) is a significant bottleneck when rendering multiple KaTeX expressions across multiple components simultaneously. By sharing this cache across all component instances via `<script context="module">`, identical strings will only be processed once.
📊 Impact: Significantly reduces UI blocking by avoiding redundant KaTeX layout/rendering, yielding faster response times in exam views.
🔬 Measurement: Verify through rendering multiple identical complex LaTeX string questions; observe reduced time spent in synchronous JavaScript execution compared to no caching.

---
*PR created automatically by Jules for task [14708596115661831877](https://jules.google.com/task/14708596115661831877) started by @iberi22*