### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded CAPTCHA_SECRET fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** KaTeX configuration was set to `trust: true`, allowing potentially malicious LaTeX commands to render raw HTML/execute JS (XSS vulnerability).
 **Learning:** In Svelte components rendering LaTeX via KaTeX, using `trust: true` alongside `{@html ...}` bindings opens a direct XSS vector because KaTeX will trust arbitrary user-provided HTML commands in the LaTeX string, and Svelte will render it unescaped.
 **Prevention:** Always set `trust: false` (the default) in KaTeX configurations when dealing with user-generated or external content. Avoid DOM sanitization libraries (like `isomorphic-dompurify`) to clean KaTeX output unless absolutely necessary, as it can break complex SVG/MathML outputs and add bundle bloat; KaTeX is designed to be secure with `trust: false`.
+
+## 2025-07-27 - [Fix Hardcoded Secret Fallback]
+**Vulnerability:** A hardcoded fallback string was used for `CAPTCHA_SECRET` during HMAC signing.
+**Learning:** Providing a fallback hardcoded secret string is a dangerous practice, as it means attackers can forge valid HMAC signatures and bypass security measures (in this case, CAPTCHA verification) if the environment variable happens to be unset in production.
+**Prevention:** Remove hardcoded fallback strings for secrets. Instead, fail securely by explicitly checking for the environment variable and returning a 500 server error if the configuration is incomplete.

--- a/saberparatodos/src/pages/api/auth/verify-captcha.ts
+++ b/saberparatodos/src/pages/api/auth/verify-captcha.ts
@@ -7,10 +7,14 @@ import type { APIRoute } from 'astro';
 // Using Cloudflare Turnstile
 // https://developers.cloudflare.com/turnstile/troubleshooting/testing/
 const TURNSTILE_SECRET = import.meta.env.TURNSTILE_SECRET_KEY;
-const CAPTCHA_SECRET = import.meta.env.CAPTCHA_SECRET || 'spt-captcha-2026-worldexams-secret-key';
+const CAPTCHA_SECRET = import.meta.env.CAPTCHA_SECRET;
 
 if (!TURNSTILE_SECRET) {
   console.warn('[verify-captcha] TURNSTILE_SECRET_KEY is not set. CAPTCHA verification will fail.');
+}
+
+if (!CAPTCHA_SECRET) {
+  console.warn('[verify-captcha] CAPTCHA_SECRET is not set. CAPTCHA verification will fail.');
 }
 
 async function hmacSign(data: string, secret: string): Promise<string> {
@@ -32,6 +36,13 @@ export const POST: APIRoute = async ({ request }) => {
   try {
     const body = await request.json();
     const token = body.captchaToken || body.verificationToken || body.token;
+
+    if (!CAPTCHA_SECRET) {
+      return new Response(JSON.stringify({
+        verified: false,
+        error: 'Server configuration error: CAPTCHA_SECRET is missing',
+      }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+    }
 
     if (!TURNSTILE_SECRET) {
       return new Response(JSON.stringify({


### PR DESCRIPTION
Removed a CRITICAL security vulnerability where a hardcoded string `spt-captcha-2026-worldexams-secret-key` was used as a fallback for the `CAPTCHA_SECRET` environment variable during HMAC token signing.

If the `CAPTCHA_SECRET` is missing in production, the application will now fail securely with a `500 Server Error` instead of using an insecure, publicly known secret. This aligns with security best practices and prevents attackers from forging valid HMAC signatures to bypass security measures.

Logged the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18058570149451969129](https://jules.google.com/task/18058570149451969129) started by @iberi22*