### PR TITLE
🎨 Palette: Accessibility improvements for icon-only buttons

### DIFF
--- a/saberparatodos/src/components/CollegeSelect.svelte
+++ b/saberparatodos/src/components/CollegeSelect.svelte
@@ -100,6 +100,7 @@
           type="button"
           on:click={clearSelection}
           class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+          aria-label="Borrar selección de colegio"
         >
           ✕
         </button>

--- a/saberparatodos/src/components/OfflineProfile.svelte
+++ b/saberparatodos/src/components/OfflineProfile.svelte
@@ -63,6 +63,7 @@
       <button
         on:click={onClose}
         class="absolute top-4 right-4 p-2 text-white/40 hover:text-white z-10 transition-colors"
+        aria-label="Cerrar modal de progreso"
       >
         <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/saberparatodos/src/components/PeriodTrackerModal.svelte
+++ b/saberparatodos/src/components/PeriodTrackerModal.svelte
@@ -24,7 +24,7 @@
           <h2 class="text-lg font-bold uppercase tracking-widest text-white">
               Cronograma Escolar
           </h2>
-          <button onclick={onClose} class="text-white/40 hover:text-white">
+          <button onclick={onClose} class="text-white/40 hover:text-white" aria-label="Cerrar">
               ✕
           </button>
       </div>

--- a/saberparatodos/src/components/Search.svelte
+++ b/saberparatodos/src/components/Search.svelte
@@ -76,7 +76,7 @@
             class="flex-1 bg-transparent border-none outline-none text-[#F5F5DC] placeholder-white/20"
             autocomplete="off"
           />
-          <button on:click={toggleSearch} class="text-xs uppercase tracking-widest text-white/40 hover:text-white">
+          <button on:click={toggleSearch} class="text-xs uppercase tracking-widest text-white/40 hover:text-white" aria-label="Cerrar búsqueda">
             ESC
           </button>
         </div>


### PR DESCRIPTION
This PR introduces a small UX accessibility enhancement by adding `aria-label` attributes to several icon-only buttons (such as '✕', 'ESC', and SVG icons). This ensures that screen reader users are provided with descriptive context for these actions.

Components modified:
- `OfflineProfile.svelte`
- `PeriodTrackerModal.svelte`
- `CollegeSelect.svelte`
- `Search.svelte`

---
*PR created automatically by Jules for task [9367281994774728202](https://jules.google.com/task/9367281994774728202) started by @iberi22*