### PR TITLE
fix(content): enforce EJE axis for non-Colombia bundles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,18 @@
 # AGENTS.md - WorldExams / SaberParaTodos
 
+## SWAL ecosystem (WorldExams como nodo activo)
+
+- **Canonical:** `docs/SWAL/GOAL.md` · `docs/SWAL/PROJECT_MAP.md`
+- **Pro:** Nodo SWAL activo — sin Stripe ni suscripciones externas
+- **Memoria:** Xavier HTTP/MCP · namespaces `app/worldexams/instance/{instanceId}`
+- **Mesh:** edge-mesh · `swal/worldexams/{instanceId}`
+- **Token:** $SWAL ownership + stake yield
+- **Protocolo:** GitCore 3.8+ · feature-verify / implementation-score
+- **Generación de contenido:** Jules (label `jules` en issues)
+- **Integración:** Pipeline cíclico automático cada 30 min
+
+---
+
 Este archivo es leido por Jules para generar y validar bundles. La fuente de verdad actual es el protocolo semanal v5.2.
 
 ## Project Overview
@@ -91,7 +104,6 @@ No usar `semana` como reemplazo de `week`. No usar `Context`, `Options` ni encab
 **ICFES:** Numerico
 **Expected_Success:** 0.90
 **Contexto:** Escenario local, util para resolver o interpretar la pregunta.
-
 ### Enunciado
 Texto de la pregunta.
 
@@ -112,6 +124,7 @@ Explicacion completa del concepto evaluado.
 Reglas:
 - Usar `## Question N [D#]`, no `## Pregunta`.
 - Usar `### Enunciado`, `### Opciones`, `### Explicacion Pedagogica`.
+- Eje evaluado por pais: `**ICFES:**` es EXCLUSIVO de Colombia. Todos los demas paises usan `**EJE:**` (eje/componente evaluado). La entidad de cada pais (PAES, EXANI, ENEM, CNEB, Aprender...) va solo en el frontmatter `alignment`, nunca como marca dentro de las preguntas.
 - Exactamente 4 opciones A-D.
 - Exactamente una opcion con `[x]`.
 - Todas las opciones tienen feedback HTML en la linea siguiente o inmediata.
@@ -201,6 +214,12 @@ curl "https://api.saberparatodos.space/v1/questions?country=mx&grade=11&subject=
 
 El API debe preferir packs con prefijo de pais (`co-`, `mx-`, `ar-`, `br-`) antes de usar packs genericos.
 
+## AI Core on-device (SWAL)
+
+- Runtime generico: `edge-mesh` → `createAiCore({ mesh, instanceId })` (ver `docs/SWAL/AI_CORE.md`).
+- UI PWA: `/ajustes/ia` · tutor en Results · generacion local no publica a `questions_data/`.
+- Smoke: `cd saberparatodos && npm run smoke:ai`
+
 ## Country Readiness KPI
 
 La meta operativa para pruebas finales es 2000 preguntas por pais soportado.
@@ -238,3 +257,14 @@ Estados del reporte:
 8. No afirmar que el contenido esta publicado hasta que se generen/verifiquen los static packs.
 9. Ejecutar `npm run audit:country-readiness` cuando el issue afecte cobertura por pais.
 10. Comentar el issue con: `[OK] Generados N bundles: ID1, ID2, ...`.
+
+---
+
+## 🧹 POLÍTICA DE LIMPIEZA
+
+El proyecto se mantiene limpio mediante:
+1. **Branches:** Solo `main` y `develop` — branches de features se borran post-merge
+2. **Scripts:** Solo `.mjs`, `.sh`, `.ts` — nada de `.ps1` (migrado a Linux)
+3. **Temp:** `temp/`, `temp_*`, `*.log` están en `.gitignore` — no se commitean
+4. **Issues:** Issues de Jules se cierran al completar el feature
+5. **Documentación:** SRS, SRC, features.json siempre sincronizados

--- a/docs/specs/CONTENT_ERRORS.md
+++ b/docs/specs/CONTENT_ERRORS.md
@@ -1,0 +1,68 @@
+# Catálogo de errores de contenido — purga 2026-07-28
+
+> Documento de aprendizaje post-purga. Cada clase de error incluye causa raíz, detección
+> automatizada actual y regla de prevención para Jules/generadores.
+> Resultado de la purga: 5306 bundles `.md` eliminados, 5601 packs huérfanos eliminados,
+> corpus final **958/958 válido** (`npm run validate`).
+
+## E1 — Marca de examen de otro país (ICFES/Saber/DBA fuera de Colombia)
+
+- **Síntoma:** `**ICFES:**` por pregunta en bundles CL/PE/MX/BR/…; `alignment: "ICFES Saber 11 2026 + DBA MEN 2026"` en archivos de Chile/Argentina/Ecuador.
+- **Causa raíz:** plantilla v5.2 nacida en Colombia; el validador exigía `**ICFES:**` para todos los países.
+- **Fix aplicado:** `**ICFES:**` exclusivo de Colombia; todos los demás países usan `**EJE:**`. Validadores country-aware con guarda anti-regresión (rechazan ICFES fuera de CO y en `alignment`).
+- **Prevención:** la entidad de cada país (PAES, EXANI, ENEM, CNEB, Aprender, MINERD, ANEP…) va SOLO en `alignment`. Ver tabla en `_TEMPLATE.md`.
+
+## E2 — Placeholders / dummies
+
+- **Síntoma:** opciones literales "Distractor 1/2/3", "Opcion correcta", "Opcion B"; temas genéricos "tema-semana-NN-de-{materia}".
+- **Causa raíz:** generadores masivos con plantillas sin contenido real (156 bundles CR, cientos CO).
+- **Detección:** `validate-bundles-v52.mjs` rechaza esos literales; el generador de packs los salta.
+- **Prevención:** todo distractor debe ser un error conceptual plausible del currículo del país; prohibido texto de plantilla.
+
+## E3 — Ruta no canónica
+
+- **Síntoma:** bundles en `costarica/` (vs `costa-rica`), `uy/` `py/` `bo/` `es/` `pr/` `gq/` `do/` `gt/` (códigos en vez de nombre), `{pais}/grado-11/weekly/` (sin materia ni año), `3o-EM/` (vs `3o-ano/`), carpetas `periodo-1/…/`.
+- **Causa raíz:** pipelines antiguos anteriores a la ruta canónica v5.2.
+- **Fix aplicado:** migración de 1205 semanales rescatables a `questions_data/{pais}/{materia}/grado-{N}/2026/weekly/` con frontmatter normalizado; el resto eliminado.
+- **Prevención:** el validador exige la ruta canónica exacta; Jules solo escribe en la ruta del issue.
+
+## E4 — Frontmatter no canónico
+
+- **Síntoma:** `semana: 1` en vez de `week: "W01"`, `country: "uy"` (código en vez de nombre), campos extra (`exam:`), faltantes (`periodo`, `bundle_type`, `total_questions`, `license`, `tier`, `creador`), `id` sin sufijo `-bundle`.
+- **Fix aplicado:** normalización en la migración; validador exige los 15 campos exactos.
+- **Prevención:** copiar el frontmatter exacto de `AGENTS.md`; `semana` está prohibido.
+
+## E5 — Formato de pregunta legacy
+
+- **Síntoma:** `## Pregunta N` (en vez de `## Question N [D#]`), sin `**EJE:**`/`**Expected_Success:**`, sin `### Explicacion Pedagogica`, opciones sin feedback.
+- **Causa raíz:** protocolo anterior a v5.2 (UY/PY/BO: 481 bundles irrecuperables, eliminados).
+- **Prevención:** formato exacto de `AGENTS.md` § Question Format; validación obligatoria antes de PR.
+
+## E6 — Opciones duplicadas
+
+- **Síntoma:** mismo texto en 2+ opciones de la misma pregunta (SV lengua/matematicas: 105 bundles eliminados).
+- **Detección:** validador (`duplicate option text`).
+- **Prevención:** revisar unicidad de distractores antes de guardar.
+
+## E7 — Fuentes fuera de formato canónico
+
+- **Síntoma:** bundles fuente en JSON (`elsalvador/**/SV-*.json`) en vez de markdown.
+- **Fix aplicado:** conversión determinista JSON→md (200 archivos; 95 válidos tras filtrar E6, =1900 preguntas SV).
+- **Prevención:** la fuente de verdad es SIEMPRE `.md` en `questions_data/`; los JSON del API son artefactos derivados.
+
+## E8 — Carpetas junk / países no soportados
+
+- **Eliminadas:** `australia/`, `gb/`, `india/`, `newzealand/`, `southafrica/`, `usa/`, `ingles/` (stray CO), `test_weekly_validation/`.
+- **Prevención:** solo los 20 países de `AGENTS.md` § Supported Countries.
+
+## E9 — Packs huérfanos
+
+- **Síntoma:** packs JSON cuyos `bundle_id` ya no existen en fuentes (5601 tras la purga).
+- **Fix aplicado:** script de limpieza cruzada pack↔fuente; regeneración completa.
+- **Prevención:** tras borrar bundles, SIEMPRE regenerar packs (`node scripts/generate-static-packs.js --all-weekly`) y correr `npm run audit:country-readiness`.
+
+## Estado final (2026-07-28)
+
+- `npm run validate`: **958 archivos, 0 fallos**.
+- 17/20 países `published_validated`; **CO (224%) y SV (110%) listos**; PE 76%, CL 69%, ES 60%, EC 50%.
+- UY/PY/BO en `missing` → regeneración vía issues Jules.

--- a/scripts/audit-country-readiness.mjs
+++ b/scripts/audit-country-readiness.mjs
@@ -15,7 +15,7 @@ const COUNTRIES = [
   { code: 'PE', folder: 'peru', name: 'Peru' },
   { code: 'EC', folder: 'ecuador', name: 'Ecuador' },
   { code: 'PA', folder: 'panama', name: 'Panama' },
-  { code: 'CR', folder: 'costa-rica', name: 'Costa Rica' },
+  { code: 'CR', folder: 'costarica', name: 'Costa Rica' },
   { code: 'GT', folder: 'guatemala', name: 'Guatemala' },
   { code: 'DO', folder: 'dominican_republic', name: 'Republica Dominicana' },
   { code: 'SV', folder: 'el-salvador', name: 'El Salvador' },
@@ -251,14 +251,25 @@ function validateStrictBundle(file) {
   const questions = questionBlocks(content);
   if (expected && questions.length !== expected) errors.push(`Expected ${expected} questions, found ${questions.length}`);
 
-  questions.forEach((question, index) => {
+    const isCO = country?.code === 'CO';
+    if (!isCO && /icfes|saber\s?11|dba men/i.test(String(fm.alignment || ''))) {
+      errors.push('alignment must reference the country exam entity, not ICFES/Saber/DBA (Colombia-only brands)');
+    }
+
+    questions.forEach((question, index) => {
     const prefix = `Question ${index + 1}`;
     if (question.label !== 'Question') errors.push(`${prefix}: heading must use "Question"`);
     if (question.number !== index + 1) errors.push(`${prefix}: question numbering is not sequential`);
     if (!/^D\d+(?:-D?\d+)?$/.test(question.difficulty)) errors.push(`${prefix}: invalid difficulty label`);
     if (!/\*\*ID:\*\*\s*\S/.test(question.text)) errors.push(`${prefix}: missing ID`);
     if (!/\*\*Bloom:\*\*\s*(Remember|Understand|Apply|Analyze|Evaluate)/.test(question.text)) errors.push(`${prefix}: invalid Bloom`);
-    if (!/\*\*ICFES:\*\*\s*\S/.test(question.text)) errors.push(`${prefix}: missing ICFES/eje field`);
+    if (isCO) {
+      if (!/\*\*ICFES:\*\*\s*\S/.test(question.text)) errors.push(`${prefix}: missing ICFES field (Colombia exam axis)`);
+      if (/\*\*EJE:\*\*/.test(question.text)) errors.push(`${prefix}: use ICFES, not EJE, for Colombia`);
+    } else {
+      if (/\*\*ICFES:\*\*/.test(question.text)) errors.push(`${prefix}: ICFES is a Colombia-only brand; use **EJE:**`);
+      if (!/\*\*EJE:\*\*\s*\S/.test(question.text)) errors.push(`${prefix}: missing EJE field (exam axis)`);
+    }
     if (!/\*\*Expected_Success:\*\*\s*0\.\d+/.test(question.text)) errors.push(`${prefix}: missing Expected_Success`);
     if (!/\*\*Contexto:\*\*\s*\S/.test(question.text)) errors.push(`${prefix}: missing Contexto`);
     if (/\*\*Context:\*\*/.test(question.text)) errors.push(`${prefix}: use Contexto, not Context`);

--- a/scripts/generate-jules-issue-matrix.mjs
+++ b/scripts/generate-jules-issue-matrix.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * generate-jules-issue-matrix.mjs
+ * Builds atomic Jules issue markdown (≤15 bundles) with skill links + agent-state.
+ *
+ * Usage:
+ *   node scripts/generate-jules-issue-matrix.mjs --country PE --grade 11 --subject matematicas --from 1 --to 10
+ *   node scripts/generate-jules-issue-matrix.mjs --country CL --grade 11 --subject lenguaje --from 1 --to 10 --write
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const COUNTRY_META = {
+  PE: { name: 'Peru', folder: 'peru', subjCode: { matematicas: 'MAT', comunicacion: 'COM', ciencia: 'CIE', sociales: 'SOC', ingles: 'ING' } },
+  CL: { name: 'Chile', folder: 'chile', subjCode: { matematicas: 'MAT', lenguaje: 'LEN', 'ciencias-naturales': 'CIE', historia: 'HIS', ingles: 'ING' } },
+  MX: { name: 'Mexico', folder: 'mexico', subjCode: { matematicas: 'MAT', lengua: 'LEN', 'lectura-critica': 'LC', 'ciencias-naturales': 'CIE', 'sociales-ciudadanas': 'SOC', ingles: 'ING' } },
+  AR: { name: 'Argentina', folder: 'argentina', subjCode: { matematicas: 'MAT', lengua: 'LEN', ciencias: 'CIE', sociales: 'SOC', ingles: 'ING' } },
+  EC: { name: 'Ecuador', folder: 'ecuador', subjCode: { matematicas: 'MAT', lengua: 'LEN', ciencias: 'CIE', sociales: 'SOC', ingles: 'ING' } },
+  BR: { name: 'Brasil', folder: 'brasil', subjCode: { matematica: 'MAT', portugues: 'POR' } },
+  CO: { name: 'Colombia', folder: 'colombia', subjCode: { matematicas: 'MAT', 'lectura-critica': 'LC', 'ciencias-naturales': 'CN', 'sociales-ciudadanas': 'SOC', ingles: 'ING', lengua: 'LEN' } },
+  UY: { name: 'Uruguay', folder: 'uruguay', subjCode: { matematicas: 'MAT', lengua: 'LEN', 'ciencias-naturales': 'CIE', sociales: 'SOC', ingles: 'ING' } },
+  PY: { name: 'Paraguay', folder: 'paraguay', subjCode: { matematicas: 'MAT', lengua: 'LEN', 'ciencias-naturales': 'CIE', sociales: 'SOC', ingles: 'ING' } },
+  SV: { name: 'El Salvador', folder: 'el-salvador', subjCode: { matematicas: 'MAT', lengua: 'LEN', 'ciencias-naturales': 'CIE', sociales: 'SOC', ingles: 'ING' } },
+  PR: { name: 'Puerto Rico', folder: 'puerto-rico', subjCode: { matematicas: 'MAT', espanol: 'ESP', ciencias: 'CIE', sociales: 'SOC', ingles: 'ING' } },
+  BO: { name: 'Bolivia', folder: 'bolivia', subjCode: { matematicas: 'MAT', lengua: 'LEN', 'ciencias-naturales': 'CIE', sociales: 'SOC', ingles: 'ING' } },
+  CR: { name: 'Costa Rica', folder: 'costarica', subjCode: { matematicas: 'MAT', lengua: 'LEN', 'ciencias-naturales': 'CIE', 'estudios-sociales': 'SOC', ingles: 'ING' } },
+  HN: { name: 'Honduras', folder: 'honduras', subjCode: { matematicas: 'MAT', lengua: 'LEN', 'ciencias-naturales': 'CIE', sociales: 'SOC', ingles: 'ING' } },
+  ES: { name: 'Espana', folder: 'spain', subjCode: { matematicas: 'MAT', lengua: 'LEN', 'ciencias-naturales': 'CIE', sociales: 'SOC', ingles: 'ING' } },
+};
+
+function parseArgs(argv) {
+  const out = { country: 'PE', grade: 11, subject: 'matematicas', from: 1, to: 10, write: false, year: 2026 };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    const n = argv[i + 1];
+    if (a === '--country') { out.country = String(n).toUpperCase(); i++; }
+    else if (a === '--grade') { out.grade = Number(n); i++; }
+    else if (a === '--subject') { out.subject = String(n); i++; }
+    else if (a === '--from') { out.from = Number(n); i++; }
+    else if (a === '--to') { out.to = Number(n); i++; }
+    else if (a === '--year') { out.year = Number(n); i++; }
+    else if (a === '--write') { out.write = true; }
+  }
+  return out;
+}
+
+function questionsPerBundle(grade) {
+  if (grade <= 5) return 8;
+  if (grade <= 7) return 10;
+  if (grade <= 10) return 12;
+  return 20;
+}
+
+function weekTopic(w) {
+  return `tema-w${String(w).padStart(2, '0')}`;
+}
+
+function buildIssue(opts) {
+  const meta = COUNTRY_META[opts.country];
+  if (!meta) throw new Error(`Unknown country ${opts.country}. Add to COUNTRY_META.`);
+  const from = Math.max(1, opts.from);
+  const to = Math.min(40, opts.to);
+  const count = to - from + 1;
+  if (count < 1) throw new Error('Invalid week range');
+  if (count > 15) throw new Error(`Max 15 bundles/issue (got ${count}). Split the range.`);
+
+  const subjCode = meta.subjCode[opts.subject] || opts.subject.slice(0, 3).toUpperCase();
+  const qn = questionsPerBundle(opts.grade);
+  const gradeToken = opts.grade === '3EM' ? '3EM' : String(opts.grade);
+  const wFrom = `W${String(from).padStart(2, '0')}`;
+  const wTo = `W${String(to).padStart(2, '0')}`;
+  const title = `[JULES] ${meta.name} - ${opts.subject} ${gradeToken} - ${wFrom}-${wTo} (${count} bundles)`;
+  const route = `questions_data/${meta.folder}/${opts.subject}/grado-${opts.grade}/${opts.year}/weekly/`;
+
+  const rows = [];
+  for (let w = from; w <= to; w++) {
+    const ww = `W${String(w).padStart(2, '0')}`;
+    const topic = weekTopic(w);
+    const file = `${opts.country}-${subjCode}-${gradeToken}-${opts.year}-${ww}-${topic}-001-MASTERY-bundle.md`;
+    rows.push(`| ${w - from + 1} | ${ww} | ${topic} | \`${file}\` |`);
+  }
+
+  const body = `---
+title: "${title}"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **${count}**.
+- No regenerar existentes salvo \`REPLACE\`.
+- Solo archivos \`.md\` en \`${route}\`.
+- Validar: \`npm run validate -- {archivos}\` en **0 fallos** antes de comentar.
+- Comentar: \`[OK] Generados N bundles: ...\`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: ${opts.country === 'CO' ? '`**ICFES:**` (solo Colombia)' : '`**EJE:**` — ICFES PROHIBIDO fuera de Colombia'}.
+2. \`alignment\`: entidad oficial del país (ver regla ${opts.country}); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA \`${route}\` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; \`week: "WNN"\` (nunca \`semana:\`); \`id\` = filename sin \`.md\`.
+5. \`## Question N [D#]\` (nunca \`## Pregunta\`); \`### Enunciado/Opciones/Explicacion Pedagogica\`; \`**Contexto:**\` (nunca \`Context\`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: \`node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only\` + \`npm run audit:country-readiness\`.
+
+## Skills y protocolo (obligatorio)
+
+1. \`AGENTS.md\` (v5.2)
+2. \`skills/worldexams-bundle-generator/SKILL.md\`
+3. \`skills/bundle-creator/SKILL.md\`
+4. \`skills/bundle-creator/rules/${opts.country}.md\` (incluye Anti-Error Checklist del país)
+5. \`docs/specs/curriculums/${meta.folder}/README.md\` (si existe)
+6. \`docs/HERMES_JULES_WORKFLOW.md\`
+7. \`docs/specs/ACTIVE_PROTOCOLS.md\`
+8. \`docs/specs/CONTENT_ERRORS.md\`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | ${meta.name} |
+| Codigo | ${opts.country} |
+| Asignatura | ${opts.subject} |
+| Subject code | ${subjCode} |
+| Grado | ${gradeToken} |
+| Ano | ${opts.year} |
+| Protocolo | v5.2 |
+| Preguntas/bundle | ${qn} |
+| Ruta | \`${route}\` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+${rows.join('\n')}
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo \`${route}\`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate ${opts.country} ${opts.subject} G${gradeToken} ${wFrom}-${wTo}</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate ${count} weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>
+`;
+
+  return { title, body, count };
+}
+
+const opts = parseArgs(process.argv);
+const { title, body } = buildIssue(opts);
+console.log(title);
+console.log('---');
+console.log(body);
+
+if (opts.write) {
+  const dir = path.join(root, '.gitcore/planning/jules-wave0');
+  fs.mkdirSync(dir, { recursive: true });
+  const safe = `${opts.country}-${opts.subject}-G${opts.grade}-W${opts.from}-W${opts.to}.md`.replace(/[^a-zA-Z0-9._-]/g, '-');
+  const file = path.join(dir, safe);
+  fs.writeFileSync(file, body, 'utf8');
+  console.error(`Wrote ${file}`);
+}

--- a/scripts/validate-bundles-v52.mjs
+++ b/scripts/validate-bundles-v52.mjs
@@ -68,6 +68,14 @@ function expectedCount(file, fm) {
   return QUESTION_COUNTS.get(grade);
 }
 
+function countryCodeOf(file, fm) {
+  const m = path.basename(file).match(/^([A-Z]{2})-/);
+  if (m) return m[1];
+  const c = String(fm?.country || '').trim().toLowerCase();
+  if (c === 'colombia') return 'CO';
+  return null;
+}
+
 function rel(file) {
   return path.relative(ROOT, file).replace(/\\/g, '/');
 }
@@ -133,6 +141,12 @@ function validateFile(file) {
     errors.push('Forbidden all/none/multiple-combination option detected');
   }
 
+  const cc = countryCodeOf(file, fm);
+  const isCO = cc === 'CO';
+  if (!isCO && /icfes|saber\s?11|dba men/i.test(String(fm.alignment || ''))) {
+    errors.push('alignment must reference the country exam entity, not ICFES/Saber/DBA (Colombia-only brands)');
+  }
+
   const questions = questionBlocks(content);
   if (expected && questions.length !== expected) errors.push(`Expected ${expected} questions, found ${questions.length}`);
 
@@ -143,7 +157,13 @@ function validateFile(file) {
     if (!/^D\d+(?:-D?\d+)?$/.test(q.difficulty)) errors.push(`${prefix}: invalid difficulty label`);
     if (!/\*\*ID:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing ID`);
     if (!/\*\*Bloom:\*\*\s*(Remember|Understand|Apply|Analyze|Evaluate)/.test(q.text)) errors.push(`${prefix}: invalid Bloom`);
-    if (!/\*\*ICFES:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing ICFES/eje field`);
+    if (isCO) {
+      if (!/\*\*ICFES:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing ICFES field (Colombia exam axis)`);
+      if (/\*\*EJE:\*\*/.test(q.text)) errors.push(`${prefix}: use ICFES, not EJE, for Colombia`);
+    } else {
+      if (/\*\*ICFES:\*\*/.test(q.text)) errors.push(`${prefix}: ICFES is a Colombia-only brand; use **EJE:**`);
+      if (!/\*\*EJE:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing EJE field (exam axis)`);
+    }
     if (!/\*\*Expected_Success:\*\*\s*0\.\d+/.test(q.text)) errors.push(`${prefix}: missing Expected_Success`);
     if (!/\*\*Contexto:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing Contexto`);
     if (/\*\*Context:\*\*/.test(q.text)) errors.push(`${prefix}: use Contexto, not Context`);

--- a/skills/bundle-creator/SKILL.md
+++ b/skills/bundle-creator/SKILL.md
@@ -110,6 +110,11 @@ For 8 or 12 questions, keep the same progression and avoid overloading expert qu
 **Expected_Success:** 0.80
 **Contexto:** Local country context.
 
+<!-- AXIS FIELD BY COUNTRY: `**ICFES:**` is EXCLUSIVE to Colombia bundles.
+     Every other country uses `**EJE:** {competency_or_exam_axis}` instead.
+     The country's exam entity (PAES, EXANI, ENEM, CNEB, Aprender, ...)
+     belongs only in frontmatter `alignment`, never as a brand inside questions. -->
+
 ### Enunciado
 Question text.
 

--- a/skills/bundle-creator/rules/AR.md
+++ b/skills/bundle-creator/rules/AR.md
@@ -1,30 +1,88 @@
-# AR - Argentina Bundle Creation Rules
+# AR - Argentina Bundle Creation Rules (v5.2)
 
 ## Official Exam Framework
-- **Exam:** Aprender (Operativo Nacional de Evaluación)
-- **Agency:** Ministerio de Educación de la Nación (Secretaría de Evaluación e Información Educativa)
-- **Subjects:** Lengua, Matemática, Ciencias Sociales (rotating), Ciencias Naturales (rotating)
-- **Grade:** 5°/6° Secundaria (Último año de educación secundaria)
+- **Exam:** Aprender (Operativo Nacional de Evaluación); university entry is mostly open (UBA CBC, UTN seminars, etc. — not a single national entrance exam)
+- **Agency:** Ministerio de Educación de la Nación · Secretaría de Evaluación e Información Educativa
+- **Curriculum:** NAP (Núcleos de Aprendizajes Prioritarios) + jurisdiccional overlays
+- **Grade:** Primaria 1°–6°/7° and Secundaria 1°–5°/6° depending on jurisdiction; WorldExams commonly maps último año secundaria to `grado-11`/`grado-12`
 - **Reference:** https://www.argentina.gob.ar/educacion/aprender
+- **Curriculum notes:** `docs/specs/curriculums/argentina/README.md`
+- **Bundles Directory:** `questions_data/argentina/`
+- **Authority:** `AGENTS.md` Bundle Protocol v5.2 · `npm run validate`
 
-## Curriculum Notes
-- No centralized university entrance exam (CBC for UBA, others have own exams)
-- NAP (Núcleos de Aprendizajes Prioritarios) established 2004–2012
-- Each province may have complementary evaluations
-- Focus bundles on Aprender-style assessment + NAP-aligned content
+## Subjects (folder keys)
+| Area | Subject key | Notes |
+|------|-------------|-------|
+| Matemática | `matematicas` (prefer) / `matematica` | Prefer plural for new weekly packs |
+| Lengua | `lengua` | Aprender core |
+| Lectura Crítica | `lectura-critica` | Practice overlay |
+| Ciencias Naturales | `ciencias-naturales` | Rotating Aprender area |
+| Ciencias Sociales | `sociales-ciudadanas` | Rotating Aprender area |
+| Inglés | `ingles` | Jurisdictional |
 
-## Bundle Directory Structure
+## Curriculum Alignment (NAP stubs)
+
+### Grado 6°
+- **Matemática:** Números naturales/racionales intro, operaciones, geometría, medición, datos.
+- **Lengua:** Cuentos/fábulas, comprensión narrativa, ortografía y gramática básica.
+
+### Grado 9° (≈ 3° secundaria)
+- **Matemática:** Proporcionalidad, ecuaciones, geometría, estadística introductoria.
+- **Lengua:** Textos expositivos/argumentativos; tipologías; coherencia.
+- **Cs. Naturales / Sociales:** According to NAP ciclo — keep claims factual.
+
+### Grado 11° (cierre secundaria / pre-CBC)
+- **Matemática:** Reales, álgebra, funciones, trigonometría, estadística/probabilidad; intro análisis según orientación.
+- **Lengua:** Comprensión argumentativa, producción académica, literatura argentina/latinoamericana.
+- **Cs. Naturales:** Genética, química general, mecánica básica — nivel secundario.
+- Do **not** claim a single national W01–W40 calendar (jurisdictions differ).
+
+## Canonical Path (Protocol v5.2)
+
+```text
+questions_data/argentina/{subject}/grado-{N}/2026/weekly/
+  AR-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle.md
 ```
-questions_data/argentina/
-  └── grado-11/
-      └── periodo-1/
-          └── [subject]/
-              └── AR-SUBJ-11-P1-TOPIC-NNN-MASTERY-bundle.md
+
+Example:
+
+```text
+questions_data/argentina/matematicas/grado-11/2026/weekly/
+  AR-MAT-11-2026-W01-numeros-reales-001-MASTERY-bundle.md
 ```
+
+Obsolete: `grado-11/periodo-1/...` and `AR-*-P1-*` IDs — do not use for new weekly generation.
+
+## Calendar Notes (W ↔ periods)
+- School year typically **March–December**, but **calendars vary by jurisdicción** (CABA, PBA, etc.).
+- Common patterns: **3 trimestres** or 2 cuatrimestres — treat W-bands as internal only.
+- Stub mapping (non-official): W01–W13 ≈ T1, W14–W26 ≈ T2, W27–W40 ≈ T3.
+- Aprender administration windows vary by year (often second semester); do not invent dates in stems.
+- Sources: `docs/specs/curriculums/argentina/README.md`; AGENTS.md Argentina calendar note.
 
 ## Language & Cultural Rules
-- Use voseo (vos) — Argentine Spanish variant
-- Use ARS $ (Peso argentino) for currency references
-- Reference Argentine cities: Buenos Aires, Córdoba, Rosario, Mendoza, La Plata
-- Use common Argentine names: Juan, Martín, Lucía, Valentina, Facundo, Camila
-- Never reference ICFES or Colombian exam names
+- **Voseo** required: "vos tenés", "calculá", "mirá" — not tú forms as default.
+- Currency: Peso argentino (**ARS $**).
+- Cities: Buenos Aires, Córdoba, Rosario, Mendoza, La Plata, Mar del Plata, Salta.
+- Names: Matías, Facundo, Lucía, Valentina, Martín, Camila, Sofía, Agustín.
+- Contexts: mate, asado, fútbol, 25 de Mayo, 9 de Julio — factual only.
+- Never reference ICFES; do not put "Aprender" brand inside stems (metadata/`alignment` only).
+
+## Subject Bundle Strategy
+1. **Priority 1:** Lengua + Matemática G6/G11 (Aprender-style).
+2. **Priority 2:** Cs. Naturales / Sociales; inglés.
+3. Bundle sizes (v5.2): G3–G5 = 8q · G6–G7 = 10q · G8–G10 = 12q · G11 = 20q.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de AR:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "NAP Argentina / Aprender" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/argentina/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "argentina"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/BO.md
+++ b/skills/bundle-creator/rules/BO.md
@@ -22,3 +22,24 @@ questions_data/bo/
 - Reference Bolivian cities: La Paz, Santa Cruz, Cochabamba, Sucre, Potosí
 - Note: Bolivia has 36+ official indigenous languages including Quechua, Aymara, Guaraní
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  BO-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de BO:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "MINEDU Bolivia" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/bolivia/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "bolivia"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/BR.md
+++ b/skills/bundle-creator/rules/BR.md
@@ -34,3 +34,24 @@ Create bundles in order of priority:
 1. Core mandatory subjects first
 2. Most popular modular areas second
 3. Progressive difficulty (basic → intermediate → advanced → expert)
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  BR-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de BR:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "BNCC Brasil / ENEM" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/brasil/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "brasil"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/CL.md
+++ b/skills/bundle-creator/rules/CL.md
@@ -1,36 +1,89 @@
-# CL - Chile Bundle Creation Rules
+# CL - Chile Bundle Creation Rules (v5.2)
 
 ## Official Exam Framework
-- **Exam:** PAES (Prueba de Acceso a la Educación Superior)
-- **Agency:** DEMRE (Departamento de Evaluación, Medición y Registro Educacional) — Universidad de Chile; MINEDUC (Ministerio de Educación)
-- **Subjects:** N/A
-- **Grade:** 4° Medio (12th grade / Último año enseñanza media)
-- **Established:** 2022 (replaced PSU/PDT); content from 7° básico to 2° medio curriculum
+- **Exam:** PAES (Prueba de Acceso a la Educación Superior); school quality: SIMCE (Agencia de Calidad)
+- **Agency:** DEMRE (Universidad de Chile) for PAES · MINEDUC · Agencia de Calidad for SIMCE
+- **Grade:** Educación Básica 1°–8° and Enseñanza Media 1°–4°; PAES focus **4° Medio** (WorldExams often `grado-11`/`grado-12` — prefer `grado-11` for weekly pack parity unless issue specifies otherwise)
+- **Established:** PAES 2022 (replaced PSU/PDT); content draws from 7° básico–2° medio bases for compulsory tests
+- **Reference:** https://www.demre.cl · https://www.mineduc.cl
+- **Curriculum notes:** `docs/specs/curriculums/chile/README.md`
 - **Bundles Directory:** `questions_data/chile/`
+- **Authority:** `AGENTS.md` Bundle Protocol v5.2 · `npm run validate`
 
-## Curriculum Alignment
+## Subjects (folder keys)
+| Area | Subject key | PAES / school note |
+|------|-------------|--------------------|
+| Matemática | `matematicas` (prefer) / `matematica` | M1 obligatoria; M2 electiva |
+| Lenguaje / Competencia Lectora | `lengua` / `lenguaje` | Prefer `lengua` for new weekly packs |
+| Ciencias Naturales | `ciencias-naturales` | Biología, Física, Química (electiva) |
+| Historia y Cs. Sociales | `sociales` / `sociales-ciudadanas` | Electiva PAES |
+| Inglés | `ingles` | School curriculum; not PAES core |
 
+## Curriculum Alignment (Bases + PAES stubs)
 
-## Bundle Directory Structure
+### Grado 6° (6° básico)
+- **Matemática:** Números naturales/decimales, fracciones, geometría plana, datos.
+- **Lenguaje:** Comprensión literal e inferencial; textos narrativos e informativos.
+- **Ciencias:** Ecosistemas chilenos, materia, energía solar/térmica introductoria.
+
+### Grado 10° (2° medio)
+- **Matemática:** Álgebra, funciones lineales/cuadráticas, probabilidad introductoria (base M1).
+- **Lenguaje:** Textos argumentativos, multimodales; vocabulario académico.
+- **Historia:** Procesos republicanos, geografía de Chile, ciudadanía.
+
+### Grado 11° / 4° Medio (PAES prep)
+- **Competencia Lectora:** Inferencias, propósito, estructuras argumentativas, textos discontinuos.
+- **Matemática M1:** Números, álgebra, geometría, datos y azar (currículo hasta 2° medio).
+- **Matemática M2:** Funciones, cálculo introductorio, geometría analítica (electiva).
+- **Ciencias / Historia:** Según electiva DEMRE.
+
+## Canonical Path (Protocol v5.2)
+
+```text
+questions_data/chile/{subject}/grado-{N}/2026/weekly/
+  CL-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle.md
 ```
-questions_data/chile/
-  ├── grado-11/
-  │   ├── periodo-1/
-  │   │   ├── SUBJECT/
-  │   │   │   └── CODE-SUBJ-11-P1-TOPIC-NNN-MASTERY-bundle.md
-  │   │   └── ...
-  │   └── ...
-  └── ...
+
+Example:
+
+```text
+questions_data/chile/matematicas/grado-11/2026/weekly/
+  CL-MAT-11-2026-W01-algebra-lineal-basica-001-MASTERY-bundle.md
 ```
+
+Obsolete: `grado-11/periodo-1/...` and `CL-*-P1-*` IDs — do not use for new weekly generation.
+
+## Calendar Notes (W ↔ periods)
+- School year: typically **March–December** (summer break Dec–Feb; winter break ~July).
+- Common structure: **2 semestres** (1°: Mar–Jun/Jul; 2°: Jul/Aug–Dec).
+- Stub mapping: W01–W20 ≈ 1° semestre, W21–W40 ≈ 2° semestre.
+- PAES regular process is typically late-year (Nov–Dic windows vary by process year); winter/especial processes exist — verify DEMRE calendar before asserting dates in content.
+- `W01-W40` is internal; not an official MINEDUC week claim.
+- Sources: `docs/specs/curriculums/chile/README.md`; stubs in `config/countries.config.ts`.
 
 ## Language & Cultural Rules
-- Questions must use Chile-specific spelling and terminology
-- Use local cultural references in contexts
-- Never reference ICFES or Colombian exam names; use the country's own exam name
-- All questions must be in standard Spanish 
+- Chilean Spanish (tú; informal register ok in contexts, not slang-heavy stems).
+- Currency: Peso chileno (**CLP $**).
+- Cities: Santiago, Valparaíso, Concepción, Antofagasta, Viña del Mar, Temuco, La Serena.
+- Names: Sebastián, Benjamín, Sofía, Martina, Vicente, Isidora, Catalina, Matías.
+- Contexts: cordillera, Pacífico, Atacama, Patagonia, Fiestas Patrias (18), minería, empanadas, cueca — avoid inventing legal/regulatory facts.
+- Never reference ICFES or Colombian exam brands; do not put "PAES"/"SIMCE" inside stems (metadata/`alignment` only).
 
 ## Subject Bundle Strategy
-Create bundles in order of priority:
-1. Core mandatory subjects first
-2. Most popular modular areas second
-3. Progressive difficulty (basic → intermediate → advanced → expert)
+1. **Priority 1:** Competencia Lectora + Matemática M1 (G11).
+2. **Priority 2:** Ciencias / Historia electivas; G6–G10 school reinforcement.
+3. Bundle sizes (v5.2): G3–G5 = 8q · G6–G7 = 10q · G8–G10 = 12q · G11 = 20q.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de CL:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "PAES DEMRE + MINEDUC Bases Curriculares" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/chile/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "chile"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/CO.md
+++ b/skills/bundle-creator/rules/CO.md
@@ -1,11 +1,12 @@
-# CO - Colombia Bundle Creation Rules (v6.0)
+# CO - Colombia Bundle Creation Rules (v5.2)
 
 ## Official Exam Framework
 - **Exam:** Saber 3°, 5°, 7°, 9°, 11°
 - **Agency:** ICFES (Instituto Colombiano para la Evaluación de la Educación) — under MEN (Ministerio de Educación Nacional)
-- **Grade:** 3° to 11°
+- **Grade:** 3° to 11° (WorldExams `grado-3` … `grado-11`)
 - **Established:** 1968 (ICFES). Current standards: Estándares Básicos de Competencias (EBC) — 2006 and DBA (Derechos Básicos de Aprendizaje) — 2017.
 - **Bundles Directory:** `questions_data/colombia/`
+- **Authority:** `AGENTS.md` Bundle Protocol v5.2 · `npm run validate`
 
 ## Curriculum Alignment (DBA + Standards)
 
@@ -28,23 +29,42 @@
 - **Sociales y Ciudadanas:** Geopolítica, conflictos contemporáneos, economía, Constitución 1991.
 - **Inglés (B1-B2):** Conditionals, Passive voice, Relative clauses, Reading comprehension.
 
-## Bundle Directory Structure
+## Canonical Path (Protocol v5.2)
+
+```text
+questions_data/colombia/{subject}/grado-{N}/2026/weekly/
+  CO-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle.md
 ```
-questions_data/colombia/
-  ├── [asignatura]/
-  │   ├── grado-[N]/
-  │   │   ├── periodo-[P]/
-  │   │   │   ├── [tema]/
-  │   │   │   │   └── CO-[SUBJ]-[GRADO]-P[P]-[TOPIC]-NNN-MASTERY-bundle.md
-```
+
+Legacy `periodo-[1-4]/` and `P[P]` IDs are historical (see `skills/colombia-assessment-protocol-v6`). Do **not** create new bundles under `periodo-*` for weekly 2026 work.
+
+## Calendar Notes (W ↔ periods)
+- Colombia academic year (Calendario A, majority): roughly Feb–Nov with four periods.
+- Internal mapping stub: W01–W10 ≈ P1, W11–W20 ≈ P2, W21–W30 ≈ P3, W31–W40 ≈ P4.
+- `W01-W40` is a curricular sequence compatible with ~40 academic weeks; not an ISO week claim.
+- Saber 11 calendar A/B exam windows: see `config/countries.config.ts` schedules.
 
 ## Language & Cultural Rules
-- Use local context: Pesos Colombianos, landmarks (Bogotá, Cartagena, Monserrate), local names (Juan, Valentina).
+- Use local context: Pesos Colombianos (COP), landmarks (Bogotá, Cartagena, Monserrate), local names (Juan, Valentina).
 - Spelling: Use "seseo" and standard Colombian vocabulary.
-- Never mention "ICFES" in question content; only in metadata.
+- Never mention "ICFES" in question content; only in metadata / `alignment`.
 
 ## Subject Bundle Strategy
-1. **Priority 1:** Grado 6° (Gap closing).
-2. **Priority 2:** Grado 3° (Primary baseline).
-3. **Priority 3:** Grado 5° (Key primary assessment).
-4. Bundle sizes: 10 (Grades 3-4), 15 (Grades 5-7), 20 (Grades 8-11).
+1. **Priority 1:** Grado 6°–7° (gap closing).
+2. **Priority 2:** Grado 3°–5° (primary baseline).
+3. **Priority 3:** Grado 11° (Saber 11 / PREU).
+4. Bundle sizes (v5.2): G3–G5 = 8q · G6–G7 = 10q · G8–G10 = 12q · G11 = 20q.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de CO:
+
+- **Eje por pregunta:** `**ICFES:**` (exclusivo de Colombia; prohibido `**EJE:**` aquí).
+- **alignment:** "DBA MEN Colombia / Saber 11" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/colombia/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "colombia"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/CR.md
+++ b/skills/bundle-creator/rules/CR.md
@@ -22,3 +22,24 @@ questions_data/cr/
 - Reference Costa Rican cities: San José, Alajuela, Cartago, Heredia, Liberia
 - Use common Costa Rican names: Carlos, María, José, Ana, Javier, Sofía
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  CR-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de CR:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "MEP Costa Rica / Bachillerato" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/costarica/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "costa-rica"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/DO.md
+++ b/skills/bundle-creator/rules/DO.md
@@ -22,3 +22,24 @@ questions_data/do/
 - Reference Dominican cities: Santo Domingo, Santiago, La Romana, San Pedro de Macorís
 - Use common Dominican names: Juan, María, Pedro, Ana, Luis, Carmen
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  DO-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de DO:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "MINERD - Pruebas Nacionales RD" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/dominican_republic/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "dominican_republic"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/EC.md
+++ b/skills/bundle-creator/rules/EC.md
@@ -28,3 +28,24 @@ questions_data/ecuador/
 - Reference Ecuadorian cities: Quito, Guayaquil, Cuenca, Ambato, Manta
 - Use common Ecuadorian names: Ana, Luis, Patricia, Fernando, María, José
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  EC-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de EC:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "BGU Ministerio de Educacion Ecuador / SENESCYT" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/ecuador/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "ecuador"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/ES.md
+++ b/skills/bundle-creator/rules/ES.md
@@ -34,3 +34,24 @@ Create bundles in order of priority:
 1. Core mandatory subjects first
 2. Most popular modular areas second
 3. Progressive difficulty (basic → intermediate → advanced → expert)
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  ES-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de ES:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "EBAU/EVAU + LOMLOE" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/spain/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "spain"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/GQ.md
+++ b/skills/bundle-creator/rules/GQ.md
@@ -27,3 +27,24 @@ questions_data/gq/
 - Reference Equatorial Guinean cities: Malabo, Bata, Mongomo, Ebebiyín
 - Reference local cultural contexts (tropical geography, local economy, etc.)
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  GQ-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de GQ:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "Ministerio de Educacion Guinea Ecuatorial" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/guinea-ecuatorial/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "guinea-ecuatorial"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/GT.md
+++ b/skills/bundle-creator/rules/GT.md
@@ -22,3 +22,24 @@ questions_data/gt/
 - Reference Guatemalan cities: Ciudad de Guatemala, Quetzaltenango, Antigua, Escuintla
 - Cultural references may include Maya heritage contexts
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  GT-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de GT:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "MINEDUC Guatemala / CNB" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/guatemala/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "guatemala"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/HN.md
+++ b/skills/bundle-creator/rules/HN.md
@@ -21,3 +21,24 @@ questions_data/hn/
 - Use HNL L (Lempira) for currency references
 - Reference Honduran cities: Tegucigalpa, San Pedro Sula, La Ceiba, Comayagua
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  HN-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de HN:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "CNB Honduras / Secretaria de Educacion" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/honduras/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "honduras"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/MX.md
+++ b/skills/bundle-creator/rules/MX.md
@@ -1,45 +1,98 @@
-# MX - Mexico Bundle Creation Rules
+# MX - Mexico Bundle Creation Rules (v5.2)
 
 ## Official Exam Framework
-- **Exam:** EXANI-II (Examen Nacional de Ingreso a la Educación Superior)
-- **Agency:** CENEVAL (Centro Nacional de Evaluación para la Educación Superior)
-- **Subjects:** Comprensión Lectora, Redacción Indirecta, Pensamiento Matemático, Inglés (diagnóstico)
-- **Grade:** 12 (Último año de preparatoria / Educación Media Superior)
-- **Established:** 2022 (SEP Plan de Estudios — Marco Curricular Común); EXANI-II itself is older
+- **Exam:** EXANI-II (ingreso a educación superior); also COMIPEMS (EMS CDMX/ZMVM); school assessments vary (PLANEA historical / NEM diagnostics)
+- **Agency:** CENEVAL (EXANI) · SEP (Secretaría de Educación Pública) · NEM (Nueva Escuela Mexicana)
+- **Grade:** Primaria 1°–6°, Secundaria 1°–3° (G7–G9), Media Superior 1°–3° (often WorldExams `grado-10`–`grado-12`; weekly packs commonly use `grado-11` for EMS)
+- **Established:** EXANI long-running; SEP Plan de Estudios / MCCEMS updates under NEM (2022+)
+- **Reference:** https://www.ceneval.edu.mx · https://www.gob.mx/sep
+- **Curriculum notes:** `docs/specs/curriculums/mexico/README.md`
 - **Bundles Directory:** `questions_data/mexico/`
+- **Authority:** `AGENTS.md` Bundle Protocol v5.2 · `npm run validate`
 
-## Curriculum Alignment
-### EXANI-II (CENEVAL) - Mexico
-- **Core Transversal (65%):**
-  - Comprensión Lectora (30 questions)
-  - Redacción Indirecta (30 questions)
-  - Pensamiento Matemático (30 questions) - Aritmética, Álgebra, Estadística, Probabilidad, Geometría, Trigonometría
-- **Modular (35% - 24 questions each):**
-  - 16 modules: Administración, Aritmética, Biología, Cálculo Diferencial e Integral, Ciencias de la Salud, Ciencias Experimentales, Ciencias Sociales, Derecho, Economía, Filosofía, Física, Historia, Literatura, Matemáticas Financieras, Probabilidad y Estadística, Psicología, Química
-- **Diagnóstico:** Inglés (30 questions, not scored)
-- **Format:** 168 questions + 20 pilot, 4.5 hours
-- **Bundle Strategy:** Create 3-5 bundles per transversal subject + modular bundles for high-demand careers
+## Subjects (folder keys)
+| Area | Subject key | Notes |
+|------|-------------|-------|
+| Matemáticas / Pensamiento Matemático | `matematicas` | Core transversal EXANI |
+| Lengua / Español | `lengua` | Redacción / lengua escolar |
+| Lectura Crítica / Comprensión Lectora | `lectura-critica` | EXANI transversal |
+| Ciencias Naturales | `ciencias-naturales` | Biología, física, química |
+| Formación Cívica / Sociales | `sociales-ciudadanas` | Historia, civismo |
+| Inglés | `ingles` | Diagnóstico EXANI (often unscored) |
 
-## Bundle Directory Structure
+## Curriculum Alignment (SEP/NEM + EXANI stubs)
+
+### Grado 6° (fin de primaria)
+- **Matemáticas:** Números naturales y decimales, fracciones, perímetro/área, tablas y gráficas.
+- **Lengua:** Comprensión literal; tipologías narrativas e informativas; ortografía básica.
+- **Ciencias:** Ecosistemas mexicanos, cuerpo humano, materia y energía introductoria.
+- **Civismo:** Derechos de niñas/niños, convivencia, símbolos patrios (sin adoctrinamiento).
+
+### Grado 9° (3° secundaria)
+- **Matemáticas:** Proporcionalidad, ecuaciones lineales, geometría, probabilidad introductoria.
+- **Lengua:** Argumentación breve, textos discontinuos, gramática funcional.
+- **Ciencias:** Célula, reacciones químicas básicas, movimiento; salud ambiental.
+- **Historia:** México independiente / siglo XX (nivel secundaria; hechos verificables).
+
+### Grado 11° (Media Superior — EXANI-II prep)
+- **Pensamiento Matemático:** Aritmética, álgebra, geometría, trigonometría, estadística, probabilidad.
+- **Comprensión Lectora:** Textos continuos/discontinuos, inferencias, vocabulario en contexto.
+- **Redacción Indirecta:** Cohesión, coherencia, puntuación, concordancia.
+- **Módulos electivos (alta demanda):** Biología, Química, Física, Historia, Cálculo, Economía, etc.
+- Do **not** claim W01–W40 is the official SEP ciclo escolar calendar.
+
+### EXANI-II structure (generation awareness)
+- Transversales (~65%): Comprensión Lectora, Redacción Indirecta, Pensamiento Matemático.
+- Módulos (~35%): career-specific blocks.
+- Inglés diagnóstico often present but not always scored — treat as optional packs.
+
+## Canonical Path (Protocol v5.2)
+
+```text
+questions_data/mexico/{subject}/grado-{N}/2026/weekly/
+  MX-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle.md
 ```
-questions_data/mexico/
-  ├── grado-11/
-  │   ├── periodo-1/
-  │   │   ├── SUBJECT/
-  │   │   │   └── CODE-SUBJ-11-P1-TOPIC-NNN-MASTERY-bundle.md
-  │   │   └── ...
-  │   └── ...
-  └── ...
+
+Example:
+
+```text
+questions_data/mexico/matematicas/grado-11/2026/weekly/
+  MX-MAT-11-2026-W01-numeros-reales-001-MASTERY-bundle.md
 ```
+
+Obsolete: `grado-11/periodo-1/...`, root `grado-11/` without `2026/weekly/`, and `MX-*-P1-*` IDs — do not use for new weekly generation.
+
+## Calendar Notes (W ↔ periods)
+- SEP **ciclo escolar** typically runs ~**mid-August → early July** (not calendar-year aligned).
+- Common EMS/secundaria organization: **3 periodos** or school-defined blocks within the ciclo.
+- Stub mapping (internal only): W01–W14 ≈ Periodo 1 (Aug–Nov), W15–W28 ≈ Periodo 2 (Dec–Mar), W29–W40 ≈ Periodo 3 (Mar–Jun).
+- EXANI-II application windows vary by institution/process (often spring for many licenciatura admissions); never invent Exact CENEVAL dates in stems.
+- Sources: `docs/specs/curriculums/mexico/README.md`; AGENTS.md Mexico calendar note; stubs in `config/countries.config.ts`.
 
 ## Language & Cultural Rules
-- Questions must use Mexico-specific spelling and terminology
-- Use local cultural references in contexts
-- Never reference ICFES or Colombian exam names; use the country's own exam name
-- All questions must be in standard Spanish 
+- Mexican Spanish (tú; ustedes plural).
+- Currency: Peso mexicano (**MXN $**).
+- Cities: Ciudad de México, Guadalajara, Monterrey, Puebla, Cancún, Mérida, Oaxaca, Tijuana.
+- Names: José, María, Guadalupe, Luis, Fernanda, Diego, Ximena, Carlos.
+- Institutions as context (not endorsement): UNAM, IPN, IMSS, SEP — factual only.
+- Contexts: Día de Muertos, 15/16 de septiembre, gastronomía, geografía diversa — no historical/legal hallucinations.
+- Never reference ICFES; do not put "EXANI"/"CENEVAL" inside stems (metadata/`alignment` only).
 
 ## Subject Bundle Strategy
-Create bundles in order of priority:
-1. Core mandatory subjects first
-2. Most popular modular areas second
-3. Progressive difficulty (basic → intermediate → advanced → expert)
+1. **Priority 1:** G11 transversales EXANI (matemáticas, lectura-crítica, lengua).
+2. **Priority 2:** G6–G9 SEP/NEM core; then high-demand modules.
+3. Bundle sizes (v5.2): G3–G5 = 8q · G6–G7 = 10q · G8–G10 = 12q · G11 = 20q.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de MX:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "SEP/NEM Mexico / EXANI CENEVAL" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/mexico/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "mexico"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/NI.md
+++ b/skills/bundle-creator/rules/NI.md
@@ -21,3 +21,24 @@ questions_data/ni/
 - Use NIO C$ (Córdoba) for currency references
 - Reference Nicaraguan cities: Managua, León, Granada, Masaya
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  NI-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de NI:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "MINED Nicaragua" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/nicaragua/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "nicaragua"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/PA.md
+++ b/skills/bundle-creator/rules/PA.md
@@ -22,3 +22,24 @@ questions_data/pa/
 - Reference Panamanian cities: Panama City, Colón, David, Santiago, Chitré
 - Reference Canal de Panamá as cultural context when appropriate
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  PA-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de PA:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "MEDUCA Panama" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/panama/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "panama"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/PE.md
+++ b/skills/bundle-creator/rules/PE.md
@@ -1,31 +1,90 @@
-# PE - Peru Bundle Creation Rules
+# PE - Peru Bundle Creation Rules (v5.2)
 
 ## Official Exam Framework
-- **Exam:** No single centralized national exam — each university (UNMSM, UNI, PUCP, etc.) administers its own
-- **Agency:** MINEDU (Ministerio de Educación del Perú)
-- **National evaluations (diagnostic):** ECE (Evaluación Censal de Estudiantes) — 2° and 4° primaria, 2° secundaria
-- **Grade:** 5° de Secundaria (11th/12th grade equivalent)
+- **Exam:** No single centralized university entrance exam — each university (UNMSM, UNI, PUCP, etc.) administers its own. National diagnostic: ECE (Evaluación Censal de Estudiantes).
+- **Agency:** MINEDU (Ministerio de Educación del Perú) · UMC for ECE
 - **Curriculum:** CNEB (Currículo Nacional de la Educación Básica) — 2016
+- **Grade:** Primaria 1°–6° and Secundaria 1°–5° mapped to WorldExams `grado-3` … `grado-11` (5° secundaria ≈ G11)
 - **Reference:** https://www.minedu.gob.pe/curriculo/
+- **Curriculum notes:** `docs/specs/curriculums/peru/README.md`
+- **Bundles Directory:** `questions_data/peru/`
+- **Authority:** `AGENTS.md` Bundle Protocol v5.2 · `npm run validate`
 
-## Curriculum Notes
-- No centralized ENEM-style exam
-- Focus on CNEB-aligned content (competency-based curriculum)
-- Popular university admission subjects: Razonamiento Matemático, Razonamiento Verbal, Aritmética, Álgebra, Geometría, Trigonometría, Lenguaje, Literatura, Historia, Geografía, Economía, Filosofía, Psicología, Biología, Física, Química
-- Focus on competencies: Resuelve problemas de cantidad, Resuelve problemas de regularidad, etc.
+## Subjects (folder keys)
+| Area | Subject key | Notes |
+|------|-------------|-------|
+| Matemática | `matematicas` (prefer) / `matematica` | Prefer plural folder for new weekly packs |
+| Comunicación | `comunicacion` | CNEB language area |
+| Ciencia y Tecnología | `ciencia` / `ciencias-naturales` | Prefer `ciencias-naturales` for new packs when aligning cross-country |
+| Ciencias Sociales | `sociales` | Historia, geografía, economía (admisión) |
+| Inglés | `ingles` | Optional / elective |
 
-## Bundle Directory Structure
+## Curriculum Alignment (CNEB stubs)
+
+### Grado 6° (fin de primaria / inicio transición)
+- **Matemáticas:** Números naturales y decimales, fracciones, perímetro/área, datos e incertidumbre básicos.
+- **Comunicación:** Comprensión de textos narrativos e informativos; producción escrita breve.
+- **Ciencia:** Ecosistemas locales (costa/sierra/selva), materia y energía introductoria.
+
+### Grado 9° (2° secundaria ≈ ciclos VI)
+- **Matemáticas:** Racionales, proporciones, ecuaciones lineales, estadística descriptiva.
+- **Comunicación:** Textos argumentativos, tipologías textuales, oralidad formal.
+- **Ciencia:** Célula, sistemas del cuerpo, mezcla/separación, fuerza y movimiento.
+
+### Grado 11° (5° secundaria — foco admisión)
+- **Matemáticas / Razonamiento Matemático:** Números reales, álgebra, geometría, trigonometría, funciones.
+- **Comunicación / Razonamiento Verbal:** Comprensión lectora, analogías, tipologías, literatura peruana/latinoamericana.
+- **Ciencias:** Biología, física y química a nivel admisión (UNMSM/UNI-style topics).
+- **Sociales:** Historia del Perú, geografía, economía, filosofía (según carrera).
+
+Competencias CNEB (matemática): cantidad; regularidad, equivalencia y cambio; forma, movimiento y localización; gestión de datos e incertidumbre.
+
+## Canonical Path (Protocol v5.2)
+
+```text
+questions_data/peru/{subject}/grado-{N}/2026/weekly/
+  PE-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle.md
 ```
-questions_data/peru/
-  └── grado-11/
-      └── periodo-1/
-          └── [subject]/
-              └── PE-SUBJ-11-P1-TOPIC-NNN-MASTERY-bundle.md
+
+Example:
+
+```text
+questions_data/peru/matematicas/grado-11/2026/weekly/
+  PE-MAT-11-2026-W01-numeros-reales-001-MASTERY-bundle.md
 ```
+
+Obsolete: `grado-11/periodo-1/...` and `PE-*-P1-*` IDs — do not use for new weekly generation.
+
+## Calendar Notes (W ↔ periods)
+- School year (EBR): typically **March–December** (vacations Dec–Feb; mid-year winter break ~July).
+- Many schools use **4 bimestres** or 2 semesters; W01–W40 is an internal sequence, not an official MINEDU week index.
+- Stub mapping: W01–W10 ≈ Bimestre 1 (Mar–May), W11–W20 ≈ B2 (May–Jul), W21–W30 ≈ B3 (Aug–Oct), W31–W40 ≈ B4 (Oct–Dec).
+- ECE windows vary by year (historically late-year diagnostic); do not hardcode ECE dates into stems.
+- Sources: `docs/specs/curriculums/peru/README.md`; schedule stubs in `config/countries.config.ts`.
 
 ## Language & Cultural Rules
-- Use standard Peruvian Spanish
-- Use PEN S/ (Sol) for currency references
-- Reference Peruvian cities: Lima, Arequipa, Cusco, Trujillo, Chiclayo
-- Use common Peruvian names: Carlos, María, José, Carmen, Diego, Andrea
-- Never reference ICFES or Colombian exam names
+- Standard Peruvian Spanish (tú; avoid Argentine voseo).
+- Currency: Sol (**PEN S/**).
+- Cities: Lima, Arequipa, Cusco, Trujillo, Chiclayo, Piura, Iquitos.
+- Names: Carlos, María, José, Carmen, Diego, Andrea, Luis, Rosa.
+- Geography/contexts: costa–sierra–selva, Machu Picchu, Andes, Amazonía, ceviche, quipu (as cultural context, not pseudoscience claims).
+- Never reference ICFES, Saber, or Colombian exam brands in content.
+
+## Subject Bundle Strategy
+1. **Priority 1:** Grado 11 matemáticas + comunicación (admisión / CNEB cierre).
+2. **Priority 2:** Grado 6–9 (ECE-aligned competencies).
+3. Bundle sizes (v5.2): G3–G5 = 8q · G6–G7 = 10q · G8–G10 = 12q · G11 = 20q.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de PE:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "CNEB MINEDU Peru" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/peru/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "peru"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/PR.md
+++ b/skills/bundle-creator/rules/PR.md
@@ -22,3 +22,24 @@ questions_data/pr/
 - Reference Puerto Rican cities: San Juan, Ponce, Mayagüez, Bayamón, Carolina
 - Use common Puerto Rican names: Luis, José, Carmen, Marta, Pedro, Ana
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  PR-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de PR:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "Departamento de Educacion de Puerto Rico" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/puerto-rico/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "puerto-rico"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/PY.md
+++ b/skills/bundle-creator/rules/PY.md
@@ -22,3 +22,24 @@ questions_data/py/
 - Reference Paraguayan cities: Asunción, Ciudad del Este, Encarnación, San Lorenzo
 - Note: Paraguay has both Spanish and Guaraní as official languages
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  PY-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de PY:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "MEC Paraguay" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/paraguay/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "paraguay"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/SV.md
+++ b/skills/bundle-creator/rules/SV.md
@@ -22,3 +22,24 @@ questions_data/sv/
 - Reference Salvadoran cities: San Salvador, Santa Ana, San Miguel, Soyapango
 - Use common Salvadoran names: José, Francisco, María, Rosa, Carlos, Ana
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  SV-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de SV:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "MINED - PAES El Salvador" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/el-salvador/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "el-salvador"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/UY.md
+++ b/skills/bundle-creator/rules/UY.md
@@ -26,3 +26,24 @@ questions_data/uy/
 - Use UYU $U (Peso uruguayo) for currency references
 - Reference Uruguayan cities: Montevideo, Salto, Punta del Este, Colonia del Sacramento
 - Never reference ICFES or Colombian exam names
+
+## Canonical directory (REQUIRED — v5.2)
+```
+questions_data/[country-folder]/{asignatura}/grado-{N}/2026/weekly/
+  UY-{SUBJ}-{GRADE}-2026-W{NN}-{tema}-001-MASTERY-bundle.md
+```
+Do **not** use `periodo-1` for new bundles. See `_TEMPLATE.md` and `AGENTS.md`.
+
+## Anti-Error Checklist (v5.2, 2026-07-28)
+
+Basado en la purga de contenido 2026-07-28 — ver `docs/specs/CONTENT_ERRORS.md`.
+Antes de guardar CADA bundle de UY:
+
+- **Eje por pregunta:** `**EJE:**` (ICFES está PROHIBIDO fuera de Colombia).
+- **alignment:** "ANEP Uruguay" — nunca ICFES/Saber/DBA MEN.
+- **Carpeta canónica:** `questions_data/uruguay/{subject}/grado-{N}/2026/weekly/` (la carpeta es el nombre completo del país, no el código).
+- **Frontmatter:** los 15 campos exactos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country: "uruguay"`; `id` = filename sin `.md`.
+- **Formato:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`/`### Opciones`/`### Explicacion Pedagogica`, `**Contexto:**` (nunca `**Context:**`).
+- **Sin placeholders:** prohibidos los literales "Distractor N", "Opcion correcta", "Opcion B/C/D", "tema-semana-NN".
+- **Opciones:** exactamente 4 (A-D), una sola `[x]`, textos únicos, feedback no vacío en todas.
+- **Validación obligatoria:** `npm run validate -- {archivos}` en 0 fallos antes de comentar `[OK]` en el issue; después regenerar packs con `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` y verificar `npm run audit:country-readiness`.

--- a/skills/bundle-creator/rules/_TEMPLATE.md
+++ b/skills/bundle-creator/rules/_TEMPLATE.md
@@ -4,22 +4,64 @@
 - **Exam:** [e.g., Pruebas Nacionales de Bachillerato]
 - **Agency:** [e.g., MEDUCA]
 - **Subjects:** [list]
-- **Grade:** 11 (last year of secondary)
+- **Grade:** [range mapped to WorldExams grado-N]
 - **Reference:** [URL]
+- **Bundles Directory:** `questions_data/[country-folder]/
+- **Axis field:** `**EJE:**` (todos los países excepto Colombia, que usa `**ICFES:**`)
+- **alignment:** [entidad oficial del país, p.ej. "MEDUCA - Pruebas Nacionales" — NUNCA ICFES/Saber/DBA]
 
 ## Curriculum Alignment
 Research the country's official curriculum and exam framework before creating bundles.
+Stub grade-level topics for at least one primary and one upper-secondary grade.
 
-## Bundle Directory Structure
+## Canonical Path (Protocol v5.2)
+
+Authority: `AGENTS.md`. Do **not** use obsolete `periodo-[N]/` trees for new weekly generation.
+
+```text
+questions_data/{country}/{subject}/grado-{N}/2026/weekly/
+  {CODE}-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle.md
 ```
-questions_data/[country-code]/
-  └── grado-11/
-      └── periodo-1/
-          └── [subject]/
-              └── CODE-SUBJ-11-P1-TOPIC-NNN-MASTERY-bundle.md
+
+Example:
+
+```text
+questions_data/[country-folder]/[subject]/grado-11/2026/weekly/
+  CODE-SUBJ-11-2026-W01-topic-slug-001-MASTERY-bundle.md
 ```
+
+Validate with:
+
+```bash
+npm run validate -- questions_data/[country-folder]/[subject]/grado-11/2026/weekly/*.md
+```
+
+## Anti-Error Checklist (obligatorio antes de guardar)
+
+Basado en la purga 2026-07-28 (`docs/specs/CONTENT_ERRORS.md`). Revisar CADA bundle:
+
+1. **Marca correcta:** `**EJE:**` por pregunta (no ICFES salvo Colombia); `alignment` con la entidad del país; cero menciones ICFES/Saber/DBA en todo el archivo.
+2. **Sin placeholders:** ningún literal "Distractor N", "Opcion correcta", "Opcion B/C/D", "Pregunta sobre", "tema-semana-NN".
+3. **Ruta exacta:** `questions_data/{country-folder-nombre-completo}/{subject}/grado-{N}/2026/weekly/` — códigos de país (`uy`, `py`, `es`, `do`...) NO son carpetas válidas; Brasil usa `3o-ano` (no `3o-EM`).
+4. **Frontmatter exacto:** los 15 campos de `AGENTS.md`; `week: "WNN"` (nunca `semana:`); `country` = nombre completo en minúsculas; `id` = nombre de archivo sin `.md`; sin campos extra como `exam:`.
+5. **Formato de pregunta:** `## Question N [D#]` (nunca `## Pregunta`), `### Enunciado`, `### Opciones`, `### Explicacion Pedagogica`, `**Bloom:**`, `**EJE:**`, `**Expected_Success:**`, `**Contexto:**` (nunca `**Context:**`).
+6. **Opciones únicas:** mismo texto en 2+ opciones = inválido; exactamente 4 opciones A-D, una sola `[x]`.
+7. **Feedback completo:** toda opción tiene `<!-- feedback: ... -->` no vacío.
+8. **Sin opciones prohibidas:** "todas/ninguna de las anteriores", "A y B" → inválido.
+9. **Validar antes de PR:** `npm run validate -- {archivos}` en 0 fallos; después `node scripts/generate-static-packs.js --all-weekly --changed-only` y `npm run audit:country-readiness`.
+
+## Calendar Notes (W ↔ periods)
+- `W01-W40` is an internal curricular sequence, not necessarily an official national calendar week.
+- Map approximate school periods / semesters / ciclo escolar to W-bands in comments when known.
+- Do not claim W01-W40 is the official ministry calendar unless documented.
 
 ## Language & Cultural Rules
 - Use country-specific spelling and terminology
-- Use local cultural references
-- Never reference ICFES or Colombia-specific exam names
+- Use local cultural references (cities, currency, names)
+- Never reference ICFES or Colombia-specific exam names unless the country is Colombia
+- Never put the official exam brand name inside question stems (metadata / alignment only)
+
+## Subject Bundle Strategy
+1. Core curriculum subjects first
+2. High-stakes assessment grades second
+3. Progressive difficulty per AGENTS.md bands (G3-G5: 8q, G6-G7: 10q, G8-G10: 12q, G11: 20q)


### PR DESCRIPTION
## Summary
- Hardens `validate-bundles-v52` + country readiness audit: `**ICFES:**` only for Colombia; all other countries require `**EJE:**`
- Documents error catalog in `docs/specs/CONTENT_ERRORS.md`
- Updates AGENTS.md + all 20 country rules / template with anti-error checklist

## Test plan
- [x] Validator rejects non-CO bundles that still use `**ICFES:**`
- [ ] Confirm open Jules content PRs fail until rewritten to `**EJE:**`

Made with [Cursor](https://cursor.com)