### PR TITLE
🎨 Palette: Enhance Keyboard Accessibility in Feedback Flow

### DIFF
--- a/saberparatodos/src/components/GlobalFeedbackButton.svelte
+++ b/saberparatodos/src/components/GlobalFeedbackButton.svelte
@@ -44,7 +44,7 @@
   <div class="fixed bottom-6 right-6 z-40 print:hidden" in:fly={{ y: 20, duration: 500 }}>
     <button
       on:click={() => showModal = true}
-      class="group flex items-center gap-2 px-4 py-3 bg-[#121212]/90 backdrop-blur-md border border-white/10 hover:border-emerald-500/50 rounded-full shadow-lg hover:shadow-emerald-500/10 transition-all duration-300 transform hover:-translate-y-1"
+      class="group flex items-center gap-2 px-4 py-3 bg-[#121212]/90 backdrop-blur-md border border-white/10 hover:border-emerald-500/50 rounded-full shadow-lg hover:shadow-emerald-500/10 transition-all duration-300 transform hover:-translate-y-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#121212]"
       aria-label="Dejanos tu feedback"
     >
       <div class="relative">

--- a/saberparatodos/src/components/ReportModal.svelte
+++ b/saberparatodos/src/components/ReportModal.svelte
@@ -110,7 +110,7 @@
             <span>{questionId ? '🚩 Reportar Problema' : '💬 Enviar Feedback'}</span>
           {/if}
         </h3>
-        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors" aria-label="Cerrar modal de reporte">
+        <button on:click={onClose} class="text-white/40 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded" aria-label="Cerrar modal de reporte">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -143,7 +143,7 @@
               {#each reportTypes as type}
                 {#if questionId || !type.requiresQuestion}
                   <button
-                    class={`px-3 py-2 rounded-lg text-xs font-medium border transition-all text-left truncate
+                    class={`px-3 py-2 rounded-lg text-xs font-medium border transition-all text-left truncate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1 focus-visible:ring-offset-[#121212]
                       ${reportType === type.id
                         ? 'bg-emerald-600 border-emerald-500 text-white shadow-lg shadow-emerald-500/20'
                         : 'bg-white/5 border-white/5 text-white/60 hover:bg-white/10 hover:border-white/10'
@@ -194,14 +194,14 @@
           <div class="pt-4 flex justify-between items-center gap-3">
             <button
               on:click={onClose}
-              class="px-4 py-2 rounded-lg text-xs font-bold text-white/40 hover:text-white hover:bg-white/10 transition-colors"
+              class="px-4 py-2 rounded-lg text-xs font-bold text-white/40 hover:text-white hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
             >
               Cancelar
             </button>
             <button
               on:click={handleSubmit}
               disabled={loading}
-              class="px-6 py-2 bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-bold uppercase tracking-widest rounded-lg shadow-lg shadow-emerald-600/20 transition-all transform active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              class="px-6 py-2 bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-bold uppercase tracking-widest rounded-lg shadow-lg shadow-emerald-600/20 transition-all transform active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#121212]"
             >
               {#if loading}
                 <div class="w-3 h-3 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>


### PR DESCRIPTION
This PR enhances keyboard navigation accessibility in the feedback flow by adding distinct focus rings to the interactive elements.

Changes made:
- Applied `focus-visible:ring-2 focus-visible:ring-emerald-500` to the global feedback trigger button and all buttons within the feedback modal.
- Avoided using standard `focus:ring` to prevent mouse/touch users from seeing unnecessary focus outlines when clicking.
- Handled visual offset appropriately with `focus-visible:ring-offset-2`.

---
*PR created automatically by Jules for task [10474643056398678966](https://jules.google.com/task/10474643056398678966) started by @iberi22*