### PR TITLE
chore(docs): land local-only SRS/Jules planning and fix edge-mesh path

### DIFF
--- a/.gitcore/MANIFEST.json
+++ b/.gitcore/MANIFEST.json
@@ -1,0 +1,41 @@
+{
+  "protocol_version": "3.8.0",
+  "package": "gitcore-consumer",
+  "updated": "2026-07-17",
+  "description": "Files managed by gitcore-update and copied into every SWAL project under .gitcore/",
+  "source_of_truth": {
+    "local_env": "GITCORE_HOME",
+    "local_default": "E:\\\\proyectosSWAL\\\\GitCore",
+    "remote_repo": "iberi22/GitCore",
+    "remote_fallback": "iberi22/Git-Core-Protocol"
+  },
+  "managed_paths": [
+    "PROTOCOL_REFERENCE.md",
+    "docs/SWAL_PRIVATE_ERA.md",
+    "docs/SWAL_GOAL.md",
+    "scripts/gitcore-update.ps1",
+    "scripts/implementation-score.ps1",
+    "scripts/feature-verify.ps1",
+    "scripts/feature-diff-claimed.ps1",
+    "scripts/protocol-health.ps1",
+    "scripts/check-protocol-update.ps1",
+    "scripts/ensure-srs-src.ps1",
+    "scripts/lib/GitCore.Common.ps1",
+    "MANIFEST.json"
+  ],
+  "preserved_paths": [
+    "ARCHITECTURE.md",
+    "AGENT_INDEX.md",
+    "features.json",
+    "features.details/",
+    "planning/",
+    "srs/",
+    "harness/",
+    "STATE.md",
+    "CONTEXT_LOG.md"
+  ],
+  "project_root_touch": [
+    ".git-core-protocol-version"
+  ],
+  "notes": "ARCHITECTURE and planning are never overwritten unless missing. features.json only gets protocol_version field patched."
+}

--- a/.gitcore/PROTOCOL_REFERENCE.md
+++ b/.gitcore/PROTOCOL_REFERENCE.md
@@ -1,0 +1,73 @@
+# GitCore Protocol Template v3.8.0
+
+> Template repo for SWAL development workflow.  
+> GitCore is a **PROTOCOL** — not a product app.  
+> **Updated:** 2026-07-17 — Private SWAL era
+
+## Core
+
+| Path | Purpose |
+|------|---------|
+| `.gitcore/ARCHITECTURE.md` | Non-negotiable decisions |
+| `.gitcore/features.json` | Feature tracking |
+| `.gitcore/planning/` | PLANNING.md + TASK.md |
+| `AGENTS.md` | Agent read order + rules |
+| `SRC.md` | Source Code Reference (**mandatory, complete**) |
+| `docs/SRS/` | Software Requirements Spec (**mandatory, 100% structure**) |
+| Xavier MCP/HTTP | Persistent agent memory |
+
+## Principles (v3.8)
+
+1. **Issues** = long-term state (local `.github/issues` OK when GH Actions off)
+2. **TASK.md** = session state
+3. **git + gh** = primary interface
+4. **Xavier** = memory (HTTP `:8006` and/or **MCP**)
+5. **Commits** = conventional + issue refs
+6. **Repos private by default** (SWAL, until explicitly public)
+7. **GitHub Actions disabled by default** (workflows live in `.github/workflows.disabled/`)
+8. **SRS + SRC always present and complete** (definition of done for protocol compliance)
+9. **Pro features in apps** = active SWAL node — not Stripe (see monorepo `docs/SWAL/README.md`)
+
+## Version
+
+**3.8.0** (2026-07-17)
+
+### Breaking / policy changes from 3.7
+
+| Topic | 3.7 | 3.8 |
+|-------|-----|-----|
+| Visibility | Mixed / adaptive CI | **Private default** |
+| CI | Active workflows copied on install | **Workflows disabled**; optional re-enable |
+| SRS | Optional post-read | **Mandatory 100% skeleton + fill** |
+| SRC | Recommended | **Mandatory complete** |
+| Xavier | HTTP curl examples | **HTTP + MCP** first-class |
+| SWAL product rules | Not in protocol | **Linked** (node Pro, instance isolation) |
+
+## Completeness gates (must be 100%)
+
+### SRC.md complete when it has:
+
+1. Overview / purpose of the repo  
+2. Directory tree (real modules)  
+3. Core components table  
+4. Build / run / test commands  
+5. Env vars (no secrets)  
+6. Cross-links to `.gitcore/*`, `docs/SRS/*`, `AGENTS.md`  
+7. Protocol version footer  
+
+### docs/SRS/ complete when it has:
+
+1. `index.md` — status table, doc list, synced ratio target  
+2. `REQUIREMENTS.md` — REQ-IDs with acceptance criteria + file traces  
+3. `ARCHITECTURE.md` — component map + non-functionals summary  
+4. Optional: `NON-FUNCTIONAL.md`, `INTERFACES.md`, `DATABASE.md` if domain needs them  
+5. Target: **synced ratio 100%** once drift tooling runs; until then `draft` is OK if every REQ has Files + Acceptance  
+
+## Install / upgrade (local monorepo)
+
+```powershell
+# From monorepo root
+pwsh .\GitCore\scripts\swal-sync-gitcore.ps1 -ProjectPath "E:\proyectosSWAL\shelf"
+pwsh .\GitCore\scripts\swal-disable-workflows.ps1 -Root "E:\proyectosSWAL"
+pwsh .\GitCore\scripts\swal-ensure-srs-src.ps1 -Root "E:\proyectosSWAL"
+```

--- a/.gitcore/detailsFeatures.json
+++ b/.gitcore/detailsFeatures.json
@@ -1,0 +1,272 @@
+{
+  "deprecated": true,
+  "merged_into": "features.json v3.0",
+  "deprecated_at": "2026-07-28",
+  "metadata": {
+    "project": "WorldExams",
+    "version": "1.0",
+    "created": "2026-07-10",
+    "total_features": 12,
+    "description": "Detalle técnico de cada feature del proyecto — PRs, issues, dependencias, KPIs y riesgos. DEPRECATED: contenido absorbido por features.json v3.0 (raíz). Se conserva solo para historia."
+  },
+  "features": [
+    {
+      "id": "feat-mastery-colombia",
+      "category": "generation",
+      "description": "Generación de bundles MASTERY para Colombia (Grados 3-11, todas las materias)",
+      "tech_details": "Bundles en formato markdown con frontmatter YAML v5.2. Generados por Jules (Google Agent) + Gemini API. Ubicación: questions_data/colombia/{subject}/grado-{N}/2026/. Cubre: matematicas, lectura-critica, ciencias-naturales, sociales-ciudadanas, ingles, preuniversitario, tecnologia-informatica.",
+      "prs": ["#395", "#406", "#405", "#410"],
+      "issues": [],
+      "dependencies": ["Gemini API", "Jules Agent", "Protocolo v5.2"],
+      "kpis": {
+        "bundles_generated": 120,
+        "total_questions": 1800,
+        "pass_rate": "92%"
+      },
+      "risks": [
+        "Dependencia de disponibilidad de Gemini API",
+        "Calidad inconsistente en bundles generados automáticamente"
+      ],
+      "status": "active",
+      "priority": "P0",
+      "progress_pct": 100,
+      "verified_by": "PRs #395, #406, #405, #410"
+    },
+    {
+      "id": "feat-weekly-packs",
+      "category": "generation",
+      "description": "Generación de WEEKLY packs semanales por grado y país (Protocolo v5.2)",
+      "tech_details": "Secuencia curricular W01-W40. Por grado: G3-5 (8 preguntas), G6-7 (10), G8-10 (12), G11/3EM (20). Formato: {COUNTRY}-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle.md. Validación con npm run validate.",
+      "prs": ["#395", "#397", "#410"],
+      "issues": [],
+      "dependencies": ["Protocolo v5.2", "npm run validate", "Estructura questions_data/"],
+      "kpis": {
+        "weekly_packs_colombia": 40,
+        "coverage_grades": "G6 (completo), G3-5, G7-11 (parcial)",
+        "validation_pass_rate": "95%"
+      },
+      "risks": [
+        "Secuencia W01-W40 puede no alinearse con calendarios escolares oficiales",
+        "Riesgo de alucinaciones en contexto regional"
+      ],
+      "status": "active",
+      "priority": "P0",
+      "progress_pct": 95,
+      "verified_by": "PRs #395, #397"
+    },
+    {
+      "id": "feat-multi-country",
+      "category": "core",
+      "description": "Generalización multi-país: eliminar hardcodes de Colombia, soporte configurable por país",
+      "tech_details": "Refactor de shared libs: grade11-local-bank.ts, generate-static-packs.js, questions.ts, index.astro. Config en config/countries.config.ts. Paletas de colores por país. Packs con prefijo ISO (co-, mx-, ar-, br-).",
+      "prs": ["#310", "#315", "#317", "#318"],
+      "issues": [],
+      "dependencies": ["config/countries.config.ts", "Supabase per-country config"],
+      "kpis": {
+        "countries_code_complete": 2,
+        "countries_api_ready": 2,
+        "total_paises_soportados": 20
+      },
+      "risks": [
+        "Mantenimiento de currículos por país es intensivo en contenido",
+        "SEO y marketing por país requiere inversión adicional"
+      ],
+      "status": "active",
+      "priority": "P0",
+      "progress_pct": 100,
+      "verified_by": "PRs #310, #315, #317, #318"
+    },
+    {
+      "id": "feat-pais-mexico",
+      "category": "expansion",
+      "description": "Expansión curricular México: SEP/NEM, EXANI, COMIPEMS, PLANEA",
+      "tech_details": "Currículo mexicano: SEP (Secretaría de Educación Pública) + NEM (Nuevo Marco Curricular). Exámenes: EXANI-I (ingreso), EXANI-II (egreso), COMIPEMS (media superior), PLANEA. Issue #230 MX_CURRICULO_SEP_CENEVAL. Bundles en questions_data/mexico/.",
+      "prs": [],
+      "issues": ["#230"],
+      "dependencies": ["feat-multi-country", "Currículo SEP", "CENEVAL alignment"],
+      "kpis": {
+        "bundles_generated": 15,
+        "total_questions": 150,
+        "country_readiness": "7.5%"
+      },
+      "risks": [
+        "Alta complejidad del sistema educativo mexicano (múltiples exámenes)",
+        "CENEVAL tiene derechos reservados sobre ciertos contenidos"
+      ],
+      "status": "in_progress",
+      "priority": "P0",
+      "progress_pct": 30,
+      "verified_by": "Issue #230"
+    },
+    {
+      "id": "feat-pais-argentina",
+      "category": "expansion",
+      "description": "Expansión curricular Argentina: NAP/Aprender, CBC/UBA, voseo moderado",
+      "tech_details": "Currículo argentino: NAP (Núcleos de Aprendizajes Prioritarios), Aprender (evaluación nacional), CBC (Ciclo Básico Común UBA). Moneda: ARS. Issue #231 AR_CURRICULO_MEN_CBC_UBA. Bundles en questions_data/argentina/.",
+      "prs": [],
+      "issues": ["#231"],
+      "dependencies": ["feat-multi-country", "NAP alignment"],
+      "kpis": {
+        "bundles_generated": 3,
+        "total_questions": 30,
+        "country_readiness": "1.5%"
+      },
+      "risks": [
+        "Argentina tiene 24 jurisdicciones con variaciones curriculares",
+        "Voseo requiere adaptación lingüística de prompts"
+      ],
+      "status": "planned",
+      "priority": "P1",
+      "progress_pct": 10,
+      "verified_by": "Issue #231"
+    },
+    {
+      "id": "feat-pais-brasil",
+      "category": "expansion",
+      "description": "Expansión curricular Brasil: BNCC/ENEM, 3o ano Ensino Médio",
+      "tech_details": "Currículo brasileño: BNCC (Base Nacional Comum Curricular), ENEM (Exame Nacional do Ensino Médio). Formato especial: 3o-ano en lugar de grado-11. Moneda: BRL. Issue #235 BR_CURRICULO_BNCC_ENEM.",
+      "prs": [],
+      "issues": ["#235"],
+      "dependencies": ["feat-multi-country", "BNCC alignment"],
+      "kpis": {
+        "bundles_generated": 1,
+        "total_questions": 10,
+        "country_readiness": "0.5%"
+      },
+      "risks": [
+        "Portugués brasileño requiere generación con modelo especializado",
+        "ENEM es uno de los exámenes más grandes del mundo (8M+ estudiantes)"
+      ],
+      "status": "planned",
+      "priority": "P1",
+      "progress_pct": 5,
+      "verified_by": "Issue #235"
+    },
+    {
+      "id": "feat-ci-cd",
+      "category": "infra",
+      "description": "CI/CD con Playwright E2E, pre-commit hooks, validación automática de bundles",
+      "tech_details": "GitHub Actions con triggers en push/PR a main. Playwright con 48 tests E2E. Pre-commit hooks: prettier, eslint, validate-bundles. npm run validate para bundles v5.2.",
+      "prs": [],
+      "issues": [],
+      "dependencies": ["GitHub Actions", "Playwright", "pre-commit"],
+      "kpis": {
+        "e2e_tests": 48,
+        "test_pass_rate": "85%",
+        "ci_duration_min": 8
+      },
+      "risks": [
+        "16/30 tests pueden fallar por issues de configuración de entorno",
+        "Deploys son manuales (no en CI/CD) — riesgo de drift"
+      ],
+      "status": "active",
+      "priority": "P0",
+      "progress_pct": 100,
+      "verified_by": "GitHub Actions, 48 tests E2E"
+    },
+    {
+      "id": "feat-premium-api",
+      "category": "infra",
+      "description": "API Premium con API Keys, cuotas, rate limits y usage analytics",
+      "tech_details": "Tiers: Free (10 req/min, 10 preguntas/req), Pro (60 req/min, 50/req), Enterprise (300 req/min, 100/req). API Keys: prefijo wx_, hash SHA-256 en storage. Edge Functions: api-gateway, generate-key. Tablas: api_keys, usage_logs, organizations.",
+      "prs": [],
+      "issues": [],
+      "dependencies": ["Supabase Edge Functions", "api_keys table", "usage_logs table"],
+      "kpis": {
+        "active_api_keys": 3,
+        "organizations": 2,
+        "daily_api_requests": 500
+      },
+      "risks": [
+        "Deploy drift: /v1/questions no está usando las últimas Edge Functions",
+        "CORS actualmente en * — riesgo de seguridad"
+      ],
+      "status": "active",
+      "priority": "P0",
+      "progress_pct": 85,
+      "verified_by": "Edge Functions, api_keys table"
+    },
+    {
+      "id": "feat-country-readiness",
+      "category": "monitoring",
+      "description": "Auditoría automática de readiness por país (KPI: 2000 preguntas)",
+      "tech_details": "npm run audit:country-readiness con --json y --smoke-public. Estados: published_validated, validated_not_published, legacy_or_invalid, missing. Solo cuentan bundles en ruta canónica v5.2, validados y publicados como JSON.",
+      "prs": [],
+      "issues": [],
+      "dependencies": ["feat-weekly-packs", "feat-ci-cd", "generate-static-packs.js"],
+      "kpis": {
+        "countries_at_2000": 0,
+        "closest_country": "Colombia (90%)",
+        "total_published_questions": 1800
+      },
+      "risks": [
+        "2000 preguntas por país es una meta ambiciosa",
+        "Contenido legacy no cuenta — puede haber 3000+ preguntas legacy no contabilizadas"
+      ],
+      "status": "active",
+      "priority": "P1",
+      "progress_pct": 75,
+      "verified_by": "npm run audit:country-readiness"
+    },
+    {
+      "id": "feat-telegram-monitoring",
+      "category": "monitoring",
+      "description": "Monitoreo automático vía Telegram: reportes, alertas, estado del pipeline",
+      "tech_details": "Bot de Telegram envía reportes periódicos al CEO. Alertas de: bundles fallando validación, servicios caídos, readiness audit, PRs pendientes de revisión. Integración via Telegram Bot API.",
+      "prs": [],
+      "issues": [],
+      "dependencies": ["Telegram Bot API", "Cron jobs"],
+      "kpis": {
+        "reports_daily": 4,
+        "alert_response_time": "<5min"
+      },
+      "risks": [
+        "Dependencia de conectividad a Internet",
+        "Bot token debe rotarse periódicamente"
+      ],
+      "status": "active",
+      "priority": "P2",
+      "progress_pct": 100,
+      "verified_by": "Bot activo en @BeRi0n3"
+    },
+    {
+      "id": "feat-security",
+      "category": "security",
+      "description": "Limpieza de secrets expuestos en git history",
+      "tech_details": "GitHub Issue #221: secrets expuestos en git history de saberparatodos. Acción: escanear con git-filter-repo, force-push a todas las ramas, actualizar .gitignore. Pendiente de ejecución por impacto en colaboradores.",
+      "prs": [],
+      "issues": ["#221"],
+      "dependencies": ["git-filter-repo", "coordinaciín con colaboradores"],
+      "kpis": {},
+      "risks": [
+        "Force-push puede perder commits de otros colaboradores",
+        "Secrets ya expuestos en GitHub no se pueden eliminar del todo"
+      ],
+      "status": "pending",
+      "priority": "P1",
+      "progress_pct": 0,
+      "verified_by": "pending"
+    },
+    {
+      "id": "feat-tests",
+      "category": "testing",
+      "description": "Tests unitarios para IsarVectorStoreService + agent_memory",
+      "tech_details": "GitHub Issue #408: Implementar tests unitarios para IsarVectorStoreService y agent_memory store. Cobertura mínima: 70%. Framework: Vitest + Playwright.",
+      "prs": [],
+      "issues": ["#408"],
+      "dependencies": ["Vitest", "IsarVectorStoreService", "agent_memory"],
+      "kpis": {
+        "current_coverage": "20%",
+        "target_coverage": "70%"
+      },
+      "risks": [
+        "Baja prioridad vs features de expansión",
+        "Isar puede requerir mocking complejo"
+      ],
+      "status": "in_progress",
+      "priority": "P1",
+      "progress_pct": 20,
+      "verified_by": "Issue #408"
+    }
+  ]
+}

--- a/.gitcore/features.details/feat-weekly-packs/README.md
+++ b/.gitcore/features.details/feat-weekly-packs/README.md
@@ -1,0 +1,40 @@
+# 📅 feat-weekly-packs — WEEKLY packs semanales
+
+**Estado:** ✅ Activo | **Prioridad:** P0 | **Progreso:** 95%
+
+## Descripción
+
+Generación de packs semanales (W01-W40) por grado y país siguiendo el Protocolo v5.2.
+Secuencia curricular interna, no necesariamente alineada a calendarios oficiales nacionales.
+
+## Progreso por grado (Colombia)
+
+| Grado | W01-W10 | W11-W20 | W21-W30 | W31-W40 | Total |
+|-------|---------|---------|---------|---------|-------|
+| G6    | ✅ | ✅ | ✅ | 🔄 | 90% |
+| G7    | ✅ | ✅ | 🔄 | ⬜ | 60% |
+| G8    | ✅ | 🔄 | ⬜ | ⬜ | 30% |
+| G9    | ✅ | 🔄 | ⬜ | ⬜ | 30% |
+| G10   | 🔄 | ⬜ | ⬜ | ⬜ | 15% |
+| G11   | ✅ | ✅ | 🔄 | ⬜ | 50% |
+
+## KPIs
+
+| Métrica | Valor | Target |
+|---------|-------|--------|
+| Weekly packs Colombia G6 | ~35/40 | 40 |
+| Validación pasando | 95% | 100% |
+| Países con weekly | 1 (CO) | 4+ |
+
+## Requisitos vinculados
+
+- `docs/SRS/REQUIREMENTS.md` → SRS-FUN-002 (Validación automática)
+
+## Archivos relacionados
+
+- Naming convention: `AGENTS.md` (Bundle Protocol v5.2)
+- Validación: `npm run validate`
+
+---
+
+*Ver también: [features.json](../features.json) | [TASK.md](../planning/TASK.md)*

--- a/.gitcore/planning/GIT_SYNC_STATUS.md
+++ b/.gitcore/planning/GIT_SYNC_STATUS.md
@@ -1,0 +1,21 @@
+# Git sync status (2026-07-28)
+
+Local root: `/home/belal/proyectosSWAL/worldexams` on `main`.
+Remote `origin` (`iberi22/worldexams`): local was **1 commit behind** after `git fetch` during this program.
+
+## Empareje pendiente (no auto-merge)
+
+Working tree has large intentional multi-pista changes (protocol, social Revisar, informe, edge-mesh bridge, Jules wave0 issues).  
+**Do not hard-reset or force-push.** Recommended next step (human/Guardian):
+
+```bash
+cd /home/belal/proyectosSWAL/worldexams
+git status -sb
+# After review/commit of this work:
+git pull --rebase origin main   # or merge
+git push origin HEAD
+```
+
+Secondary remote `org-origin` (world-exams.github.io) is deploy/pages — sync only if release pipeline requires it.
+
+Jules wave0 issues created on GitHub: #808–#816 (see `.gitcore/planning/jules-wave0/`).

--- a/.gitcore/planning/jules-wave0/AR-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/AR-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Argentina - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/argentina/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/AR.md`
+5. `docs/specs/curriculums/argentina/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Argentina |
+| Codigo | AR |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/argentina/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `AR-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `AR-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `AR-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `AR-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `AR-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `AR-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `AR-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `AR-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `AR-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `AR-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/argentina/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate AR matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/BO-ciencias-naturales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/BO-ciencias-naturales-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Bolivia - ciencias-naturales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/bolivia/ciencias-naturales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla BO); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/bolivia/ciencias-naturales/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/BO.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/bolivia/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Bolivia |
+| Codigo | BO |
+| Asignatura | ciencias-naturales |
+| Subject code | CIE |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/bolivia/ciencias-naturales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `BO-CIE-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `BO-CIE-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `BO-CIE-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `BO-CIE-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `BO-CIE-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `BO-CIE-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `BO-CIE-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `BO-CIE-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `BO-CIE-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `BO-CIE-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/bolivia/ciencias-naturales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate BO ciencias-naturales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/BO-lengua-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/BO-lengua-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Bolivia - lengua 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/bolivia/lengua/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/BO.md`
+5. `docs/specs/curriculums/bolivia/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Bolivia |
+| Codigo | BO |
+| Asignatura | lengua |
+| Subject code | LEN |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/bolivia/lengua/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `BO-LEN-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `BO-LEN-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `BO-LEN-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `BO-LEN-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `BO-LEN-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `BO-LEN-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `BO-LEN-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `BO-LEN-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `BO-LEN-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `BO-LEN-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/bolivia/lengua/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate BO lengua G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/BO-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/BO-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Bolivia - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/bolivia/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/BO.md`
+5. `docs/specs/curriculums/bolivia/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Bolivia |
+| Codigo | BO |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/bolivia/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `BO-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `BO-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `BO-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `BO-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `BO-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `BO-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `BO-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `BO-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `BO-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `BO-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/bolivia/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate BO matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/BO-sociales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/BO-sociales-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Bolivia - sociales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/bolivia/sociales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla BO); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/bolivia/sociales/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/BO.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/bolivia/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Bolivia |
+| Codigo | BO |
+| Asignatura | sociales |
+| Subject code | SOC |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/bolivia/sociales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `BO-SOC-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `BO-SOC-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `BO-SOC-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `BO-SOC-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `BO-SOC-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `BO-SOC-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `BO-SOC-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `BO-SOC-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `BO-SOC-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `BO-SOC-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/bolivia/sociales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate BO sociales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/BR-matematica-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/BR-matematica-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Brasil - matematica 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/brasil/matematica/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/BR.md`
+5. `docs/specs/curriculums/brasil/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Brasil |
+| Codigo | BR |
+| Asignatura | matematica |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/brasil/matematica/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `BR-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `BR-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `BR-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `BR-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `BR-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `BR-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `BR-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `BR-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `BR-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `BR-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/brasil/matematica/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate BR matematica G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/BR-matematica-G11-W11-W20.md
+++ b/.gitcore/planning/jules-wave0/BR-matematica-G11-W11-W20.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Brasil - matematica 11 - W11-W20 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/brasil/matematica/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla BR); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/brasil/matematica/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/BR.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/brasil/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Brasil |
+| Codigo | BR |
+| Asignatura | matematica |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/brasil/matematica/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W11 | tema-w11 | `BR-MAT-11-2026-W11-tema-w11-001-MASTERY-bundle.md` |
+| 2 | W12 | tema-w12 | `BR-MAT-11-2026-W12-tema-w12-001-MASTERY-bundle.md` |
+| 3 | W13 | tema-w13 | `BR-MAT-11-2026-W13-tema-w13-001-MASTERY-bundle.md` |
+| 4 | W14 | tema-w14 | `BR-MAT-11-2026-W14-tema-w14-001-MASTERY-bundle.md` |
+| 5 | W15 | tema-w15 | `BR-MAT-11-2026-W15-tema-w15-001-MASTERY-bundle.md` |
+| 6 | W16 | tema-w16 | `BR-MAT-11-2026-W16-tema-w16-001-MASTERY-bundle.md` |
+| 7 | W17 | tema-w17 | `BR-MAT-11-2026-W17-tema-w17-001-MASTERY-bundle.md` |
+| 8 | W18 | tema-w18 | `BR-MAT-11-2026-W18-tema-w18-001-MASTERY-bundle.md` |
+| 9 | W19 | tema-w19 | `BR-MAT-11-2026-W19-tema-w19-001-MASTERY-bundle.md` |
+| 10 | W20 | tema-w20 | `BR-MAT-11-2026-W20-tema-w20-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/brasil/matematica/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate BR matematica G11 W11-W20</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/BR-portugues-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/BR-portugues-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Brasil - portugues 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/brasil/portugues/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla BR); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/brasil/portugues/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/BR.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/brasil/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Brasil |
+| Codigo | BR |
+| Asignatura | portugues |
+| Subject code | POR |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/brasil/portugues/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `BR-POR-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `BR-POR-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `BR-POR-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `BR-POR-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `BR-POR-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `BR-POR-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `BR-POR-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `BR-POR-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `BR-POR-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `BR-POR-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/brasil/portugues/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate BR portugues G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/CL-ciencias-naturales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/CL-ciencias-naturales-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Chile - ciencias-naturales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/chile/ciencias-naturales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla CL); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/chile/ciencias-naturales/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/CL.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/chile/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Chile |
+| Codigo | CL |
+| Asignatura | ciencias-naturales |
+| Subject code | CIE |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/chile/ciencias-naturales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `CL-CIE-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `CL-CIE-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `CL-CIE-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `CL-CIE-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `CL-CIE-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `CL-CIE-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `CL-CIE-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `CL-CIE-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `CL-CIE-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `CL-CIE-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/chile/ciencias-naturales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate CL ciencias-naturales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/CL-historia-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/CL-historia-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Chile - historia 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/chile/historia/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla CL); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/chile/historia/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/CL.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/chile/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Chile |
+| Codigo | CL |
+| Asignatura | historia |
+| Subject code | HIS |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/chile/historia/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `CL-HIS-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `CL-HIS-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `CL-HIS-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `CL-HIS-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `CL-HIS-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `CL-HIS-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `CL-HIS-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `CL-HIS-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `CL-HIS-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `CL-HIS-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/chile/historia/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate CL historia G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/CL-lenguaje-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/CL-lenguaje-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Chile - lenguaje 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/chile/lenguaje/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/CL.md`
+5. `docs/specs/curriculums/chile/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Chile |
+| Codigo | CL |
+| Asignatura | lenguaje |
+| Subject code | LEN |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/chile/lenguaje/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `CL-LEN-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `CL-LEN-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `CL-LEN-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `CL-LEN-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `CL-LEN-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `CL-LEN-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `CL-LEN-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `CL-LEN-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `CL-LEN-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `CL-LEN-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/chile/lenguaje/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate CL lenguaje G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/CL-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/CL-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Chile - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/chile/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/CL.md`
+5. `docs/specs/curriculums/chile/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Chile |
+| Codigo | CL |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/chile/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `CL-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `CL-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `CL-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `CL-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `CL-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `CL-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `CL-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `CL-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `CL-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `CL-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/chile/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate CL matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/CR-ciencias-naturales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/CR-ciencias-naturales-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Costa Rica - ciencias-naturales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/costarica/ciencias-naturales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/CR.md`
+5. `docs/specs/curriculums/costarica/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Costa Rica |
+| Codigo | CR |
+| Asignatura | ciencias-naturales |
+| Subject code | CIE |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/costarica/ciencias-naturales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `CR-CIE-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `CR-CIE-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `CR-CIE-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `CR-CIE-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `CR-CIE-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `CR-CIE-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `CR-CIE-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `CR-CIE-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `CR-CIE-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `CR-CIE-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/costarica/ciencias-naturales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate CR ciencias-naturales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/CR-estudios-sociales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/CR-estudios-sociales-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Costa Rica - estudios-sociales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/costarica/estudios-sociales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/CR.md`
+5. `docs/specs/curriculums/costarica/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Costa Rica |
+| Codigo | CR |
+| Asignatura | estudios-sociales |
+| Subject code | SOC |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/costarica/estudios-sociales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `CR-SOC-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `CR-SOC-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `CR-SOC-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `CR-SOC-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `CR-SOC-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `CR-SOC-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `CR-SOC-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `CR-SOC-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `CR-SOC-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `CR-SOC-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/costarica/estudios-sociales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate CR estudios-sociales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/CR-lengua-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/CR-lengua-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Costa Rica - lengua 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/costarica/lengua/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/CR.md`
+5. `docs/specs/curriculums/costarica/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Costa Rica |
+| Codigo | CR |
+| Asignatura | lengua |
+| Subject code | LEN |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/costarica/lengua/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `CR-LEN-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `CR-LEN-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `CR-LEN-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `CR-LEN-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `CR-LEN-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `CR-LEN-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `CR-LEN-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `CR-LEN-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `CR-LEN-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `CR-LEN-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/costarica/lengua/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate CR lengua G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/CR-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/CR-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Costa Rica - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/costarica/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/CR.md`
+5. `docs/specs/curriculums/costarica/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Costa Rica |
+| Codigo | CR |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/costarica/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `CR-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `CR-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `CR-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `CR-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `CR-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `CR-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `CR-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `CR-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `CR-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `CR-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/costarica/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate CR matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/EC-lengua-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/EC-lengua-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Ecuador - lengua 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/ecuador/lengua/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla EC); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/ecuador/lengua/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/EC.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/ecuador/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Ecuador |
+| Codigo | EC |
+| Asignatura | lengua |
+| Subject code | LEN |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/ecuador/lengua/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `EC-LEN-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `EC-LEN-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `EC-LEN-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `EC-LEN-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `EC-LEN-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `EC-LEN-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `EC-LEN-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `EC-LEN-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `EC-LEN-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `EC-LEN-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/ecuador/lengua/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate EC lengua G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/EC-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/EC-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Ecuador - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/ecuador/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/EC.md`
+5. `docs/specs/curriculums/ecuador/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Ecuador |
+| Codigo | EC |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/ecuador/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `EC-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `EC-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `EC-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `EC-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `EC-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `EC-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `EC-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `EC-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `EC-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `EC-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/ecuador/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate EC matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/EC-matematicas-G11-W11-W20.md
+++ b/.gitcore/planning/jules-wave0/EC-matematicas-G11-W11-W20.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Ecuador - matematicas 11 - W11-W20 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/ecuador/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla EC); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/ecuador/matematicas/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/EC.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/ecuador/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Ecuador |
+| Codigo | EC |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/ecuador/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W11 | tema-w11 | `EC-MAT-11-2026-W11-tema-w11-001-MASTERY-bundle.md` |
+| 2 | W12 | tema-w12 | `EC-MAT-11-2026-W12-tema-w12-001-MASTERY-bundle.md` |
+| 3 | W13 | tema-w13 | `EC-MAT-11-2026-W13-tema-w13-001-MASTERY-bundle.md` |
+| 4 | W14 | tema-w14 | `EC-MAT-11-2026-W14-tema-w14-001-MASTERY-bundle.md` |
+| 5 | W15 | tema-w15 | `EC-MAT-11-2026-W15-tema-w15-001-MASTERY-bundle.md` |
+| 6 | W16 | tema-w16 | `EC-MAT-11-2026-W16-tema-w16-001-MASTERY-bundle.md` |
+| 7 | W17 | tema-w17 | `EC-MAT-11-2026-W17-tema-w17-001-MASTERY-bundle.md` |
+| 8 | W18 | tema-w18 | `EC-MAT-11-2026-W18-tema-w18-001-MASTERY-bundle.md` |
+| 9 | W19 | tema-w19 | `EC-MAT-11-2026-W19-tema-w19-001-MASTERY-bundle.md` |
+| 10 | W20 | tema-w20 | `EC-MAT-11-2026-W20-tema-w20-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/ecuador/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate EC matematicas G11 W11-W20</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/ES-lengua-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/ES-lengua-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Espana - lengua 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/spain/lengua/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla ES); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/spain/lengua/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/ES.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/spain/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Espana |
+| Codigo | ES |
+| Asignatura | lengua |
+| Subject code | LEN |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/spain/lengua/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `ES-LEN-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `ES-LEN-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `ES-LEN-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `ES-LEN-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `ES-LEN-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `ES-LEN-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `ES-LEN-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `ES-LEN-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `ES-LEN-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `ES-LEN-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/spain/lengua/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate ES lengua G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/ES-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/ES-matematicas-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Espana - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/spain/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla ES); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/spain/matematicas/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/ES.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/spain/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Espana |
+| Codigo | ES |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/spain/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `ES-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `ES-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `ES-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `ES-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `ES-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `ES-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `ES-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `ES-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `ES-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `ES-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/spain/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate ES matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/MX-lectura-critica-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/MX-lectura-critica-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Mexico - lectura-critica 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/mexico/lectura-critica/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/MX.md`
+5. `docs/specs/curriculums/mexico/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Mexico |
+| Codigo | MX |
+| Asignatura | lectura-critica |
+| Subject code | LC |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/mexico/lectura-critica/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `MX-LC-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `MX-LC-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `MX-LC-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `MX-LC-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `MX-LC-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `MX-LC-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `MX-LC-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `MX-LC-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `MX-LC-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `MX-LC-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/mexico/lectura-critica/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate MX lectura-critica G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/MX-lectura-critica-G11-W11-W20.md
+++ b/.gitcore/planning/jules-wave0/MX-lectura-critica-G11-W11-W20.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Mexico - lectura-critica 11 - W11-W20 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/mexico/lectura-critica/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla MX); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/mexico/lectura-critica/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/MX.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/mexico/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Mexico |
+| Codigo | MX |
+| Asignatura | lectura-critica |
+| Subject code | LC |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/mexico/lectura-critica/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W11 | tema-w11 | `MX-LC-11-2026-W11-tema-w11-001-MASTERY-bundle.md` |
+| 2 | W12 | tema-w12 | `MX-LC-11-2026-W12-tema-w12-001-MASTERY-bundle.md` |
+| 3 | W13 | tema-w13 | `MX-LC-11-2026-W13-tema-w13-001-MASTERY-bundle.md` |
+| 4 | W14 | tema-w14 | `MX-LC-11-2026-W14-tema-w14-001-MASTERY-bundle.md` |
+| 5 | W15 | tema-w15 | `MX-LC-11-2026-W15-tema-w15-001-MASTERY-bundle.md` |
+| 6 | W16 | tema-w16 | `MX-LC-11-2026-W16-tema-w16-001-MASTERY-bundle.md` |
+| 7 | W17 | tema-w17 | `MX-LC-11-2026-W17-tema-w17-001-MASTERY-bundle.md` |
+| 8 | W18 | tema-w18 | `MX-LC-11-2026-W18-tema-w18-001-MASTERY-bundle.md` |
+| 9 | W19 | tema-w19 | `MX-LC-11-2026-W19-tema-w19-001-MASTERY-bundle.md` |
+| 10 | W20 | tema-w20 | `MX-LC-11-2026-W20-tema-w20-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/mexico/lectura-critica/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate MX lectura-critica G11 W11-W20</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/MX-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/MX-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Mexico - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/mexico/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/MX.md`
+5. `docs/specs/curriculums/mexico/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Mexico |
+| Codigo | MX |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/mexico/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `MX-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `MX-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `MX-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `MX-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `MX-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `MX-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `MX-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `MX-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `MX-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `MX-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/mexico/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate MX matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/MX-matematicas-G11-W11-W20.md
+++ b/.gitcore/planning/jules-wave0/MX-matematicas-G11-W11-W20.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Mexico - matematicas 11 - W11-W20 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/mexico/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla MX); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/mexico/matematicas/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/MX.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/mexico/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Mexico |
+| Codigo | MX |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/mexico/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W11 | tema-w11 | `MX-MAT-11-2026-W11-tema-w11-001-MASTERY-bundle.md` |
+| 2 | W12 | tema-w12 | `MX-MAT-11-2026-W12-tema-w12-001-MASTERY-bundle.md` |
+| 3 | W13 | tema-w13 | `MX-MAT-11-2026-W13-tema-w13-001-MASTERY-bundle.md` |
+| 4 | W14 | tema-w14 | `MX-MAT-11-2026-W14-tema-w14-001-MASTERY-bundle.md` |
+| 5 | W15 | tema-w15 | `MX-MAT-11-2026-W15-tema-w15-001-MASTERY-bundle.md` |
+| 6 | W16 | tema-w16 | `MX-MAT-11-2026-W16-tema-w16-001-MASTERY-bundle.md` |
+| 7 | W17 | tema-w17 | `MX-MAT-11-2026-W17-tema-w17-001-MASTERY-bundle.md` |
+| 8 | W18 | tema-w18 | `MX-MAT-11-2026-W18-tema-w18-001-MASTERY-bundle.md` |
+| 9 | W19 | tema-w19 | `MX-MAT-11-2026-W19-tema-w19-001-MASTERY-bundle.md` |
+| 10 | W20 | tema-w20 | `MX-MAT-11-2026-W20-tema-w20-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/mexico/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate MX matematicas G11 W11-W20</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PE-comunicacion-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/PE-comunicacion-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Peru - comunicacion 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/peru/comunicacion/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PE.md`
+5. `docs/specs/curriculums/peru/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Peru |
+| Codigo | PE |
+| Asignatura | comunicacion |
+| Subject code | COM |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/peru/comunicacion/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `PE-COM-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `PE-COM-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `PE-COM-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `PE-COM-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `PE-COM-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `PE-COM-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `PE-COM-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `PE-COM-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `PE-COM-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `PE-COM-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/peru/comunicacion/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PE comunicacion G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PE-comunicacion-G11-W11-W20.md
+++ b/.gitcore/planning/jules-wave0/PE-comunicacion-G11-W11-W20.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Peru - comunicacion 11 - W11-W20 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/peru/comunicacion/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla PE); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/peru/comunicacion/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PE.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/peru/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Peru |
+| Codigo | PE |
+| Asignatura | comunicacion |
+| Subject code | COM |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/peru/comunicacion/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W11 | tema-w11 | `PE-COM-11-2026-W11-tema-w11-001-MASTERY-bundle.md` |
+| 2 | W12 | tema-w12 | `PE-COM-11-2026-W12-tema-w12-001-MASTERY-bundle.md` |
+| 3 | W13 | tema-w13 | `PE-COM-11-2026-W13-tema-w13-001-MASTERY-bundle.md` |
+| 4 | W14 | tema-w14 | `PE-COM-11-2026-W14-tema-w14-001-MASTERY-bundle.md` |
+| 5 | W15 | tema-w15 | `PE-COM-11-2026-W15-tema-w15-001-MASTERY-bundle.md` |
+| 6 | W16 | tema-w16 | `PE-COM-11-2026-W16-tema-w16-001-MASTERY-bundle.md` |
+| 7 | W17 | tema-w17 | `PE-COM-11-2026-W17-tema-w17-001-MASTERY-bundle.md` |
+| 8 | W18 | tema-w18 | `PE-COM-11-2026-W18-tema-w18-001-MASTERY-bundle.md` |
+| 9 | W19 | tema-w19 | `PE-COM-11-2026-W19-tema-w19-001-MASTERY-bundle.md` |
+| 10 | W20 | tema-w20 | `PE-COM-11-2026-W20-tema-w20-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/peru/comunicacion/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PE comunicacion G11 W11-W20</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PE-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/PE-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Peru - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/peru/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PE.md`
+5. `docs/specs/curriculums/peru/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Peru |
+| Codigo | PE |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/peru/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `PE-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `PE-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `PE-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `PE-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `PE-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `PE-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `PE-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `PE-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `PE-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `PE-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/peru/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PE matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PE-matematicas-G11-W11-W20.md
+++ b/.gitcore/planning/jules-wave0/PE-matematicas-G11-W11-W20.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Peru - matematicas 11 - W11-W20 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/peru/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla PE); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/peru/matematicas/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PE.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/peru/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Peru |
+| Codigo | PE |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/peru/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W11 | tema-w11 | `PE-MAT-11-2026-W11-tema-w11-001-MASTERY-bundle.md` |
+| 2 | W12 | tema-w12 | `PE-MAT-11-2026-W12-tema-w12-001-MASTERY-bundle.md` |
+| 3 | W13 | tema-w13 | `PE-MAT-11-2026-W13-tema-w13-001-MASTERY-bundle.md` |
+| 4 | W14 | tema-w14 | `PE-MAT-11-2026-W14-tema-w14-001-MASTERY-bundle.md` |
+| 5 | W15 | tema-w15 | `PE-MAT-11-2026-W15-tema-w15-001-MASTERY-bundle.md` |
+| 6 | W16 | tema-w16 | `PE-MAT-11-2026-W16-tema-w16-001-MASTERY-bundle.md` |
+| 7 | W17 | tema-w17 | `PE-MAT-11-2026-W17-tema-w17-001-MASTERY-bundle.md` |
+| 8 | W18 | tema-w18 | `PE-MAT-11-2026-W18-tema-w18-001-MASTERY-bundle.md` |
+| 9 | W19 | tema-w19 | `PE-MAT-11-2026-W19-tema-w19-001-MASTERY-bundle.md` |
+| 10 | W20 | tema-w20 | `PE-MAT-11-2026-W20-tema-w20-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/peru/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PE matematicas G11 W11-W20</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PR-ciencias-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/PR-ciencias-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Puerto Rico - ciencias 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/puerto-rico/ciencias/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla PR); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/puerto-rico/ciencias/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PR.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/puerto-rico/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Puerto Rico |
+| Codigo | PR |
+| Asignatura | ciencias |
+| Subject code | CIE |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/puerto-rico/ciencias/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `PR-CIE-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `PR-CIE-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `PR-CIE-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `PR-CIE-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `PR-CIE-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `PR-CIE-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `PR-CIE-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `PR-CIE-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `PR-CIE-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `PR-CIE-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/puerto-rico/ciencias/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PR ciencias G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PR-espanol-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/PR-espanol-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Puerto Rico - espanol 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/puerto-rico/espanol/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PR.md`
+5. `docs/specs/curriculums/puerto-rico/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Puerto Rico |
+| Codigo | PR |
+| Asignatura | espanol |
+| Subject code | ESP |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/puerto-rico/espanol/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `PR-ESP-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `PR-ESP-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `PR-ESP-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `PR-ESP-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `PR-ESP-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `PR-ESP-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `PR-ESP-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `PR-ESP-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `PR-ESP-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `PR-ESP-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/puerto-rico/espanol/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PR espanol G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PR-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/PR-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Puerto Rico - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/puerto-rico/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PR.md`
+5. `docs/specs/curriculums/puerto-rico/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Puerto Rico |
+| Codigo | PR |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/puerto-rico/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `PR-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `PR-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `PR-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `PR-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `PR-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `PR-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `PR-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `PR-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `PR-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `PR-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/puerto-rico/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PR matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PR-matematicas-G11-W11-W20.md
+++ b/.gitcore/planning/jules-wave0/PR-matematicas-G11-W11-W20.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Puerto Rico - matematicas 11 - W11-W20 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/puerto-rico/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla PR); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/puerto-rico/matematicas/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PR.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/puerto-rico/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Puerto Rico |
+| Codigo | PR |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/puerto-rico/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W11 | tema-w11 | `PR-MAT-11-2026-W11-tema-w11-001-MASTERY-bundle.md` |
+| 2 | W12 | tema-w12 | `PR-MAT-11-2026-W12-tema-w12-001-MASTERY-bundle.md` |
+| 3 | W13 | tema-w13 | `PR-MAT-11-2026-W13-tema-w13-001-MASTERY-bundle.md` |
+| 4 | W14 | tema-w14 | `PR-MAT-11-2026-W14-tema-w14-001-MASTERY-bundle.md` |
+| 5 | W15 | tema-w15 | `PR-MAT-11-2026-W15-tema-w15-001-MASTERY-bundle.md` |
+| 6 | W16 | tema-w16 | `PR-MAT-11-2026-W16-tema-w16-001-MASTERY-bundle.md` |
+| 7 | W17 | tema-w17 | `PR-MAT-11-2026-W17-tema-w17-001-MASTERY-bundle.md` |
+| 8 | W18 | tema-w18 | `PR-MAT-11-2026-W18-tema-w18-001-MASTERY-bundle.md` |
+| 9 | W19 | tema-w19 | `PR-MAT-11-2026-W19-tema-w19-001-MASTERY-bundle.md` |
+| 10 | W20 | tema-w20 | `PR-MAT-11-2026-W20-tema-w20-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/puerto-rico/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PR matematicas G11 W11-W20</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PY-ciencias-naturales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/PY-ciencias-naturales-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Paraguay - ciencias-naturales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/paraguay/ciencias-naturales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla PY); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/paraguay/ciencias-naturales/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PY.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/paraguay/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Paraguay |
+| Codigo | PY |
+| Asignatura | ciencias-naturales |
+| Subject code | CIE |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/paraguay/ciencias-naturales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `PY-CIE-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `PY-CIE-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `PY-CIE-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `PY-CIE-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `PY-CIE-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `PY-CIE-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `PY-CIE-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `PY-CIE-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `PY-CIE-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `PY-CIE-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/paraguay/ciencias-naturales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PY ciencias-naturales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PY-lengua-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/PY-lengua-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Paraguay - lengua 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/paraguay/lengua/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PY.md`
+5. `docs/specs/curriculums/paraguay/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Paraguay |
+| Codigo | PY |
+| Asignatura | lengua |
+| Subject code | LEN |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/paraguay/lengua/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `PY-LEN-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `PY-LEN-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `PY-LEN-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `PY-LEN-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `PY-LEN-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `PY-LEN-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `PY-LEN-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `PY-LEN-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `PY-LEN-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `PY-LEN-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/paraguay/lengua/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PY lengua G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PY-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/PY-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Paraguay - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/paraguay/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PY.md`
+5. `docs/specs/curriculums/paraguay/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Paraguay |
+| Codigo | PY |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/paraguay/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `PY-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `PY-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `PY-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `PY-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `PY-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `PY-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `PY-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `PY-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `PY-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `PY-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/paraguay/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PY matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/PY-sociales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/PY-sociales-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Paraguay - sociales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/paraguay/sociales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla PY); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/paraguay/sociales/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/PY.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/paraguay/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Paraguay |
+| Codigo | PY |
+| Asignatura | sociales |
+| Subject code | SOC |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/paraguay/sociales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `PY-SOC-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `PY-SOC-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `PY-SOC-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `PY-SOC-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `PY-SOC-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `PY-SOC-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `PY-SOC-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `PY-SOC-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `PY-SOC-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `PY-SOC-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/paraguay/sociales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate PY sociales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/SV-ciencias-naturales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/SV-ciencias-naturales-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] El Salvador - ciencias-naturales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/el-salvador/ciencias-naturales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla SV); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/el-salvador/ciencias-naturales/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/SV.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/el-salvador/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | El Salvador |
+| Codigo | SV |
+| Asignatura | ciencias-naturales |
+| Subject code | CIE |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/el-salvador/ciencias-naturales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `SV-CIE-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `SV-CIE-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `SV-CIE-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `SV-CIE-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `SV-CIE-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `SV-CIE-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `SV-CIE-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `SV-CIE-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `SV-CIE-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `SV-CIE-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/el-salvador/ciencias-naturales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate SV ciencias-naturales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/SV-lengua-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/SV-lengua-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] El Salvador - lengua 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/el-salvador/lengua/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/SV.md`
+5. `docs/specs/curriculums/el-salvador/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | El Salvador |
+| Codigo | SV |
+| Asignatura | lengua |
+| Subject code | LEN |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/el-salvador/lengua/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `SV-LEN-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `SV-LEN-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `SV-LEN-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `SV-LEN-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `SV-LEN-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `SV-LEN-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `SV-LEN-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `SV-LEN-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `SV-LEN-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `SV-LEN-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/el-salvador/lengua/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate SV lengua G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/SV-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/SV-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] El Salvador - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/el-salvador/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/SV.md`
+5. `docs/specs/curriculums/el-salvador/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | El Salvador |
+| Codigo | SV |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/el-salvador/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `SV-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `SV-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `SV-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `SV-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `SV-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `SV-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `SV-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `SV-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `SV-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `SV-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/el-salvador/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate SV matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/UY-ciencias-naturales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/UY-ciencias-naturales-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Uruguay - ciencias-naturales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/uruguay/ciencias-naturales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla UY); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/uruguay/ciencias-naturales/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/UY.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/uruguay/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Uruguay |
+| Codigo | UY |
+| Asignatura | ciencias-naturales |
+| Subject code | CIE |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/uruguay/ciencias-naturales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `UY-CIE-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `UY-CIE-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `UY-CIE-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `UY-CIE-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `UY-CIE-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `UY-CIE-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `UY-CIE-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `UY-CIE-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `UY-CIE-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `UY-CIE-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/uruguay/ciencias-naturales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate UY ciencias-naturales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/UY-lengua-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/UY-lengua-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Uruguay - lengua 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/uruguay/lengua/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/UY.md`
+5. `docs/specs/curriculums/uruguay/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Uruguay |
+| Codigo | UY |
+| Asignatura | lengua |
+| Subject code | LEN |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/uruguay/lengua/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `UY-LEN-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `UY-LEN-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `UY-LEN-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `UY-LEN-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `UY-LEN-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `UY-LEN-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `UY-LEN-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `UY-LEN-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `UY-LEN-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `UY-LEN-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/uruguay/lengua/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate UY lengua G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/UY-matematicas-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/UY-matematicas-G11-W1-W10.md
@@ -1,0 +1,66 @@
+---
+title: "[JULES] Uruguay - matematicas 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/uruguay/matematicas/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}`.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/UY.md`
+5. `docs/specs/curriculums/uruguay/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Uruguay |
+| Codigo | UY |
+| Asignatura | matematicas |
+| Subject code | MAT |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/uruguay/matematicas/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `UY-MAT-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `UY-MAT-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `UY-MAT-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `UY-MAT-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `UY-MAT-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `UY-MAT-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `UY-MAT-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `UY-MAT-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `UY-MAT-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `UY-MAT-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/uruguay/matematicas/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate UY matematicas G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/.gitcore/planning/jules-wave0/UY-sociales-G11-W1-W10.md
+++ b/.gitcore/planning/jules-wave0/UY-sociales-G11-W1-W10.md
@@ -1,0 +1,77 @@
+---
+title: "[JULES] Uruguay - sociales 11 - W01-W10 (10 bundles)"
+labels: ["jules", "generate-questions", "ai-agent", "stage:planning"]
+---
+
+## Reglas criticas para Jules
+
+- Maximo 15 bundles; este lote tiene **10**.
+- No regenerar existentes salvo `REPLACE`.
+- Solo archivos `.md` en `questions_data/uruguay/sociales/grado-11/2026/weekly/`.
+- Validar: `npm run validate -- {archivos}` en **0 fallos** antes de comentar.
+- Comentar: `[OK] Generados N bundles: ...`.
+
+## Anti-errores (purga 2026-07-28 — docs/specs/CONTENT_ERRORS.md)
+
+1. Eje por pregunta: `**EJE:**` — ICFES PROHIBIDO fuera de Colombia.
+2. `alignment`: entidad oficial del país (ver regla UY); NUNCA ICFES/Saber/DBA.
+3. Ruta EXACTA `questions_data/uruguay/sociales/grado-11/2026/weekly/` — carpeta = nombre completo del país; no crear variantes.
+4. Frontmatter: 15 campos de AGENTS.md; `week: "WNN"` (nunca `semana:`); `id` = filename sin `.md`.
+5. `## Question N [D#]` (nunca `## Pregunta`); `### Enunciado/Opciones/Explicacion Pedagogica`; `**Contexto:**` (nunca `Context`).
+6. Sin placeholders ("Distractor N", "Opcion correcta", "tema-semana-NN"); opciones únicas; feedback en las 4 opciones.
+7. Tras validar: `node saberparatodos/scripts/generate-static-packs.js --all-weekly --changed-only` + `npm run audit:country-readiness`.
+
+## Skills y protocolo (obligatorio)
+
+1. `AGENTS.md` (v5.2)
+2. `skills/worldexams-bundle-generator/SKILL.md`
+3. `skills/bundle-creator/SKILL.md`
+4. `skills/bundle-creator/rules/UY.md` (incluye Anti-Error Checklist del país)
+5. `docs/specs/curriculums/uruguay/README.md` (si existe)
+6. `docs/HERMES_JULES_WORKFLOW.md`
+7. `docs/specs/ACTIVE_PROTOCOLS.md`
+8. `docs/specs/CONTENT_ERRORS.md`
+
+## Configuracion
+
+| Campo | Valor |
+|-------|-------|
+| Pais | Uruguay |
+| Codigo | UY |
+| Asignatura | sociales |
+| Subject code | SOC |
+| Grado | 11 |
+| Ano | 2026 |
+| Protocolo | v5.2 |
+| Preguntas/bundle | 20 |
+| Ruta | `questions_data/uruguay/sociales/grado-11/2026/weekly/` |
+
+## Bundles a generar
+
+| # | Week | Tema | Archivo |
+|---|------|------|---------|
+| 1 | W01 | tema-w01 | `UY-SOC-11-2026-W01-tema-w01-001-MASTERY-bundle.md` |
+| 2 | W02 | tema-w02 | `UY-SOC-11-2026-W02-tema-w02-001-MASTERY-bundle.md` |
+| 3 | W03 | tema-w03 | `UY-SOC-11-2026-W03-tema-w03-001-MASTERY-bundle.md` |
+| 4 | W04 | tema-w04 | `UY-SOC-11-2026-W04-tema-w04-001-MASTERY-bundle.md` |
+| 5 | W05 | tema-w05 | `UY-SOC-11-2026-W05-tema-w05-001-MASTERY-bundle.md` |
+| 6 | W06 | tema-w06 | `UY-SOC-11-2026-W06-tema-w06-001-MASTERY-bundle.md` |
+| 7 | W07 | tema-w07 | `UY-SOC-11-2026-W07-tema-w07-001-MASTERY-bundle.md` |
+| 8 | W08 | tema-w08 | `UY-SOC-11-2026-W08-tema-w08-001-MASTERY-bundle.md` |
+| 9 | W09 | tema-w09 | `UY-SOC-11-2026-W09-tema-w09-001-MASTERY-bundle.md` |
+| 10 | W10 | tema-w10 | `UY-SOC-11-2026-W10-tema-w10-001-MASTERY-bundle.md` |
+
+## Ownership path (anti-conflicto)
+
+Jules solo toca archivos listados bajo `questions_data/uruguay/sociales/grado-11/2026/weekly/`. No mezclar otros paises/materias/grados.
+
+<agent-state>
+  <intent>Generate UY sociales G11 W01-W10</intent>
+  <step>planning</step>
+  <plan>
+    - [pending] Read skills + country rule
+    - [pending] Generate 10 weekly MASTERY bundles
+    - [pending] npm run validate
+    - [pending] Comment [OK] and open PR
+  </plan>
+</agent-state>

--- a/docs/HERMES_JULES_WORKFLOW.md
+++ b/docs/HERMES_JULES_WORKFLOW.md
@@ -1,0 +1,48 @@
+# Hermes × Jules — WorldExams content workflow
+
+> Integrated from SWAL assembly line (`docs/SWAL/ASSEMBLY_LINE.md`) + WorldExams `AGENTS.md` + `.github/ISSUE_TEMPLATE/jules-bundle-generation.md`.
+> Authority for new bundles: **protocol v5.2** only (`npm run validate`).
+
+## Roles
+
+| Role | Runtime | WorldExams action |
+|------|---------|-------------------|
+| Planner | Hermes | Create atomic Jules issues from curriculum maps; write `<agent-state>` |
+| Router | Hermes | Labels `ai-agent` + `stage:coding` + `jules`; zero path overlap in wave |
+| Implementer | Jules | Generate `.md` bundles only; validate; comment `[OK] Generados N bundles` |
+| Reviewer | OpenClaw | PR review (content PRs ≠ code PRs) |
+| Guardian | Hermes | Merge if feature-verify / validate OK |
+| Evaluator | OpenClaw | `npm run audit:country-readiness` smoke |
+
+## Issue rules (anti-conflict)
+
+1. **One issue = one country + one subject + one grade + week range ≤15 bundles.**
+2. Title: `[JULES] {PAIS} - {ASIGNATURA} {GRADO} - W{NN}-W{NN} ({N} bundles)`
+3. Labels: `jules`, `generate-questions`, `ai-agent`, `stage:planning` → `stage:coding`
+4. Must link: `AGENTS.md`, `skills/worldexams-bundle-generator/SKILL.md`, `skills/bundle-creator/SKILL.md`, `skills/bundle-creator/rules/{CODE}.md`, curriculum map
+5. Path ownership: Jules only touches listed files under `questions_data/{pais}/{asignatura}/grado-{N}/2026/weekly/`
+6. No regenerate unless issue says `REPLACE`
+7. Hermes waves: **14–15 issues/batch**, **zero overlapping paths**
+8. State lives in the issue (`<agent-state>`), not Hermes chat
+
+## Wave order
+
+1. Foundation (rules/README/schedules) — Hermes/Cursor, not Jules
+2. G11 core subjects per country
+3. Mid grades
+4. Primary grades
+5. Static packs + readiness audit (integrator, not Jules)
+
+## Script
+
+Generate issue markdown locally:
+
+```bash
+node scripts/generate-jules-issue-matrix.mjs --country PE --grade 11 --subject matematicas --from 1 --to 10
+```
+
+Create on GitHub only after Planner review:
+
+```bash
+gh issue create --title "..." --body-file /tmp/jules-issue.md --label jules --label generate-questions --label ai-agent
+```

--- a/docs/SRS/ARCHITECTURE.md
+++ b/docs/SRS/ARCHITECTURE.md
@@ -1,0 +1,52 @@
+# worldexams — SRS Architecture map
+
+> **Protocol:** GitCore 3.8.0 · **Updated:** 2026-07-17
+
+## System context
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  worldexams (L4 product or L2/L3 library)             │
+│  Business DB / local state  ·  UI / API                     │
+└───────────────┬─────────────────────────┬───────────────────┘
+                │                         │
+                ▼                         ▼
+         Xavier (L3)               edge-mesh (L2)
+         memory / MCP              namespaces by instance
+                │                         │
+                └──────────┬──────────────┘
+                           ▼
+                    $SWAL economic core (L0–L1)
+                    node identity · optional stake
+```
+
+## Non-negotiables (SWAL)
+
+1. Business data ≠ mesh bulk storage ≠ chain blobs  
+2. Pro = SWAL node active (not Stripe)  
+3. Multi-instance isolation by default  
+4. Xavier for agentic memory  
+5. GitCore protocol files always present  
+
+## Components
+
+| Component | Responsibility | REQ |
+|-----------|----------------|-----|
+| App domain modules | Business logic | domain REQs |
+| SwalNode gate | Pro enablement | REQ-003 |
+| Xavier client | Agentic memory | REQ-005 |
+| Mesh adapter | P2P work data | REQ-004 |
+| GitCore meta | Process compliance | REQ-001 |
+
+## Deployment / privacy
+
+- Repository visibility: **private** (default)  
+- CI: local or `.github/workflows.disabled`  
+- Secrets: env only  
+
+## Related
+
+- [REQUIREMENTS.md](./REQUIREMENTS.md)  
+- [SRC.md](../../SRC.md)  
+- Ecosystem: monorepo `docs/SWAL/README.md`  
+

--- a/docs/SRS/DATABASE.md
+++ b/docs/SRS/DATABASE.md
@@ -1,0 +1,190 @@
+# Modelo de Datos
+
+**Proyecto:** WorldExams
+**Versión:** 3.0
+**Fecha:** 2026-07-10
+
+---
+
+## Entidades Principales (Supabase PostgreSQL)
+
+### questions
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| id | UUID PK | Identificador único |
+| bundle_id | TEXT | ID del bundle de origen |
+| question_number | INTEGER | Número de pregunta en el bundle |
+| country | TEXT | Código ISO del país (co, mx, ar, etc.) |
+| grade | INTEGER | Grado escolar |
+| subject | TEXT | Asignatura |
+| difficulty | TEXT | D3-D10 según Bloom taxonomy |
+| bloom_level | TEXT | Remember, Understand, Apply, Analyze, Evaluate |
+| question_text | TEXT | Enunciado de la pregunta |
+| options | JSONB | Array de 4 opciones {option, text, is_correct, feedback} |
+| correct_answer | TEXT | Letra de la respuesta correcta (A, B, C, D) |
+| pedagogical_explanation | TEXT | Explicación pedagógica |
+| context | TEXT | Contexto regional |
+| metadata | JSONB | Metadata adicional (competencia_icfes, etc.) |
+| created_at | TIMESTAMPTZ | Fecha de creación |
+| updated_at | TIMESTAMPTZ | Última actualización |
+
+### users
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| id | UUID PK | Auth UID (Supabase Auth) |
+| email | TEXT | Email del usuario |
+| full_name | TEXT | Nombre completo |
+| country | TEXT | País de origen |
+| role | TEXT | user, admin, superadmin |
+| is_premium | BOOLEAN | Tiene suscripción premium |
+| created_at | TIMESTAMPTZ | Fecha de registro |
+| last_login | TIMESTAMPTZ | Último inicio de sesión |
+
+### sessions
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| id | UUID PK | ID de sesión de examen |
+| user_id | UUID FK → users.id | Usuario que tomó el examen |
+| country | TEXT | País del examen |
+| grade | INTEGER | Grado evaluado |
+| subject | TEXT | Asignatura evaluada |
+| question_ids | UUID[] | IDs de preguntas seleccionadas |
+| status | TEXT | in_progress, completed, abandoned |
+| started_at | TIMESTAMPTZ | Inicio del examen |
+| completed_at | TIMESTAMPTZ | Fin del examen |
+| time_spent_seconds | INTEGER | Duración total |
+
+### results
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| id | UUID PK | ID del resultado |
+| session_id | UUID FK → sessions.id | Sesión asociada |
+| user_id | UUID FK → users.id | Usuario |
+| answers | JSONB | Respuestas del usuario {question_id, selected_option, is_correct} |
+| total_questions | INTEGER | Total de preguntas |
+| correct_count | INTEGER | Respuestas correctas |
+| incorrect_count | INTEGER | Respuestas incorrectas |
+| score_pct | NUMERIC(5,2) | Porcentaje de aciertos |
+| analysis | JSONB | Análisis por competencia (opcional premium) |
+| created_at | TIMESTAMPTZ | Fecha del resultado |
+
+### organizations (Premium)
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| id | UUID PK | ID de organización |
+| name | TEXT | Nombre |
+| tier | TEXT | free, pro, enterprise |
+| max_members | INTEGER | Máximo de miembros |
+| created_at | TIMESTAMPTZ | Fecha de creación |
+
+### organization_members (Premium)
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| id | UUID PK | ID |
+| organization_id | UUID FK → organizations.id | Organización |
+| user_id | UUID FK → users.id | Miembro |
+| role | TEXT | admin, member |
+| joined_at | TIMESTAMPTZ | Fecha de ingreso |
+
+### api_keys (Premium)
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| id | UUID PK | ID |
+| organization_id | UUID FK → organizations.id | Organización propietaria |
+| key_prefix | TEXT | Prefijo visible `wx_xxxx` |
+| key_hash | TEXT | SHA-256 del API key |
+| name | TEXT | Nombre descriptivo |
+| rate_limit | INTEGER | Requests/minuto |
+| is_active | BOOLEAN | Si está activa |
+| created_at | TIMESTAMPTZ | Fecha de creación |
+| expires_at | TIMESTAMPTZ | Fecha de expiración |
+| last_used_at | TIMESTAMPTZ | Último uso |
+
+### usage_logs (Premium)
+
+| Columna | Tipo | Descripción |
+|---------|------|-------------|
+| id | UUID PK | ID |
+| api_key_id | UUID FK → api_keys.id | API Key usada |
+| endpoint | TEXT | Endpoint consultado |
+| request_count | INTEGER | Requests en este log |
+| response_time_ms | INTEGER | Tiempo de respuesta |
+| ip_address | INET | IP de origen |
+| created_at | TIMESTAMPTZ | Fecha del request |
+
+---
+
+## Bundle Data (Markdown + Static JSON)
+
+### Formato de Bundle (questions_data/)
+
+Los bundles no están en la base de datos — se almacenan como archivos markdown:
+
+```
+questions_data/{country}/{subject}/grado-{N}/2026/weekly/{COUNTRY}-{SUBJ}-{GRADE}-2026-W{NN}-{topic}-001-MASTERY-bundle.md
+```
+
+### Frontmatter YAML
+
+```yaml
+---
+id: "CO-MAT-6-2026-W01-numeros-enteros-001-MASTERY-bundle"
+country: "colombia"
+grado: 6
+asignatura: "matematicas"
+tema: "numeros-enteros"
+periodo: "weekly"
+week: "W01"
+year: 2026
+bundle_type: "weekly"
+protocol_version: "5.2"
+total_questions: 10
+bundle_size: 10
+alignment: "DBA MEN Colombia"
+license: "FREE"
+tier: "legacy"
+creador: "Jules-Agent"
+---
+```
+
+### Packs JSON Estáticos (para API)
+
+Convertidos a JSON para servir desde CDN:
+
+```
+apps/worldexams-api/public/v1/packs/{country}-week-{N}-grade-{G}-subject-{S}.json
+```
+
+---
+
+## Relaciones Clave
+
+```
+users 1──N sessions 1──1 results
+users N──M organizations (via organization_members)
+organizations 1──N api_keys
+api_keys 1──N usage_logs
+users 1──N sessions (exam attempts)
+```
+
+## Volumen Estimado
+
+| Entidad | Volumen Actual | Crecimiento Estimado |
+|---------|---------------|---------------------|
+| questions | ~2000 preguntas | +500/mes por país activo |
+| bundles | ~200 bundles | +40/mes |
+| users | <100 (prelaunch) | +1000/mes post-lanzamiento |
+| sessions | <500 | +5000/mes post-lanzamiento |
+| api_keys | <10 | +20/mes |
+| usage_logs | <1000/día | +10000/día post-lanzamiento |
+
+---
+
+*Actualizado: 2026-07-10*

--- a/docs/SRS/DECISIONS_2026-07-28.md
+++ b/docs/SRS/DECISIONS_2026-07-28.md
@@ -1,0 +1,22 @@
+# Decisiones de alcance — 2026-07-28 (F6)
+
+## Admin UI (INTERFACES: "Desarrollo")
+
+**Fuera de alcance del programa end-to-end actual.** No hay pantalla Admin en el tree de
+`saberparatodos/src/pages` más allá de `/developers/*` (keys, docs, dashboard de uso).
+El dashboard de developers cubre el caso operativo actual (API keys + métricas de uso).
+Si se requiere un Admin de contenido/usuarios, se abrirá como feature nuevo con diseño propio.
+
+## Blog/Recursos (INTERFACES: "Planeado")
+
+**Cubierto parcialmente por `/novedades`** (content collections + `BlogView.svelte`) y la
+tarjeta "Revisar" habilitada en home. No se construye un sitio de recursos separado;
+si crece, se migra a content collections adicionales dentro de la PWA actual.
+
+## question-generator (apps/worldexams-api)
+
+Tooling offline, no superficie del Worker. Ver `apps/worldexams-api/src/question-generator/DECISION.md`.
+
+## video pipeline y social-orchestrator
+
+Tooling local opcional, fuera del camino crítico. Ver `DECISION.md` en cada carpeta.

--- a/docs/SRS/GLOSSARY.md
+++ b/docs/SRS/GLOSSARY.md
@@ -1,0 +1,82 @@
+# Glosario de Términos
+
+**Proyecto:** WorldExams
+**Versión:** 3.0
+**Fecha:** 2026-07-10
+
+---
+
+## Términos del Dominio Educativo
+
+| Término | Definición |
+|---------|------------|
+| Bundle | Conjunto de 8-20 preguntas educativas en formato markdown con frontmatter YAML |
+| Bundle MASTERY | Bundle de preguntas organizado por tema/competencia para dominio completo |
+| Bundle WEEKLY | Bundle semanal que sigue una secuencia curricular interna (W01-W40) |
+| Frontmatter | Bloque YAML al inicio de cada bundle con metadatos (país, grado, materia, etc.) |
+| DBA (Derechos Básicos de Aprendizaje) | Estándar curricular colombiano del MEN |
+| ICFES | Instituto Colombiano para la Evaluación de la Educación (examen Saber) |
+| ENEM | Exame Nacional do Ensino Médio (Brasil) |
+| SEP/NEM | Secretaría de Educación Pública / Nuevo Marco Curricular (México) |
+| Bloom Taxonomy | Taxonomía de habilidades cognitivas: Remember → Understand → Apply → Analyze → Evaluate |
+| D3-D10 | Escala de dificultad del proyecto (D3 = básico, D10 = experto) |
+| Static Pack | Archivo JSON generado a partir de un bundle .md para servir por API |
+| Country Readiness | KPI de 2000 preguntas validadas y publicadas por país soportado |
+| Protocolo v5.2 | Versión actual del formato de bundle (naming, frontmatter, estructura, validación) |
+
+## Términos Técnicos
+
+| Término | Definición |
+|---------|------------|
+| API Gateway | Cloudflare Worker que enruta requests a free (static) o premium (Supabase) |
+| Edge Function | Función serverless en Supabase (PostgresML + Deno) |
+| SRS | Software Requirements Specification — especificación de requisitos de software |
+| RLS | Row Level Security — políticas de seguridad a nivel de fila en PostgreSQL |
+| KPI | Key Performance Indicator — indicador clave de rendimiento |
+| CDN | Content Delivery Network — red de distribución de contenido (Cloudflare) |
+| RTO | Recovery Time Objective — tiempo objetivo de recuperación |
+| RPO | Recovery Point Objective — punto objetivo de recuperación |
+| SHA-256 | Algoritmo de hash criptográfico usado para almacenar API keys |
+| Rate Limit | Límite de requests por minuto/hora según tier |
+
+## Acrónimos
+
+| Acrónimo | Significado |
+|----------|-------------|
+| SRS | Software Requirements Specification |
+| SRC | Source Code Reference (`.gitcore/SRC.md`) |
+| API | Application Programming Interface |
+| SLA | Service Level Agreement |
+| DoD | Definition of Done |
+| ADR | Architecture Decision Record |
+| KPI | Key Performance Indicator |
+| RLS | Row Level Security |
+| RTO | Recovery Time Objective |
+| RPO | Recovery Point Objective |
+| CORS | Cross-Origin Resource Sharing |
+| CI/CD | Continuous Integration / Continuous Deployment |
+| E2E | End-to-End (tests) |
+| UUID | Universally Unique Identifier |
+| YAML | YAML Ain't Markup Language |
+| JSON | JavaScript Object Notation |
+| MD | Markdown |
+| ASTRO | Framework web (Astro.build) |
+| SSR | Server-Side Rendering |
+| DB | Database (Base de Datos) |
+| PK | Primary Key |
+| FK | Foreign Key |
+
+## Roles de Agentes (Skills)
+
+| Rol | Descripción |
+|-----|-------------|
+| Jules | Agente autónomo de Google para generación de bundles |
+| Claude | Agente de Anthropic para revisión y validación |
+| Generator | Skill para generación de preguntas vía Gemini |
+| Reviewer | Skill para revisión automática de calidad |
+| Creator | Skill para creación manual de bundles |
+| Remotion Architect | Skill para videos educativos con Remotion |
+
+---
+
+*Actualizado: 2026-07-10*

--- a/docs/SRS/INTERFACES.md
+++ b/docs/SRS/INTERFACES.md
@@ -1,0 +1,134 @@
+# Interfaces del Sistema
+
+**Proyecto:** WorldExams
+**Versión:** 3.0
+**Fecha:** 2026-07-28
+
+---
+
+## Interfaces de Usuario (Frontend)
+
+### SaberParaTodos (saberparatodos.space)
+
+| Pantalla | Descripción | Tech | Estado |
+|----------|-------------|------|--------|
+| Home/Landing | Página principal con selector de país y grado | Astro + TailwindCSS | ✅ Activo |
+| Examen | Simulacro de preguntas con temporizador | Astro SSR + React | ✅ Activo |
+| Resultados | Dashboard de resultados por intento | Astro + Chart.js | ✅ Activo |
+| Preparación | Guías de estudio por país y materia | Astro + MDX | ✅ Activo |
+| Premium | Portal de gestión de API Keys y suscripción | Astro + Supabase | ✅ Activo |
+| Admin | Panel de administración de contenido | Astro + RLS | 🔄 Desarrollo (feat-admin-ui 20%) |
+
+### WorldExams Landing (worldexams.com)
+
+| Pantalla | Descripción | Tech | Estado |
+|----------|-------------|------|--------|
+| Landing global | Presentación multi-país del producto | Astro | ✅ Activo |
+| Página por país | Landing localizada por país (CO, MX, AR, etc.) | Astro + i18n | ✅ Activo |
+| Blog/Recursos | Contenido educativo y novedades | Astro + MDX | 🔄 Desarrollo (BlogView implementado; contenido parcial — ver features.json) |
+
+---
+
+## Interfaces de API
+
+### Endpoints Públicos (Free Tier)
+
+| Método | Endpoint | Descripción | Auth | Rate Limit |
+|--------|----------|-------------|------|-----------|
+| GET | `/v1/questions` | Obtener preguntas gratis | None (guest) | 10 req/min, 100 req/hora |
+| GET | `/v1/packs/{country}-week-{N}-grade-{G}-subject-{S}.json` | Packs semanales estáticos | None | Ilimitado (CDN) |
+
+### Endpoints Premium
+
+| Método | Endpoint | Descripción | Auth | Rate Limit |
+|--------|----------|-------------|------|-----------|
+| GET | `/v1/premium/questions` | Preguntas premium con cuotas | API Key | Según tier |
+| POST | `/v1/analyze` | Analizar respuestas con IA | API Key | Según tier |
+
+### Edge Functions (Supabase)
+
+| Método | Endpoint | Descripción | Auth |
+|--------|----------|-------------|------|
+| GET | `/functions/v1/get-questions` | Backend público de preguntas | Bearer anon o sesión |
+| GET | `/functions/v1/get-questions-bulk` | Obtención masiva de preguntas | API Key |
+| GET | `/functions/v1/api-gateway` | Enforcement premium | API Key |
+| POST | `/functions/v1/generate-key` | Emisión de API Keys | Sesión autenticada |
+
+### Query Parameters Comunes
+
+| Parámetro | Tipo | Obligatorio | Descripción | Ejemplo |
+|-----------|------|-------------|-------------|---------|
+| `country` | string | Sí | Código ISO del país (2 chars) | `co`, `mx`, `ar` |
+| `grade` | integer | Sí | Grado escolar | `6`, `11` |
+| `subject` | string | Depende | Asignatura | `matematicas`, `lengua` |
+| `limit` | integer | No | Máximo de preguntas | `10` (default), `50` (premium) |
+| `week` | string | No | Semana específica | `W01`, `W14` |
+| `difficulty` | string | No | Rango D3-D10 | `D3` |
+
+---
+
+## Integraciones Externas
+
+| Sistema | Tipo | Propósito | Estado |
+|---------|------|-----------|--------|
+| Gemini API | REST API | Generación de preguntas con IA | ✅ Activo |
+| Claude API | REST API | Revisión y validación de bundles | ✅ Activo |
+| Supabase | PostgreSQL + Edge Functions | Base de datos, auth, API gateway | ✅ Activo |
+| Cloudflare Workers | Edge Runtime | API Gateway y hosting | ✅ Activo |
+| Cloudflare Pages | Static Hosting | Landing sites y packs JSON | ✅ Activo |
+| Telegram Bot | Bot API | Notificaciones y reportes automáticos | ✅ Activo |
+| GitHub Actions | CI/CD | Tests E2E y validaciones | ✅ Activo |
+| Jules Agent | Google Agent | Generación autónoma de bundles | ✅ Activo |
+
+### Diagrama de Integraciones
+
+```
+┌─────────────┐     ┌──────────────┐     ┌──────────────┐
+│  Gemini AI   │────▶│   Claude AI  │────▶│  Jules Agent │
+│ (Generation) │     │  (Review)    │     │ (Autonomous) │
+└──────┬───────┘     └──────┬───────┘     └──────┬───────┘
+       │                    │                     │
+       ▼                    ▼                     ▼
+┌──────────────────────────────────────────────────────┐
+│                 questions_data/ bundles .md           │
+│          (Git push → npm run validate → PR)          │
+└──────────────────────┬───────────────────────────────┘
+                       │
+                       ▼
+┌──────────────────────────────────────────────────────┐
+│          generate-static-packs.js → .json            │
+│          (Cloudflare Pages public dir)               │
+└──────────────────────┬───────────────────────────────┘
+                       │
+                       ▼
+               ┌───────────────┐
+               │  API Gateway  │
+               │  (Worker)     │
+               └───────┬───────┘
+                      ╱╲
+                     ╱  ╲
+                    ╱    ╲
+                   ▼      ▼
+          ┌──────────┐ ┌──────────┐
+          │  Free     │ │ Premium  │
+          │ (Static)  │ │ (Supabase│
+          │           │ │ + Worker)│
+          └──────────┘ └──────────┘
+```
+
+---
+
+## Interfaces Internas (entre componentes)
+
+| Origen | Destino | Protocolo | Datos | Frecuencia |
+|--------|---------|-----------|-------|-----------|
+| Generator Service | Gemini API | HTTPS/REST | Prompt + contexto curricular | Por demanda |
+| Review System | Claude API | HTTPS/REST | Bundle markdown + checklist | Cada 6h |
+| Review System | Supabase | HTTPS/REST | Historial de revisiones | Cada 6h |
+| API Gateway | Supabase | HTTPS/REST | Auth + API keys + usage | Por request |
+| API Gateway | Static JSON | HTTPS/HTTP2 | Packs de preguntas | Por request |
+| Deploy Script | Cloudflare API | HTTPS/REST | Wrangler deploy | Manual |
+
+---
+
+*Actualizado: 2026-07-28*

--- a/docs/SRS/NON-FUNCTIONAL.md
+++ b/docs/SRS/NON-FUNCTIONAL.md
@@ -1,0 +1,74 @@
+# Requisitos No Funcionales
+
+**Proyecto:** WorldExams
+**Versión:** 3.0
+**Fecha:** 2026-07-10
+
+---
+
+## Rendimiento
+
+| Métrica | Objetivo | Límite | Medición |
+|---------|----------|--------|----------|
+| Latencia API pública p95 | <200ms | <500ms | Cloudflare Analytics |
+| Latencia API premium p95 | <150ms | <300ms | Cloudflare Analytics |
+| Tiempo de generación de bundle | <30min | <60min | Pipeline tracking |
+| Tiempo de validación (npm run validate) | <5s | <15s | CI log |
+| Requests concurrentes free | 10 req/min | 30 req/min | API Gateway |
+| Requests concurrentes premium | 60-300 req/min | según tier | API Gateway + usage_logs |
+
+## Seguridad
+
+| Requisito | Descripción | Estado |
+|-----------|-------------|--------|
+| Autenticación | Supabase Auth con magic links + OAuth | ✅ Implementado |
+| API Keys | Hash SHA-256 para storage, prefijo `wx_xxxx` visible | ✅ Implementado |
+| Rate Limiting | Por IP (guest) y por API Key (premium) | ✅ Implementado |
+| CORS | Restringido a `saberparatodos.space` y `www.saberparatodos.space` | ⚠️ Pendiente (actualmente `*`) |
+| Secrets | SUPABASE_SERVICE_ROLE_KEY nunca expuesto en frontend | ✅ Implementado |
+| Encriptación | TLS 1.3 en todos los endpoints Cloudflare | ✅ Implementado |
+| RLS (Row Level Security) | Políticas por organización en Supabase | ✅ Implementado |
+| Git History | Limpieza de secrets expuestos en git history (#221) | 🔄 En progreso |
+
+## Disponibilidad
+
+| Métrica | Objetivo |
+|---------|----------|
+| Uptime API | 99.9% (8.76h downtime/año) |
+| RTO (Recovery Time Objective) | 1 hora |
+| RPO (Recovery Point Objective) | 15 minutos |
+| Backup DB | Diario automatizado vía Supabase |
+| SLA para partners premium | 99.5% |
+
+## Escalabilidad
+
+| Dimensión | Estrategia | Estado |
+|-----------|-----------|--------|
+| Contenido | Escritura directa a `questions_data/` + generación de packs JSON | ✅ Operacional |
+| API free | Static JSON API en Cloudflare Pages (escalado automático) | ✅ Implementado |
+| API premium | Cloudflare Workers con Supabase backend (escalado horizontal) | ✅ Implementado |
+| Base de datos | Supabase PostgreSQL con índices + partitioning | ✅ Implementado |
+| Multi-país | Monorepo con lógica compartida + config por país | ✅ Implementado |
+
+## Mantenibilidad
+
+| Práctica | Estado |
+|----------|--------|
+| Tests E2E (Playwright) | ✅ 48 tests |
+| Validación de bundles (v5.2) | ✅ npm run validate |
+| Pre-commit hooks | ✅ .pre-commit-config.yaml |
+| CI/CD GitHub Actions | ✅ Activo |
+| Revisión automática cada 6h | ✅ Activo |
+| Documentación en .gitcore/ | ✅ Actualizada |
+| Skills de agente (12 skills) | ✅ Activo |
+
+## Portabilidad
+
+- Bundles en formato markdown estándar con frontmatter YAML
+- Packs JSON estáticos servidos desde CDN
+- Sin dependencias de vendor lock-in (Cloudflare elegido por conveniencia, no por requisito)
+- Supabase PostgreSQL exportable a cualquier PostgreSQL vanilla
+
+---
+
+*Actualizado: 2026-07-10*

--- a/docs/SRS/REQUIREMENTS.md
+++ b/docs/SRS/REQUIREMENTS.md
@@ -1,0 +1,70 @@
+# Requisitos Funcionales
+
+**Proyecto:** WorldExams
+**Fecha:** 2026-07-28
+
+---
+
+## Requisitos Funcionales
+
+| ID | Descripción | Prioridad | Estado |
+|----|-------------|-----------|--------|
+| SRS-FUN-001 | Generación de bundles MASTERY multi-país | Crítica | ✅ Activo |
+| SRS-FUN-002 | Validación automática de bundles (npm run validate) | Crítica | ✅ Activo |
+| SRS-FUN-003 | API REST pública con tier free/premium | Crítica | ✅ Activo |
+| SRS-FUN-004 | Revisión automática de calidad cada 6h | Crítica | ✅ Activo |
+| SRS-FUN-005 | Publicación de packs JSON estáticos a producción | Crítica | ✅ Activo |
+| SRS-FUN-006 | Auditoría de Country Readiness (2000 preguntas/pais) | Alta | ✅ Activo |
+| SRS-FUN-007 | Expansión curricular multi-país (MX, AR, CL, PE, BR) | Alta | 🔄 Desarrollo |
+| SRS-FUN-008 | API Premium con API Keys, cuotas y rate limits | Alta | ✅ Activo |
+| SRS-FUN-009 | Monitoreo y alertas vía Telegram | Media | ✅ Activo |
+| SRS-FUN-010 | Tests E2E con Playwright + CI/CD | Media | ✅ Activo |
+
+---
+
+## Casos de Uso
+
+### UC-001: Estudiante practica examen semanal
+
+**Actor:** Estudiante (usuario anónimo o autenticado)
+**Descripción:** El estudiante selecciona un examen semanal de su país/grado/materia, lo responde y revisa sus resultados con un informe pedagógico.
+**Precondiciones:**
+- Existe al menos un pack semanal publicado para el país/grado/materia en `apps/worldexams-api/public/v1/packs` con prefijo ISO del país.
+- La app puede resolver la geo-ruta del país vía middleware (`saberparatodos/src/middleware.ts`).
+
+**Flujo Principal:**
+1. El estudiante entra a `saberparatodos.space/practica`.
+2. Selecciona país, grado, materia y semana (W01-W40) en `ExamConfigModal`.
+3. La app carga el pack semanal vía `pack-fetcher` (prefiere packs con prefijo de país).
+4. El estudiante responde las preguntas del examen (8/10/12/20 según grado, protocolo v5.2).
+5. Al finalizar, la app muestra resultados en `ResultsView`: puntaje, feedback por opción y explicación pedagógica.
+6. El estudiante puede generar un informe local (`LocalReportsView`) y, opcionalmente, practicar en un salón mesh (`/sala-examenes`).
+
+**Postcondiciones:**
+- El intento queda registrado localmente; no se publica contenido nuevo a `questions_data/`.
+- Un solo intento activo por sala (BR-01).
+
+---
+
+## Reglas de Negocio
+
+- **BR-01:** Un solo intento activo por sala de examen. No se permite abrir un segundo intento del mismo examen mientras otro esté en curso en la misma sala.
+- **BR-02:** Contenido canónico solo v5.2 en ruta weekly: `questions_data/{country}/{subject}/grado-{N}/2026/weekly/`. Contenido legacy no cuenta para KPIs ni se sirve como contenido principal.
+
+---
+
+## Requisitos Baseline SWAL
+
+| ID | Descripción | Files | Acceptance |
+|----|-------------|-------|-----------|
+| REQ-001 | App gratuita usable sin paywall fiat | `saberparatodos/src/pages/practica.astro`, `apps/worldexams-api/public/v1/packs/` | Un estudiante anónimo completa UC-001 end-to-end sin pago ni API key |
+| REQ-002 | Pro = nodo SWAL activo, sin Stripe | `docs/SWAL/GOAL.md`, `saberparatodos/src/lib/p2p-edge-mesh.ts` | Ninguna referencia a Stripe/suscripciones externas en código de gating; Pro se activa por nodo SWAL activo |
+| REQ-003 | Xavier namespace `app/worldexams/instance/{instanceId}` | `saberparatodos/src/lib/swal-instance-id.ts` | La app genera/reutiliza un instanceId estable y lo usa como namespace de memoria Xavier |
+| REQ-004 | Mesh namespace `swal/worldexams/{instanceId}` | `saberparatodos/src/lib/p2p-edge-mesh.ts` | Los salones mesh-first se registran bajo el namespace `swal/worldexams/{instanceId}` en edge-mesh |
+| REQ-005 | GitCore 3.8: SRC + SRS sincronizados | `.gitcore/SRC.md`, `docs/SRS/index.md` | SRC.md refleja estructura real auditada; SRS cubre REQUIREMENTS/INTERFACES/DATABASE/ARCHITECTURE/NON-FUNCTIONAL |
+| REQ-006 | AGENTS.md apunta a docs/SWAL/GOAL.md | `AGENTS.md`, `docs/SWAL/GOAL.md` | La sección "SWAL ecosystem" de AGENTS.md referencia el canonical GOAL.md y PROJECT_MAP.md |
+| REQ-007 | AI Core on-device vía `createAiCore` | `saberparatodos/src/lib/ai/ai-core-client.ts`, `saberparatodos/src/pages/ajustes/ia.astro` | `createAiCore({ mesh, instanceId })` monta tutor y exam-generator on-device; `npm run smoke:ai` pasa |
+
+---
+
+*Actualizado: 2026-07-28*

--- a/docs/SRS/index.md
+++ b/docs/SRS/index.md
@@ -1,0 +1,125 @@
+# Software Requirements Specification (SRS)
+
+**Proyecto:** WorldExams
+**Versión:** 3.0
+**Fecha:** 2026-07-24
+**Estado:** ACTIVE
+
+---
+
+## Tabla de Contenidos
+
+1. [REQUIREMENTS.md](REQUIREMENTS.md) — Requisitos Funcionales y Casos de Uso
+2. [NON-FUNCTIONAL.md](NON-FUNCTIONAL.md) — Requisitos No Funcionales
+3. [INTERFACES.md](INTERFACES.md) — Interfaces de Sistema y API
+4. [DATABASE.md](DATABASE.md) — Modelo de Datos
+5. [GLOSSARY.md](GLOSSARY.md) — Glosario de Términos
+
+---
+
+## Resumen Ejecutivo
+
+WorldExams es una plataforma SaaS de simulación de exámenes educativos multi-país para Latinoamérica. Genera, valida y distribuye preguntas alineadas a currículos nacionales (ICFES Colombia, ENEM Brasil, EXANI México, etc.) mediante un pipeline automatizado de agentes de IA.
+
+### Misión
+
+Democratizar el acceso a contenido educativo de alta calidad para estudiantes de Latinoamérica, proporcionando simulacros de examen gratuitos y premium alineados a los currículos nacionales de cada país.
+
+### Características Principales
+
+| Feature | Descripción | Prioridad | Estado |
+|---------|-------------|-----------|--------|
+| Banco de preguntas multi-país | Bundles MASTERY + WEEKLY en markdown con frontmatter | 🔴 Crítica | 🟢 Activo |
+| Generación IA con Gemini | Preguntas automáticas alineadas a currículos nacionales | 🔴 Crítica | 🟢 Activo |
+| Revisión automática de calidad | Sub-agentes cada 6h con checklist de 12 checks | 🔴 Crítica | 🟢 Activo |
+| API REST pública | Endpoints free + premium para consumo de preguntas | 🔴 Crítica | 🟢 Activo |
+| Publicación a producción | Pipeline bundle .md → validar → JSON estático → deploy | 🔴 Crítica | 🟢 Activo |
+| Multi-país | Soporte para CO, MX, AR, CL, PE, BR, y más | 🟡 Alta | 🟡 En desarrollo |
+| Premium API | API Keys, cuotas, rate limits, analytics | 🟡 Alta | 🟢 Activo |
+| Country Readiness Audit | Score de 2000 preguntas por país con dashboard | 🟡 Alta | 🟢 Activo |
+| Monitoreo Telegram | Reportes automáticos de estado y alertas | 🔵 Media | 🟢 Activo |
+
+---
+
+## Documentación Relacionada
+
+| Documento | Ubicación |
+|-----------|-----------|
+| Arquitectura del Sistema | `.gitcore/ARCHITECTURE.md` |
+| Plan de Trabajo Activo | `.gitcore/planning/TASK.md` |
+| Roadmap del Proyecto | `ROADMAP.md` |
+| Reglas de Codificación | `RULES.md` |
+| Feature Registry | `.gitcore/features.json` |
+| Detalle de Features | `.gitcore/detailsFeatures.json` |
+
+---
+
+## Stack Tecnológico
+
+| Capa | Tecnología | Versión |
+|------|------------|---------|
+| Frontend | Astro + TailwindCSS | 5.x |
+| API Gateway | Cloudflare Workers | ES2022 |
+| Database | Supabase PostgreSQL | 15.x |
+| AI Generation | Gemini API + Claude | — |
+| Agentes de Contenido | Jules (Google) | — |
+| Hosting | Cloudflare Pages + Workers | — |
+| Tests E2E | Playwright | latest |
+| Validación | Protocolo v5.2 (npm run validate) | — |
+| Monitoreo | Telegram Bot API | — |
+| Despliegue | Wrangler CLI (manual) | — |
+
+---
+
+## Modelo de Negocio
+
+### Tiered Access
+
+| Plan | Precio | Requests/min | Preguntas/req | AI Analysis | Rate Limit |
+|------|--------|-------------|---------------|-------------|------------|
+| **Free** | $0 | 10 req/min | 10 | ❌ | 100 req/hora guest |
+| **Pro** | Por organización | 60 req/min | 50 | Basic | API Key |
+| **Enterprise** | Por organización | 300 req/min | 100 | Full | API Key |
+
+### Monetización
+
+- **API como producto**: Venta de acceso premium al banco de preguntas vía API Keys
+- **White-label**: Licenciamiento a instituciones educativas y gobiernos
+- **Freemium**: Captación con tier gratuito, conversión a planes pagos
+- **País como unidad**: Expansión por país con metadata curricular específica
+
+---
+
+## Calidad de Servicio (SLAs)
+
+| Métrica | Objetivo | Medición |
+|---------|----------|----------|
+| Uptime API | 99.9% | Uptime checks cada 5min |
+| Latencia API p95 | <200ms | Cloudflare Analytics |
+| Quality Score mínimo | >= 0.70 | evaluate.service.ts |
+| Bundle Pass Rate | >= 80% | Revisión automática |
+| Country Readiness | 2000 preguntas/pais | `audit:country-readiness` |
+| Tiempo de generación | <30min por bundle | Pipeline tracking |
+
+---
+
+## Metadata
+
+```yaml
+project: "WorldExams"
+version: "3.0"
+created: "2026-03-13"
+last_updated: "2026-07-24"
+status: "ACTIVE"
+repository: "https://github.com/iberi22/worldexams"
+protocol_version: "5.2"
+countries_active: ["CO", "MX", "UY", "PY", "CL"]
+countries_planned: ["AR", "PE", "EC", "BR", "BO", "CR", "SV", "HN"]
+total_bundles: 200+
+total_skills: 12
+```
+
+---
+
+*Documento generado y mantenido por GitCore Auto-Maintainer*
+*Última actualización: 2026-07-24*

--- a/saberparatodos/package.json
+++ b/saberparatodos/package.json
@@ -78,7 +78,7 @@
     "@trystero-p2p/supabase": "^0.23.1",
     "astro": "^7.0.3",
     "chart.js": "^4.5.1",
-    "edge-mesh": "file:../../../home/belal/proyectosSWAL/edge-mesh",
+    "edge-mesh": "file:../../edge-mesh",
     "html2canvas": "^1.4.1",
     "jspdf": "^4.2.1",
     "katex": "^0.16.40",


### PR DESCRIPTION
## Summary
- Lands local-only docs that were never on remote: `docs/SRS/*`, Jules wave0 planning, GitCore manifests
- Fixes broken `edge-mesh` dependency path (`file:../../../home/belal/...` → `file:../../edge-mesh`)

## Test plan
- [x] `cd saberparatodos && npm run test:unit` → 215/215
- [x] `npm run validate` → 1128 bundles, 0 failures
- [x] `npm run audit:country-readiness` → 2/20 ready, ~19348 published

Made with [Cursor](https://cursor.com)