### PR TITLE
🎨 Palette: Improve accessibility of ReportModal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-07-26 - Accessible Modals and Close Buttons
+**Learning:** For custom modals built from scratch (without a dialog element), it is critical to explicitly provide `role="dialog"`, `aria-modal="true"`, and an `aria-labelledby` linking to the header ID. Furthermore, icon-only close buttons inside these modals often lack sufficient keyboard visual feedback and accessible names.
+**Action:** Always ensure custom modals in this codebase are annotated with `role="dialog"`, `aria-modal="true"`, and `aria-labelledby`. Always verify icon-only buttons have an `aria-label` and explicit `focus-visible` ring classes.

--- a/saberparatodos/dev_server.log
+++ b/saberparatodos/dev_server.log
@@ -1,178 +1,47 @@
 
-> saberparatodos@0.15.2 dev
-> astro dev --port 4321
+> saberparatodos@0.15.2 dev /app/saberparatodos
+> astro dev --host
 
-(node:82971) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(node:44857) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
 (Use `node --trace-deprecation ...` to show where the warning was created)
-01:29:46 [@astrojs/cloudflare] Enabling compile-time image optimization. Images will be pre-optimized at build time.
-01:29:46 [@astrojs/cloudflare] Enabling sessions with Cloudflare KV with the "SESSION" KV binding.
-1:29:46 AM [vite-plugin-svelte] no Svelte config found at /app/saberparatodos - using default configuration.
-01:29:46 [WARN] [vite] Default inspector port 9229 not available, using 9230 instead
-
+18:47:08 [@astrojs/cloudflare] Enabling compile-time image optimization. Images will be pre-optimized at build time.
+18:47:08 [@astrojs/cloudflare] Enabling sessions with Cloudflare KV with the "SESSION" KV binding.
+6:47:08 PM [vite-plugin-svelte] no Svelte config found at /app/saberparatodos - using default configuration.
 Using secrets defined in .env
-01:29:49 [types] Generated 1ms
-[vite] connected.
-01:29:49 [content] Syncing content
-01:29:49 [content] Synced content
-01:29:50 [vite] Re-optimizing dependencies because vite config has changed
-01:29:50 [vite] Re-optimizing dependencies because vite config has changed
-01:29:50 [vite] Port 4321 is in use, trying another one...
- astro  v6.3.1 ready in 7493 ms
-┃ Local    http://localhost:4322/
-┃ Network  use --host to expose
-01:29:50 watching for file changes...
-9:44 [vite] Forced re-optimization of dependencies
- astro  v6.3.1 ready in 12950 ms
+18:47:09 [vite] connected.
+18:47:11 [types] Generated 1ms
+18:47:12 [content] Syncing content
+18:47:12 [content] Astro config changed
+18:47:12 [content] Clearing content store
+18:47:12 [content] Synced content
+ astro  v7.1.3 ready in 7381 ms
 ┃ Local    http://localhost:4321/
-┃ Network  use --host to expose
-01:29:44 watching for file changes...
-1:31:52 AM [vite-plugin-svelte] src/components/ReportModal.svelte:113:8 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
-https://svelte.dev/e/a11y_consider_explicit_label
-1:31:52 AM [vite-plugin-svelte] src/components/ReportModal.svelte:113:16 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
+┃ Network  http://192.168.0.2:4321/
+18:47:12 watching for file changes...
+6:47:36 PM [vite-plugin-svelte] src/components/ReportModal.svelte:113:16 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
 https://svelte.dev/e/event_directive_deprecated
-1:31:52 AM [vite-plugin-svelte] src/components/ReportModal.svelte:141:12 A form label must be associated with a control
+6:47:36 PM [vite-plugin-svelte] src/components/ReportModal.svelte:141:12 A form label must be associated with a control
 https://svelte.dev/e/a11y_label_has_associated_control
-1:31:52 AM [vite-plugin-svelte] src/components/ReportModal.svelte:151:20 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
+6:47:36 PM [vite-plugin-svelte] src/components/ReportModal.svelte:151:20 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
 https://svelte.dev/e/event_directive_deprecated
-1:31:52 AM [vite-plugin-svelte] src/components/ReportModal.svelte:162:12 A form label must be associated with a control
+6:47:36 PM [vite-plugin-svelte] src/components/ReportModal.svelte:162:12 A form label must be associated with a control
 https://svelte.dev/e/a11y_label_has_associated_control
-1:31:52 AM [vite-plugin-svelte] src/components/ReportModal.svelte:196:14 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
+6:47:36 PM [vite-plugin-svelte] src/components/ReportModal.svelte:196:14 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
 https://svelte.dev/e/event_directive_deprecated
-1:31:52 AM [vite-plugin-svelte] src/components/ReportModal.svelte:202:14 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
+6:47:36 PM [vite-plugin-svelte] src/components/ReportModal.svelte:202:14 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
 https://svelte.dev/e/event_directive_deprecated
-1:31:55 AM [vite-plugin-svelte] src/components/App.svelte:69:31 This reference only captures the initial value of `questions`. Did you mean to reference it inside a derived instead?
+6:47:38 PM [vite-plugin-svelte] src/components/VersionBadge.svelte:18:26 This reference only captures the initial value of `showOnlyOnUpdate`. Did you mean to reference it inside a derived instead?
 https://svelte.dev/e/state_referenced_locally
-1:31:55 AM [vite-plugin-svelte] src/components/App.svelte:118:43 This reference only captures the initial value of `countryCode`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:55 AM [vite-plugin-svelte] src/components/VersionBadge.svelte:18:26 This reference only captures the initial value of `showOnlyOnUpdate`. Did you mean to reference it inside a derived instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:55 AM [vite-plugin-svelte] src/components/IdentityRegistration.svelte:104:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:55 AM [vite-plugin-svelte] src/components/IdentityRegistration.svelte:120:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:55 AM [vite-plugin-svelte] src/components/IdentityRegistration.svelte:139:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:55 AM [vite-plugin-svelte] src/components/IdentityRegistration.svelte:155:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:55 AM [vite-plugin-svelte] src/components/IdentityRegistration.svelte:18:13 Component has unused export property 'onCancel'. If it is for external reference only, please consider using `export const onCancel`
-https://svelte.dev/e/export_let_unused
-1:31:56 AM [vite-plugin-svelte] src/components/FlashlightCard.svelte:81:2 Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
-https://svelte.dev/e/element_invalid_self_closing_tag
-1:31:56 AM [vite-plugin-svelte] src/components/AdvancedSearch.svelte:200:4 Elements with the 'dialog' interactive role must have a tabindex value
-https://svelte.dev/e/a11y_interactive_supports_focus
-1:31:56 AM [vite-plugin-svelte] src/components/AdvancedSearch.svelte:200:4 Visible, non-interactive elements with a click event must be accompanied by a keyboard event handler. Consider whether an interactive element such as `<button type="button">` or `<a>` might be more appropriate
-https://svelte.dev/e/a11y_click_events_have_key_events
-1:31:56 AM [vite-plugin-svelte] src/components/AdvancedSearch.svelte:259:16 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/AdvancedSearch.svelte:273:16 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/AdvancedSearch.svelte:287:16 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/AdvancedSearch.svelte:301:16 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/LocalReportsView.svelte:55:45 This reference only captures the initial value of `runtimeCountry`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:56 AM [vite-plugin-svelte] src/components/LocalReportsView.svelte:55:66 This reference only captures the initial value of `runtimeCountry`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:56 AM [vite-plugin-svelte] src/components/LocalReportsView.svelte:582:24 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
-https://svelte.dev/e/a11y_consider_explicit_label
-1:31:56 AM [vite-plugin-svelte] src/components/LocalReportsView.svelte:1391:4 `<div>` with a click handler must have an ARIA role
-https://svelte.dev/e/a11y_no_static_element_interactions
-1:31:56 AM [vite-plugin-svelte] src/components/LocalReportsView.svelte:1554:4 `<div>` with a click handler must have an ARIA role
-https://svelte.dev/e/a11y_no_static_element_interactions
-1:31:56 AM [vite-plugin-svelte] src/components/LocalReportsView.svelte:1719:4 `<div>` with a click handler must have an ARIA role
-https://svelte.dev/e/a11y_no_static_element_interactions
-1:31:56 AM [vite-plugin-svelte] src/components/LocalReportsView.svelte:1955:8 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
-https://svelte.dev/e/a11y_consider_explicit_label
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:48:43 This reference only captures the initial value of `countryCode`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:51:31 This reference only captures the initial value of `initialSubject`. Did you mean to reference it inside a derived instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:52:29 This reference only captures the initial value of `initialGrade`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:123:34 This reference only captures the initial value of `isEnglishRelated`. Did you mean to reference it inside a derived instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:1285:14 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:1301:16 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:1332:16 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:1459:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:1480:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:1527:10 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
-https://svelte.dev/e/a11y_consider_explicit_label
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:1795:14 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
-https://svelte.dev/e/a11y_consider_explicit_label
-1:31:56 AM [vite-plugin-svelte] src/components/ExamConfigModal.svelte:1844:16 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/BlogView.svelte:360:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/BlogView.svelte:395:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:56 AM [vite-plugin-svelte] src/components/BlogView.svelte:418:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:57 AM [vite-plugin-svelte] src/components/OfflineProfile.svelte:63:6 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
-https://svelte.dev/e/a11y_consider_explicit_label
-1:31:57 AM [vite-plugin-svelte] src/modules/exam-room/components/SpeedChallengeSetup.svelte:60:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:57 AM [vite-plugin-svelte] src/modules/exam-room/components/SpeedChallengeSetup.svelte:71:8 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:57 AM [vite-plugin-svelte] src/modules/exam-room/components/SpeedChallengeSetup.svelte:83:12 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:57 AM [vite-plugin-svelte] src/modules/exam-room/components/SpeedChallengeSetup.svelte:98:12 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:57 AM [vite-plugin-svelte] src/modules/exam-room/components/SpeedChallengeSetup.svelte:127:8 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
-https://svelte.dev/e/a11y_consider_explicit_label
-1:31:57 AM [vite-plugin-svelte] src/modules/exam-room/components/LobbyBrowser.svelte:212:16 Avoid using autofocus
-https://svelte.dev/e/a11y_autofocus
-1:31:57 AM [vite-plugin-svelte] src/components/PeriodTracker.svelte:13:7 This reference only captures the initial value of `runtimeCountry`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:57 AM [vite-plugin-svelte] src/components/PeriodTracker.svelte:17:20 This reference only captures the initial value of `runtimeCountry`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:57 AM [vite-plugin-svelte] src/components/PeriodTrackerModal.svelte:6:20 This reference only captures the initial value of `runtimeCountry`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:57 AM [vite-plugin-svelte] src/components/ReportModal.svelte:113:8 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
-https://svelte.dev/e/a11y_consider_explicit_label
-1:31:57 AM [vite-plugin-svelte] src/components/ReportModal.svelte:113:16 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
+6:47:38 PM [vite-plugin-svelte] src/components/ReportModal.svelte:113:16 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
 https://svelte.dev/e/event_directive_deprecated
-1:31:57 AM [vite-plugin-svelte] src/components/ReportModal.svelte:141:12 A form label must be associated with a control
+6:47:38 PM [vite-plugin-svelte] src/components/ReportModal.svelte:141:12 A form label must be associated with a control
 https://svelte.dev/e/a11y_label_has_associated_control
-1:31:57 AM [vite-plugin-svelte] src/components/ReportModal.svelte:151:20 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
+6:47:38 PM [vite-plugin-svelte] src/components/ReportModal.svelte:151:20 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
 https://svelte.dev/e/event_directive_deprecated
-1:31:57 AM [vite-plugin-svelte] src/components/ReportModal.svelte:162:12 A form label must be associated with a control
+6:47:38 PM [vite-plugin-svelte] src/components/ReportModal.svelte:162:12 A form label must be associated with a control
 https://svelte.dev/e/a11y_label_has_associated_control
-1:31:57 AM [vite-plugin-svelte] src/components/ReportModal.svelte:196:14 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
+6:47:38 PM [vite-plugin-svelte] src/components/ReportModal.svelte:196:14 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
 https://svelte.dev/e/event_directive_deprecated
-1:31:57 AM [vite-plugin-svelte] src/components/ReportModal.svelte:202:14 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
+6:47:38 PM [vite-plugin-svelte] src/components/ReportModal.svelte:202:14 Using `on:click` to listen to the click event is deprecated. Use the event attribute `onclick` instead
 https://svelte.dev/e/event_directive_deprecated
-1:31:57 AM [vite-plugin-svelte] src/components/CommentsSection.svelte:31:29 This reference only captures the initial value of `questionId`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-1:31:57 AM [vite-plugin-svelte] src/components/QuestionFeedback.svelte:166:2 Visible, non-interactive elements with a click event must be accompanied by a keyboard event handler. Consider whether an interactive element such as `<button type="button">` or `<a>` might be more appropriate
-https://svelte.dev/e/a11y_click_events_have_key_events
-1:31:57 AM [vite-plugin-svelte] src/components/QuestionFeedback.svelte:166:2 `<div>` with a click handler must have an ARIA role
-https://svelte.dev/e/a11y_no_static_element_interactions
-1:31:57 AM [vite-plugin-svelte] src/components/QuestionFeedback.svelte:181:10 Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
-https://svelte.dev/e/a11y_consider_explicit_label
-1:31:57 AM [vite-plugin-svelte] src/components/QuestionFeedback.svelte:227:14 A form label must be associated with a control
-https://svelte.dev/e/a11y_label_has_associated_control
-1:31:57 AM [vite-plugin-svelte] src/components/ScoreDisplay.svelte:273:2 Elements with the 'dialog' interactive role must have a tabindex value
-https://svelte.dev/e/a11y_interactive_supports_focus
-1:31:57 AM [vite-plugin-svelte] src/components/ScoreDisplay.svelte:273:2 Visible, non-interactive elements with a click event must be accompanied by a keyboard event handler. Consider whether an interactive element such as `<button type="button">` or `<a>` might be more appropriate
-https://svelte.dev/e/a11y_click_events_have_key_events
-01:37:27 [vite] [vite] program reload
-1:41:53 AM [vite-plugin-svelte] src/components/App.svelte:69:31 This reference only captures the initial value of `questions`. Did you mean to reference it inside a derived instead?
-https://svelte.dev/e/state_referenced_locally
-1:41:53 AM [vite-plugin-svelte] src/components/App.svelte:118:43 This reference only captures the initial value of `countryCode`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-01:41:53 [watch] /src/styles/global.css
-01:41:53 [watch] /app/saberparatodos/src/components/App.svelte, /src/styles/global.css
-01:42:35 [vite] [vite] program reload
-1:43:09 AM [vite-plugin-svelte] src/components/App.svelte:69:31 This reference only captures the initial value of `questions`. Did you mean to reference it inside a derived instead?
-https://svelte.dev/e/state_referenced_locally
-1:43:09 AM [vite-plugin-svelte] src/components/App.svelte:118:43 This reference only captures the initial value of `countryCode`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-01:45:43 [vite] [vite] program reload
-01:46:27 [vite] [vite] program reload
+18:49:36 [vite] [vite] program reload

--- a/saberparatodos/src/components/ReportModal.svelte
+++ b/saberparatodos/src/components/ReportModal.svelte
@@ -94,14 +94,14 @@
 </script>
 
 {#if show}
-  <div class="fixed inset-0 z-[1001] flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm" transition:fade>
+  <div class="fixed inset-0 z-[1001] flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm" transition:fade role="dialog" aria-modal="true" aria-labelledby="report-modal-title">
     <div
       class="bg-[#121212] border border-white/10 rounded-2xl w-full max-w-md overflow-hidden relative shadow-2xl"
       transition:scale={{start: 0.95}}
     >
       <!-- Header -->
       <div class="px-6 py-4 border-b border-white/5 bg-gradient-to-r from-white/5 to-transparent flex justify-between items-center">
-        <h3 class="text-white font-bold text-center flex items-center justify-center gap-2">
+        <h3 id="report-modal-title" class="text-white font-bold text-center flex items-center justify-center gap-2">
           {#if success}
             <span class="text-emerald-400">✅ Enviado</span>
           {:else if userContext === 'MenGuidelinesContent'}
@@ -110,7 +110,7 @@
             <span>{questionId ? '🚩 Reportar Problema' : '💬 Enviar Feedback'}</span>
           {/if}
         </h3>
-        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors">
+        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors rounded focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-emerald-500" aria-label="Cerrar modal">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>


### PR DESCRIPTION
🎨 Palette: ReportModal Accessibility Enhancements

💡 What: Added necessary ARIA attributes to the `ReportModal.svelte` container to identify it as a dialog to screen readers, and added an `aria-label` and `focus-visible` ring to the close button.
🎯 Why: Without these attributes, screen reader users might not know they are in a modal dialog or what its purpose is. Additionally, the icon-only close button lacked an accessible name and clear visual focus for keyboard users.
♿ Accessibility: Improves screen reader and keyboard navigation experiences within the feedback/report modal.

---
*PR created automatically by Jules for task [15763642291921910054](https://jules.google.com/task/15763642291921910054) started by @iberi22*