### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Cross-Site Scripting (XSS) in MathRenderer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** KaTeX configuration was set to `trust: true`, allowing potentially malicious LaTeX commands to render raw HTML/execute JS (XSS vulnerability).
 **Learning:** In Svelte components rendering LaTeX via KaTeX, using `trust: true` alongside `{@html ...}` bindings opens a direct XSS vector because KaTeX will trust arbitrary user-provided HTML commands in the LaTeX string, and Svelte will render it unescaped.
 **Prevention:** Always set `trust: false` (the default) in KaTeX configurations when dealing with user-generated or external content. Avoid DOM sanitization libraries (like `isomorphic-dompurify`) to clean KaTeX output unless absolutely necessary, as it can break complex SVG/MathML outputs and add bundle bloat; KaTeX is designed to be secure with `trust: false`.
+
+## 2026-07-31 - Cross-Site Scripting (XSS) in MathRenderer
+**Vulnerability:** The MathRenderer component (`saberparatodos/src/components/MathRenderer.svelte`) rendered raw user input via Svelte's `{@html}` tag without escaping HTML outside of code blocks. This allowed XSS payloads like `<script>alert(1)</script>` to be executed.
+**Learning:** When using custom regex-based markdown/math parsers, HTML escaping must occur globally at the start of the parsing pipeline. Math renderers like KaTeX that fail on escaped entities (`&lt;`) must selectively unescape them within their specific regex replacements.
+**Prevention:** Always escape `<` and `>` at the beginning of any custom parser that feeds into an `{@html}` tag, and selectively unescape inside trusted blocks that are known to be safe (like `trust: false` configured KaTeX blocks).

--- a/saberparatodos/src/components/MathRenderer.svelte
+++ b/saberparatodos/src/components/MathRenderer.svelte
@@ -36,6 +36,9 @@
     // Trim input to remove leading/trailing whitespace/newlines
     let result = text.trim();
 
+    // 🛡️ SECURITY: Escape HTML to prevent XSS (Cross-Site Scripting)
+    result = result.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
     // 🎥 Multimedia Parsers (English Protocol v3.0)
     // 1. YouTube: {{youtube:ID}} -> iframe
     result = result.replace(
@@ -52,7 +55,8 @@
     // First handle block math ($$...$$)
     result = result.replace(BLOCK_MATH_REGEX, (match, latex) => {
       try {
-        return katex.renderToString(latex.trim(), {
+        let cleanLatex = latex.trim().replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+        return katex.renderToString(cleanLatex, {
           displayMode: true,
           throwOnError: false,
           errorColor: '#ef4444',
@@ -69,7 +73,7 @@
     result = result.replace(INLINE_MATH_REGEX, (match, latex) => {
       try {
         // Remove trailing punctuation like period or comma inside LaTeX if it was accidentally captured
-        let cleanLatex = latex.trim();
+        let cleanLatex = latex.trim().replace(/&lt;/g, '<').replace(/&gt;/g, '>');
         const trailingPunctuation = /[.,;:]+$/.exec(cleanLatex);
         let suffix = '';
         if (trailingPunctuation) {
@@ -93,14 +97,13 @@
 
     // Handle code blocks (```code```) BEFORE other markdown to avoid conflict
     result = result.replace(/```([\s\S]*?)```/g, (match, code) => {
-      // Escape HTML in code block
-      const escaped = code.trim().replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const escaped = code.trim();
       return `<pre class="bg-gray-900 rounded-xl p-4 overflow-x-auto text-sm font-mono text-emerald-300 border border-white/10 my-4"><code>${escaped}</code></pre>`;
     });
 
     // Handle inline code (`code`)
     result = result.replace(/`([^`\n]+)`/g, (match, code) => {
-      const escaped = code.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const escaped = code;
       return `<code class="bg-gray-800 rounded px-1.5 py-0.5 text-sm font-mono text-emerald-300">${escaped}</code>`;
     });
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Cross-Site Scripting (XSS) in MathRenderer

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `MathRenderer` component (`saberparatodos/src/components/MathRenderer.svelte`) passes user input into Svelte's `{@html}` tag without proper escaping outside of markdown code blocks. This allowed raw HTML, such as `<script>` or `<img onerror>`, to execute arbitrary code.
🎯 **Impact:** Exploitation could allow malicious actors to perform XSS attacks via user-supplied text like comments, question payloads, or user profiles.
🔧 **Fix:** Added a global HTML escaping step (`<` to `&lt;`, `>` to `&gt;`) at the beginning of the `renderMath` function. Since KaTeX errors on `&lt;`, the inline and block math replacers selectively unescape these entities back to `<` and `>` before rendering. KaTeX itself is securely configured with `trust: false`.
✅ **Verification:** Unit tests pass and the security risk is remediated. See Sentinel's journal entry in `.jules/sentinel.md` for more details.

---
*PR created automatically by Jules for task [2001991564011789267](https://jules.google.com/task/2001991564011789267) started by @iberi22*