### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded CAPTCHA_SECRET

### DIFF
--- a/saberparatodos/src/pages/api/auth/verify-captcha.ts
+++ b/saberparatodos/src/pages/api/auth/verify-captcha.ts
@@ -7,7 +7,7 @@ import type { APIRoute } from 'astro';
 // Using Cloudflare Turnstile
 // https://developers.cloudflare.com/turnstile/troubleshooting/testing/
 const TURNSTILE_SECRET = import.meta.env.TURNSTILE_SECRET_KEY;
-const CAPTCHA_SECRET = import.meta.env.CAPTCHA_SECRET || 'spt-captcha-2026-worldexams-secret-key';
+const CAPTCHA_SECRET = import.meta.env.CAPTCHA_SECRET;
 
 if (!TURNSTILE_SECRET) {
   console.warn('[verify-captcha] TURNSTILE_SECRET_KEY is not set. CAPTCHA verification will fail.');
@@ -38,6 +38,14 @@ export const POST: APIRoute = async ({ request }) => {
         verified: false,
         error: 'CAPTCHA not configured',
       }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    if (!CAPTCHA_SECRET) {
+      console.error('[verify-captcha] CRITICAL: CAPTCHA_SECRET is not configured in the environment.');
+      return new Response(JSON.stringify({
+        verified: false,
+        error: 'Server error',
+      }), { status: 500, headers: { 'Content-Type': 'application/json' } });
     }
 
     if (!token) {


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** A hardcoded default secret (`spt-captcha-2026-worldexams-secret-key`) was present in `src/pages/api/auth/verify-captcha.ts`. This secret was used for HMAC signing of verification tokens, meaning an attacker could bypass CAPTCHA checks by forging tokens if they knew or guessed the fallback secret.
**Fix:** Removed the hardcoded fallback. The API route now uses only the environment variable for `CAPTCHA_SECRET`. If the secret is missing from the environment, it fails securely by returning a generic 500 error and logging an error on the server side instead of crashing or operating insecurely.

---
*PR created automatically by Jules for task [10656695364787743519](https://jules.google.com/task/10656695364787743519) started by @iberi22*