### PR TITLE
🎨 Palette: [a11y] Add aria-label to ReportModal close button

### DIFF
--- a/saberparatodos/src/components/ReportModal.svelte
+++ b/saberparatodos/src/components/ReportModal.svelte
@@ -110,7 +110,7 @@
             <span>{questionId ? '🚩 Reportar Problema' : '💬 Enviar Feedback'}</span>
           {/if}
         </h3>
-        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors">
+        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors" aria-label="Cerrar modal de reporte">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>


### PR DESCRIPTION
💡 What: Added an `aria-label="Cerrar modal de reporte"` to the icon-only close button in `ReportModal.svelte`.
🎯 Why: Icon-only buttons without an accessible name are not navigable by screen readers. Adding an `aria-label` solves this accessibility issue.
♿ Accessibility: Improved screen reader navigation for the report modal close button.

---
*PR created automatically by Jules for task [16086496918786591176](https://jules.google.com/task/16086496918786591176) started by @iberi22*