### PR TITLE
⚡ Bolt: Optimize ResultsView.svelte multiple $derived filter iterations into a single O(N) derived.by pass

### DIFF
--- a/saberparatodos/src/components/ResultsView.svelte
+++ b/saberparatodos/src/components/ResultsView.svelte
@@ -94,19 +94,23 @@
   let safeQuestions = $derived(Array.isArray(questions) ? questions : []);
   let totalQuestions = $derived(safeQuestions.length);
 
-  let correctCount = $derived(safeQuestions.filter(q => {
-    const u = String(userAnswers[q.id] || '').trim().toLowerCase();
-    const c = String(q.correctOptionId || '').trim().toLowerCase();
-    return u === c && u !== '';
-  }).length);
+  // ⚡ Bolt Optimization: Calculate correctCount and wrongQuestions in a single pass instead of multiple .filter() iterations
+  let answerStats = $derived.by(() => {
+    return safeQuestions.reduce((acc, q) => {
+      const u = String(userAnswers[q.id] || '').trim().toLowerCase();
+      const c = String(q.correctOptionId || '').trim().toLowerCase();
+      if (u === c && u !== '') {
+        acc.correctCount++;
+      } else {
+        acc.wrongQuestions.push(q);
+      }
+      return acc;
+    }, { correctCount: 0, wrongQuestions: [] as any[] });
+  });
 
+  let correctCount = $derived(answerStats.correctCount);
   let percentage = $derived(totalQuestions > 0 ? Math.round((correctCount / totalQuestions) * 100) : 0);
-
-  let wrongQuestions = $derived(safeQuestions.filter(q => {
-    const u = String(userAnswers[q.id] || '').trim().toLowerCase();
-    const c = String(q.correctOptionId || '').trim().toLowerCase();
-    return !(u === c && u !== '');
-  }));
+  let wrongQuestions = $derived(answerStats.wrongQuestions);
 
   let canNativeShare = $state(false);
   let shareFeedback = $state<string | null>(null);


### PR DESCRIPTION
💡 What: Replaced two `$derived` array filtering blocks (`correctCount`, `wrongQuestions`) with a single `$derived.by()` block that uses `reduce()` to partition the array in one pass.
🎯 Why: Iterating over `safeQuestions` multiple times per reactivity trigger is redundant and less performant. By merging the loops, we halve the time complexity coefficient.
📊 Impact: Expected to slightly reduce UI render overhead during result recalculations. The operations transform from O(2N) back to O(N).
🔬 Measurement: Verify using Svelte component profiler (or implicitly via successful test suites, which passed).

---
*PR created automatically by Jules for task [1392796822638215715](https://jules.google.com/task/1392796822638215715) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved results processing for more efficient calculation of correct answers and incorrect questions.
  * Preserved existing percentage and incorrect-question displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->