### PR TITLE
build(deps): bump @babel/core from 7.29.0 to 7.29.7

### DIFF
--- a/saberparatodos/package-lock.json
+++ b/saberparatodos/package-lock.json
@@ -518,9 +518,9 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",


### PR DESCRIPTION
## Summary
- Reemplazo manual de #790 (Dependabot, cerrado: CONFLICTING y sin rebase automatico).
- Patch bump de dev-dependency indirecta (`@babel/core` 7.29.0 -> 7.29.7) en `saberparatodos/package-lock.json`.
- Diff minimo (3 lineas): el lockfile raiz del workspace ya estaba en 7.29.7.

## Test plan
- [x] `npm run test:unit` (vitest): 215/215 passed
- [ ] CI verde

Made with [Cursor](https://cursor.com)