### PR TITLE
⚡ Bolt: O(N*M) lookup elimination in Svelte with derived Maps

### DIFF
--- a/saberparatodos/src/components/BlogView.svelte
+++ b/saberparatodos/src/components/BlogView.svelte
@@ -226,13 +226,16 @@
 
   $: normalizedSearchTerm = normalizeForSearch(debouncedSearchTerm);
 
-  $: filteredQuestions = questions.filter((q, index, self) => {
+  $: filteredQuestions = (() => {
+    const seenIds = new Set();
+    return questions.filter((q, index) => {
     // Skip invalid questions
     if (!q || !q.category) return false;
 
     // Deduplicate by ID
-    const isFirst = self.findIndex(item => item.id === q.id) === index;
-    if (!isFirst) return false;
+    if (seenIds.has(q.id)) return false;
+    seenIds.add(q.id);
+
 
     // Debug: log first question to see structure
     if (index === 0) {
@@ -257,7 +260,8 @@
     const matchesSearch = !debouncedSearchTerm || searchTarget.includes(normalizedSearchTerm);
 
     return matchesSearch && matchesGrade && matchesDifficulty && matchesPeriod && matchesSubject;
-  });
+    });
+  })();
 
   function clearSearch() {
     searchTerm = "";

--- a/saberparatodos/src/components/BotPracticeReport.svelte
+++ b/saberparatodos/src/components/BotPracticeReport.svelte
@@ -47,6 +47,8 @@
   let examScore: any = null;
   let videoByQuestionId: Record<string, { availability: 'available' | 'pending' | 'missing'; entry?: VideoManifestEntry }> = {};
 
+  $: answerMap = new Map((session?.answers || []).map(a => [a.question_id, a]));
+
   function computeScore() {
     if (!session) return;
 
@@ -172,7 +174,7 @@
         <h2 class="text-sm font-bold uppercase tracking-widest text-white/60">Detalle por pregunta</h2>
 
         {#each questions as q, idx}
-          {@const a = session?.answers?.find((x) => x.question_id === q.id)}
+          {@const a = answerMap.get(q.id)}
           {@const ok = a?.is_correct}
           {@const videoMeta = getVideoForQuestion(q.id)}
           <div class={`p-4 rounded-xl border bg-white/5 ${ok ? 'border-emerald-500/20' : 'border-red-500/20'}`}>


### PR DESCRIPTION
⚡ **Bolt:** O(N*M) lookup elimination in Svelte with derived Maps

💡 **What:** Replaced O(N^2) array `.findIndex()` deductions in `BlogView.svelte` with an O(N) `Set` pattern. Replaced O(N*M) array `.find()` lookups inside an `#each` template loop in `BotPracticeReport.svelte` with a precomputed O(1) `Map`.
🎯 **Why:** To prevent UI stuttering and unresponsiveness caused by heavy array iteration inside reactive filter flows and rendering blocks, especially when users have a significant amount of history or loaded questions.
📊 **Impact:** Reduces question array filtering from O(N^2) to O(N). Reduces history answer matching from O(N*M) to O(1) map lookups, preventing severe rendering bottlenecks.
🔬 **Measurement:** Verify by loading a large list of questions in the "Revisar" view or a long exam report and observing faster render/update times.

---
*PR created automatically by Jules for task [17885871697257747383](https://jules.google.com/task/17885871697257747383) started by @iberi22*