### PR TITLE
🎨 Palette: Add keyboard focus rings to interactive components

### DIFF
--- a/saberparatodos/src/components/ScoreDisplay.svelte
+++ b/saberparatodos/src/components/ScoreDisplay.svelte
@@ -211,7 +211,7 @@
   {#if showBreakdown}
     <button
       on:click={() => showDetails = !showDetails}
-      class="w-full py-3 text-xs uppercase tracking-widest text-white/40 hover:text-white/80 transition-colors flex items-center justify-center gap-2"
+      class="w-full py-3 text-xs uppercase tracking-widest text-white/40 hover:text-white/80 transition-colors flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded"
     >
       {showDetails ? 'Ocultar' : 'Ver'} detalle por pregunta
     </button>
@@ -292,7 +292,7 @@
         <button
           type="button"
           on:click={closeScoreHelp}
-          class="w-10 h-10 rounded-full border border-white/10 bg-white/5 text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+          class="w-10 h-10 rounded-full border border-white/10 bg-white/5 text-white/70 hover:text-white hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
           aria-label="Cerrar explicacion del puntaje"
         >
           ✕

--- a/saberparatodos/src/components/Search.svelte
+++ b/saberparatodos/src/components/Search.svelte
@@ -44,7 +44,7 @@
 <div class="relative z-50">
   <button
     on:click={toggleSearch}
-    class="p-2 text-emerald-500 hover:text-emerald-400 transition-colors opacity-80 hover:opacity-100"
+    class="p-2 text-emerald-500 hover:text-emerald-400 transition-colors opacity-80 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded"
     aria-label="Buscar preguntas"
   >
     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -76,7 +76,7 @@
             class="flex-1 bg-transparent border-none outline-none text-[#F5F5DC] placeholder-white/20"
             autocomplete="off"
           />
-          <button on:click={toggleSearch} class="text-xs uppercase tracking-widest text-white/40 hover:text-white">
+          <button on:click={toggleSearch} class="text-xs uppercase tracking-widest text-white/40 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded px-1">
             ESC
           </button>
         </div>
@@ -90,7 +90,7 @@
             {#each results as result}
               <a
                 href={result.url}
-                class="block p-4 hover:bg-white/5 border-b border-white/5 last:border-0 transition-colors group"
+                class="block p-4 hover:bg-white/5 border-b border-white/5 last:border-0 transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:-outline-offset-2"
               >
                 <h4 class="text-emerald-500 font-bold text-sm mb-1 group-hover:text-emerald-400">
                   {result.meta.title || 'Pregunta'}

--- a/saberparatodos/src/components/SubjectSelector.svelte
+++ b/saberparatodos/src/components/SubjectSelector.svelte
@@ -116,14 +116,14 @@
   <div class="flex gap-4">
     <button
       onclick={onBack}
-      class="px-6 py-2 border border-white/20 hover:bg-white/10 transition-colors uppercase text-xs tracking-widest opacity-60 hover:opacity-100"
+      class="px-6 py-2 border border-white/20 hover:bg-white/10 transition-colors uppercase text-xs tracking-widest opacity-60 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded"
     >
       Volver
     </button>
 
     <button
       onclick={() => onSelect('CHANGE_GRADE')}
-      class="px-6 py-2 border border-emerald-500/20 hover:bg-emerald-500/10 text-emerald-500/80 hover:text-emerald-500 transition-colors uppercase text-xs tracking-widest"
+      class="px-6 py-2 border border-emerald-500/20 hover:bg-emerald-500/10 text-emerald-500/80 hover:text-emerald-500 transition-colors uppercase text-xs tracking-widest focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded"
     >
       Cambiar Grado
     </button>

--- a/saberparatodos/tests/e2e-30q.spec.ts
+++ b/saberparatodos/tests/e2e-30q.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 const BASE_URL = 'https://saberparatodos.space';
 
-async function startExam(page, grade, subject, mode, period) {
+async function startExam(page: any, grade: any, subject: any, mode: any, period: number | null = null) {
   await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 30000 });
   const gradeBtn = page.locator('button').filter({ hasText: `${grade}° Grado` }).first();
   await expect(gradeBtn).toBeVisible({ timeout: 15000 });
@@ -31,7 +31,7 @@ async function startExam(page, grade, subject, mode, period) {
   await startBtn.click();
 }
 
-async function validateQuestions(page, label) {
+async function validateQuestions(page: any, label: any) {
   try {
     await expect(page.getByTestId('options-grid')).toBeVisible({ timeout: 60000 });
     const count = await page.locator('[data-testid="options-grid"] button, [data-testid="options-grid"] div[role="button"]').count();

--- a/saberparatodos/tests/e2e-prod-matrix.spec.ts
+++ b/saberparatodos/tests/e2e-prod-matrix.spec.ts
@@ -4,7 +4,7 @@ const BASE_URL = 'https://saberparatodos.space'; // Production URL
 
 // ── Helpers ──
 
-async function closeModals(page) {
+async function closeModals(page: any) {
   // Wait for hero welcome to auto-close (countdown ~5s)
   await page.waitForTimeout(6000);
   // Close "MODO LOCAL" banner if visible
@@ -17,7 +17,7 @@ async function closeModals(page) {
   }
 }
 
-async function runExam(page, grade, subject, mode, period) {
+async function runExam(page: any, grade: any, subject: any, mode: any, period: number | null = null) {
   await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 30000 });
   await closeModals(page);
   await page.locator('[role="button"]').filter({ hasText: `${grade}° Grado` }).first().click();


### PR DESCRIPTION
💡 **What:** Added visible focus states (`focus-visible:ring-2 focus-visible:ring-emerald-500 rounded`) to interactive elements like primary action buttons and close buttons.
🎯 **Why:** To improve keyboard navigation accessibility. Without explicit focus styles, it is very difficult for users relying on keyboards to know which element they are currently focused on.
♿ **Accessibility:** Added clear focus rings to elements across `Search.svelte`, `ScoreDisplay.svelte`, and `SubjectSelector.svelte` using existing design system utility classes.

---
*PR created automatically by Jules for task [17259660812378026754](https://jules.google.com/task/17259660812378026754) started by @iberi22*