### PR TITLE
⚡ Bolt: Optimize question history lookup from O(N*M) to O(1)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-07-28 - Memoization for synchronous KaTeX rendering in Svelte
 **Learning:** KaTeX rendering is a synchronous and CPU-intensive operation that can block the main thread if repeated frequently. In a Svelte app, rendering math equations across multiple instances of a component like `MathRenderer.svelte` can cause severe performance bottlenecks, especially if equations are re-rendered during list updates or navigation.
 **Action:** When performing heavy synchronous work inside a component's render flow (like Markdown/LaTeX parsing), utilize Svelte's `<script context="module">` to create a bounded module-level cache (e.g. Map). This shares the memoized results across all component instances rather than recalculating them per-instance.
+## 2026-08-01 - O(N*M) lookup elimination in Svelte with derived Maps
+**Learning:** Performing a `.find()` on an array inside of a loop (e.g. searching through past exam details for a question) runs on every render/modal open and leads to O(N*M) time complexity. This is especially problematic with large history datasets in Svelte, leading to UI stuttering and unresponsiveness.
+**Action:** Replace nested array `.find()` calls with an O(1) `$derived` Map lookup. Constructing the Map once with Svelte's `$derived` (or `$derived.by`) caches the index and enables instant retrieval on subsequent lookups.

--- a/saberparatodos/src/components/LocalReportsView.svelte
+++ b/saberparatodos/src/components/LocalReportsView.svelte
@@ -56,6 +56,22 @@
 
   let activeTab: 'dashboard' | 'history' = $state('dashboard');
   let historyResults: ExamResultRecord[] = $state([]);
+
+  // ⚡ Bolt Optimization: O(1) lookup map for historical questions to avoid O(N*M) nested loops on every modal open
+  let historyQuestionMap = $derived.by(() => {
+    const map = new Map<string, any>();
+    for (const record of historyResults) {
+      if (record.details && Array.isArray(record.details)) {
+        for (const detail of record.details) {
+          if (detail.question && !map.has(String(detail.questionId))) {
+            map.set(String(detail.questionId), detail.question);
+          }
+        }
+      }
+    }
+    return map;
+  });
+
   let userProfile: UserProfile | null = $state(null);
   let insights: string[] = $state([]);
   let loading = $state(true);
@@ -179,16 +195,12 @@
 
     // 🆕 Step 1: Check if we already have this question in our history records
     // This is the fastest and most reliable way for previously taken exams
-    for (const record of historyResults) {
-      if (record.details && Array.isArray(record.details)) {
-        const foundInHistory = record.details.find(d => String(d.questionId) === qid);
-        if (foundInHistory && foundInHistory.question) {
-          console.log(`🧠 Found question data in local history for: ${qid}`);
-          selectedQuestionData = foundInHistory.question;
-          loadingQuestion = false;
-          return;
-        }
-      }
+    const cachedQuestion = historyQuestionMap.get(qid);
+    if (cachedQuestion) {
+      console.log(`🧠 Found question data in local history for: ${qid}`);
+      selectedQuestionData = cachedQuestion;
+      loadingQuestion = false;
+      return;
     }
 
     try {


### PR DESCRIPTION
### 💡 What:
Introduced an O(1) `$derived` Map lookup (`historyQuestionMap`) in `LocalReportsView.svelte` to replace the O(N*M) nested array `.find()` loop that executed inside `openQuestionModal`.

### 🎯 Why:
Every time a user clicked to view a question from their exam history, the component iterated over every past exam array and used `.find()` on the nested details array to locate the question object. This caused an O(N*M) time complexity bottleneck which could cause UI jank for users with substantial local exam history.

### 📊 Impact:
- **Reduces UI blocking:** Lookups are now O(1) on modal open.
- **Cache performance:** The derived map caches the history lookup structure directly when the user's local history updates, moving the heavy lifting out of the hot modal execution path.

### 🔬 Measurement:
- `openQuestionModal` executes instantly regardless of how many exams the user has taken.
- Run `pnpm test:unit` to verify the logic does not break existing application flows. Tests confirm successful execution.

---
*PR created automatically by Jules for task [7308936048624986141](https://jules.google.com/task/7308936048624986141) started by @iberi22*