### PR TITLE
⚡ Bolt: Memoize KaTeX rendering to reduce main thread blocking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-28 - Memoization for synchronous KaTeX rendering in Svelte
+**Learning:** KaTeX rendering is a synchronous and CPU-intensive operation that can block the main thread if repeated frequently. In a Svelte app, rendering math equations across multiple instances of a component like `MathRenderer.svelte` can cause severe performance bottlenecks, especially if equations are re-rendered during list updates or navigation.
+**Action:** When performing heavy synchronous work inside a component's render flow (like Markdown/LaTeX parsing), utilize Svelte's `<script context="module">` to create a bounded module-level cache (e.g. Map). This shares the memoized results across all component instances rather than recalculating them per-instance.

--- a/saberparatodos/src/components/MathRenderer.svelte
+++ b/saberparatodos/src/components/MathRenderer.svelte
@@ -1,3 +1,10 @@
+<script context="module" lang="ts">
+  // Module-level cache to share rendered math across all instances of MathRenderer
+  // Bounded Map to prevent memory leaks while optimizing synchronous rendering
+  const MAX_CACHE_SIZE = 500;
+  const renderCache = new Map<string, string>();
+</script>
+
 <script lang="ts">
   import { onMount } from 'svelte';
   import katex from 'katex';
@@ -20,6 +27,11 @@
    */
   function renderMath(text: string): string {
     if (!text) return '';
+
+    // Check cache first to avoid expensive redundant synchronous rendering
+    if (renderCache.has(text)) {
+      return renderCache.get(text)!;
+    }
 
     // Trim input to remove leading/trailing whitespace/newlines
     let result = text.trim();
@@ -135,6 +147,16 @@
     if (result.endsWith('<br><br>')) {
         result = result.slice(0, -8);
     }
+
+    // Manage cache size and save result
+    if (renderCache.size >= MAX_CACHE_SIZE) {
+      // Remove the oldest inserted item to keep within bounds
+      const firstKey = renderCache.keys().next().value;
+      if (firstKey !== undefined) {
+        renderCache.delete(firstKey);
+      }
+    }
+    renderCache.set(text, result);
 
     return result;
   }


### PR DESCRIPTION
**💡 What:** Added a module-level Map cache to `MathRenderer.svelte` to memoize the rendered HTML output of KaTeX expressions.
**🎯 Why:** Synchronous KaTeX rendering and complex regex execution can heavily block the main thread, especially when components like `MathRenderer.svelte` are instantiated multiple times (e.g. in list views) or updated frequently.
**📊 Impact:** Eliminates redundant synchronous computation for previously seen equations across all component instances, reducing main thread CPU time and preventing UI unresponsiveness.
**🔬 Measurement:** View complex math equations, navigate away, and navigate back. Re-rendering will hit the in-memory cache and render instantly. Tests remain passing.

---
*PR created automatically by Jules for task [7869236950367876414](https://jules.google.com/task/7869236950367876414) started by @iberi22*