### PR TITLE
🛡️ Sentinel: [HIGH] Fix Supabase SSR global state leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A hardcoded secret ('spt-captcha-2026-worldexams-secret-key') was used as a fallback for the CAPTCHA verification token signing in `verify-captcha.ts`.
 **Learning:** Hardcoded fallback values for secrets undermine security since any attacker with access to the source code can use them to bypass protections (e.g. generating valid verification tokens).
 **Prevention:** Fail securely if a secret is missing from environment configuration instead of falling back to a hardcoded string. Check for configuration at runtime and return an appropriate error code if missing.
+
+## 2026-08-05 - [Fix Supabase SSR Client State Leakage]
+**Vulnerability:** A global singleton Supabase client (`import { supabase } from '../../../lib/supabase'`) was being imported and used to check auth and insert rows within a server-side route (`generate-link-token.ts`).
+**Learning:** In Astro or other SSR environments, global singleton database clients can leak state across concurrent user requests, potentially allowing one request to execute queries using the authenticated session of another request.
+**Prevention:** Always create a request-scoped Supabase client per API invocation (e.g. `createServerSupabaseClient` utilizing the user's specific access token or using an admin client exclusively for server-to-server operations).

--- a/saberparatodos/src/pages/api/auth/generate-link-token.ts
+++ b/saberparatodos/src/pages/api/auth/generate-link-token.ts
@@ -1,13 +1,16 @@
 import type { APIRoute } from 'astro';
-import { supabase } from '../../../lib/supabase';
+import { createServerSupabaseClient, getServerRuntimeEnv, type RuntimeLocals } from '../../../lib/server-runtime';
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
   // 1. Auth Check (Must be logged in)
   const authHeader = request.headers.get('Authorization');
   if (!authHeader) return new Response('Unauthorized', { status: 401 });
 
   const token = authHeader.replace('Bearer ', '');
-  const { data: { user }, error } = await supabase.auth.getUser(token);
+  const env = getServerRuntimeEnv(locals as RuntimeLocals);
+  const supabase = createServerSupabaseClient(env, token);
+
+  const { data: { user }, error } = await supabase.auth.getUser();
 
   if (error || !user) {
     return new Response('Unauthorized', { status: 401 });


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Supabase SSR global state leakage

🚨 Severity: HIGH
💡 Vulnerability: The `generate-link-token.ts` API route was importing a global `supabase` client. Calling `.getUser()` or doing inserts using a shared instance in a server-side route can result in state leakage across concurrent user requests.
🎯 Impact: One user could accidentally insert a row as another user, or session state could become corrupted across different clients hitting the API concurrently.
🔧 Fix: Replaced the global client with a request-scoped Supabase client using `createServerSupabaseClient` and the user's explicit token from the `Authorization` header.
✅ Verification: Ran `pnpm test:unit` successfully.

Also recorded learning about SSR state leakage in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18043885752589175721](https://jules.google.com/task/18043885752589175721) started by @iberi22*