### PR TITLE
Support EJE: label in non-Colombia bundle validators

### DIFF
--- a/saberparatodos/scripts/generate-static-packs.js
+++ b/saberparatodos/scripts/generate-static-packs.js
@@ -193,7 +193,7 @@ function parseQuestions(body) {
 
     // Extract QA metadata fields (bloom, icfes, expected_success) for quality control
     const bloomMatch = section.match(/\*\*Bloom:\*\*\s*([^\n]+)/i);
-    const icfesMatch = section.match(/\*\*ICFES:\*\*\s*([^\n]+)/i);
+    const icfesMatch = section.match(/\*\*(ICFES|EJE):\*\*\s*([^\n]+)/i);
     const expectedSuccessMatch = section.match(/\*\*Expected_Success:\*\*\s*([^\n]+)/i);
 
     // Extract statement

--- a/scripts/audit-country-readiness.mjs
+++ b/scripts/audit-country-readiness.mjs
@@ -258,7 +258,7 @@ function validateStrictBundle(file) {
     if (!/^D\d+(?:-D?\d+)?$/.test(question.difficulty)) errors.push(`${prefix}: invalid difficulty label`);
     if (!/\*\*ID:\*\*\s*\S/.test(question.text)) errors.push(`${prefix}: missing ID`);
     if (!/\*\*Bloom:\*\*\s*(Remember|Understand|Apply|Analyze|Evaluate)/.test(question.text)) errors.push(`${prefix}: invalid Bloom`);
-    if (!/\*\*ICFES:\*\*\s*\S/.test(question.text)) errors.push(`${prefix}: missing ICFES/eje field`);
+    if (!/\*\*(ICFES|EJE):\*\*\s*\S/.test(question.text)) errors.push(`${prefix}: missing ICFES/eje field`);
     if (!/\*\*Expected_Success:\*\*\s*0\.\d+/.test(question.text)) errors.push(`${prefix}: missing Expected_Success`);
     if (!/\*\*Contexto:\*\*\s*\S/.test(question.text)) errors.push(`${prefix}: missing Contexto`);
     if (/\*\*Context:\*\*/.test(question.text)) errors.push(`${prefix}: use Contexto, not Context`);

--- a/scripts/validate-bundles-v52.mjs
+++ b/scripts/validate-bundles-v52.mjs
@@ -143,7 +143,7 @@ function validateFile(file) {
     if (!/^D\d+(?:-D?\d+)?$/.test(q.difficulty)) errors.push(`${prefix}: invalid difficulty label`);
     if (!/\*\*ID:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing ID`);
     if (!/\*\*Bloom:\*\*\s*(Remember|Understand|Apply|Analyze|Evaluate)/.test(q.text)) errors.push(`${prefix}: invalid Bloom`);
-    if (!/\*\*ICFES:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing ICFES/eje field`);
+    if (!/\*\*(ICFES|EJE):\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing ICFES/eje field`);
     if (!/\*\*Expected_Success:\*\*\s*0\.\d+/.test(q.text)) errors.push(`${prefix}: missing Expected_Success`);
     if (!/\*\*Contexto:\*\*\s*\S/.test(q.text)) errors.push(`${prefix}: missing Contexto`);
     if (/\*\*Context:\*\*/.test(q.text)) errors.push(`${prefix}: use Contexto, not Context`);


### PR DESCRIPTION
We updated the validators and static pack generators to accept the `**EJE:**` label in non-Colombia bundles. This allows non-Colombia question bundles to fully pass the `npm run validate` test suite and compile properly without violating the directive to avoid ICFES labeling outside of Colombia.

Fixes #854

---
*PR created automatically by Jules for task [39858527506603734](https://jules.google.com/task/39858527506603734) started by @iberi22*