### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix KaTeX XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-07-27 - [Fix KaTeX XSS Vulnerability]
+**Vulnerability:** KaTeX configuration was set to `trust: true`, allowing potentially malicious LaTeX commands to render raw HTML/execute JS (XSS vulnerability).
+**Learning:** In Svelte components rendering LaTeX via KaTeX, using `trust: true` alongside `{@html ...}` bindings opens a direct XSS vector because KaTeX will trust arbitrary user-provided HTML commands in the LaTeX string, and Svelte will render it unescaped.
+**Prevention:** Always set `trust: false` (the default) in KaTeX configurations when dealing with user-generated or external content. Avoid DOM sanitization libraries (like `isomorphic-dompurify`) to clean KaTeX output unless absolutely necessary, as it can break complex SVG/MathML outputs and add bundle bloat; KaTeX is designed to be secure with `trust: false`.

--- a/saberparatodos/src/components/MathRenderer.svelte
+++ b/saberparatodos/src/components/MathRenderer.svelte
@@ -45,7 +45,7 @@
           throwOnError: false,
           errorColor: '#ef4444',
           strict: false,
-          trust: true
+          trust: false
         });
       } catch (e) {
         console.warn('KaTeX block error:', e);
@@ -70,7 +70,7 @@
           throwOnError: false,
           errorColor: '#ef4444',
           strict: false,
-          trust: true
+          trust: false
         });
         return rendered + suffix;
       } catch (e) {


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix KaTeX XSS vulnerability

🚨 Severity: CRITICAL
💡 Vulnerability: KaTeX configuration was set to `trust: true`, allowing potentially malicious LaTeX commands to render raw HTML or execute JS, leading to XSS vulnerabilities.
🎯 Impact: Attackers could inject malicious LaTeX commands that result in unauthorized code execution in the browser context of the victim.
🔧 Fix: Set KaTeX configuration `trust: false` for both block and inline math rendering in MathRenderer.svelte.
✅ Verification: Review the changes in `MathRenderer.svelte` to confirm `trust` is now `false`.

Added a sentinel journal entry logging the learning.

---
*PR created automatically by Jules for task [18272798841778852020](https://jules.google.com/task/18272798841778852020) started by @iberi22*