### PR TITLE
Validation wave - Mesh functionality unit tests

### DIFF
--- a/saberparatodos/tests/unit/antiCheat.unit.test.ts
+++ b/saberparatodos/tests/unit/antiCheat.unit.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { antiCheatService } from '../../src/modules/exam-room/services/antiCheat';
+import type { SuspiciousEvent } from '../../src/modules/exam-room/types';
+
+describe('AntiCheatService Lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Stop monitoring to start with a clean state
+    antiCheatService.stopMonitoring();
+  });
+
+  afterEach(() => {
+    antiCheatService.stopMonitoring();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should start and stop monitoring correctly', () => {
+    const addEventSpy = vi.spyOn(document, 'addEventListener');
+    const removeEventSpy = vi.spyOn(document, 'removeEventListener');
+    const callback = vi.fn();
+
+    antiCheatService.startMonitoring(callback);
+    expect(addEventSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+
+    antiCheatService.stopMonitoring();
+    expect(removeEventSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+  });
+
+  it('should ignore multiple start monitoring requests', () => {
+    const addEventSpy = vi.spyOn(document, 'addEventListener');
+    const callback = vi.fn();
+
+    antiCheatService.startMonitoring(callback);
+    const firstCallCount = addEventSpy.mock.calls.length;
+
+    antiCheatService.startMonitoring(callback);
+    expect(addEventSpy.mock.calls.length).toBe(firstCallCount);
+  });
+});
+
+describe('AntiCheatService Activity Monitoring', () => {
+  let detectedEvents: SuspiciousEvent[];
+  const callback = (e: SuspiciousEvent) => {
+    detectedEvents.push(e);
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    detectedEvents = [];
+    antiCheatService.stopMonitoring();
+    antiCheatService.startMonitoring(callback);
+  });
+
+  afterEach(() => {
+    antiCheatService.stopMonitoring();
+    vi.useRealTimers();
+  });
+
+  it('should detect window blur', () => {
+    window.dispatchEvent(new Event('blur'));
+
+    expect(detectedEvents).toHaveLength(1);
+    expect(detectedEvents[0].type).toBe('window_blur');
+    expect(detectedEvents[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  it('should record activity and reset window focus', () => {
+    const recordSpy = vi.spyOn(antiCheatService, 'recordActivity');
+    window.dispatchEvent(new Event('focus'));
+    expect(recordSpy).toHaveBeenCalled();
+  });
+
+  it('should detect page hidden and page returned', () => {
+    let hidden = true;
+    Object.defineProperty(document, 'hidden', {
+      get: () => hidden,
+      configurable: true,
+    });
+
+    // Simulate switching away (page hidden)
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(detectedEvents).toHaveLength(1);
+    expect(detectedEvents[0].type).toBe('page_hidden');
+    expect(detectedEvents[0].duration).toBeUndefined();
+
+    // Advance time by 5000ms
+    vi.advanceTimersByTime(5000);
+
+    // Simulate returning (page visible)
+    hidden = false;
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(detectedEvents).toHaveLength(2);
+    expect(detectedEvents[1].type).toBe('page_hidden');
+    expect(detectedEvents[1].duration).toBe(5000);
+  });
+
+  it('should detect long inactivity', () => {
+    // Threshold is 30 seconds, checked every 10 seconds.
+    // Advance timers by 40 seconds to trigger checks and exceed threshold.
+    vi.advanceTimersByTime(40000);
+
+    expect(detectedEvents).toHaveLength(1);
+    expect(detectedEvents[0].type).toBe('long_inactivity');
+    expect(detectedEvents[0].duration).toBeGreaterThanOrEqual(30000);
+
+    // Reset list and check that recordActivity avoids the inactivity alert
+    detectedEvents = [];
+    antiCheatService.recordActivity();
+
+    vi.advanceTimersByTime(20000);
+    antiCheatService.recordActivity(); // activity resets timer
+    vi.advanceTimersByTime(20000);
+
+    expect(detectedEvents).toHaveLength(0);
+  });
+});

--- a/saberparatodos/tests/unit/connection.unit.test.ts
+++ b/saberparatodos/tests/unit/connection.unit.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { connectionService } from '../../src/modules/exam-room/services/connection';
+import { p2p } from '../../src/lib/p2p-edge-mesh';
+import { supabase } from '../../src/lib/supabase';
+import { rustBackend } from '../../src/lib/rust-backend';
+import { isSupabaseMirrorEnabled } from '../../src/modules/exam-room/services/authPersistence';
+
+// Mock authPersistence
+vi.mock('../../src/modules/exam-room/services/authPersistence', () => {
+  return {
+    isSupabaseMirrorEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+// Mock rust-backend
+vi.mock('../../src/lib/rust-backend', () => {
+  return {
+    detectBackendMode: vi.fn().mockResolvedValue('local'),
+    rustBackend: {
+      connectToParty: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      send: vi.fn(),
+      onMessage: vi.fn(),
+    },
+  };
+});
+
+// Mock supabase client
+const mockChannel = {
+  on: vi.fn().mockReturnThis(),
+  send: vi.fn(),
+  subscribe: vi.fn((cb) => {
+    cb('SUBSCRIBED');
+  }),
+  unsubscribe: vi.fn(),
+  state: 'joined',
+  presenceState: vi.fn().mockReturnValue({ 'user-1': {} }),
+};
+
+vi.mock('../../src/lib/supabase', () => {
+  return {
+    supabase: {
+      channel: vi.fn().mockImplementation(() => mockChannel),
+    },
+  };
+});
+
+// Mock p2p-edge-mesh
+const mockEstadoMesh = {
+  conexion: 'conectado',
+};
+
+vi.mock('../../src/lib/p2p-edge-mesh', () => {
+  return {
+    p2p: {
+      iniciar: vi.fn().mockResolvedValue('test-nodo-id'),
+      crearSalonExamen: vi.fn().mockResolvedValue('CREATION-ROOM-CODE'),
+      unirseSalonExamen: vi.fn().mockResolvedValue(undefined),
+      salirSalonExamen: vi.fn().mockResolvedValue(undefined),
+      cerrar: vi.fn().mockResolvedValue(undefined),
+      obtenerCodigoSalon: vi.fn().mockReturnValue('SALA-P2P'),
+    },
+    estadoMesh: {
+      subscribe: vi.fn((run) => {
+        run({ conexion: 'conectado' });
+        return () => {};
+      }),
+    },
+    estadoSalon: {
+      subscribe: vi.fn((run) => {
+        run({ id: 'active-id' });
+        return () => {};
+      }),
+    },
+  };
+});
+
+describe('ConnectionService Mode Connections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await connectionService.disconnect();
+  });
+
+  it('should auto-connect default to edge-mesh and call p2p.iniciar', async () => {
+    await connectionService.autoConnect({
+      id: 'ROOM1',
+      name: 'Test Room',
+      hostId: 'h1',
+      nombreUsuario: 'Host A',
+      maxPlayers: 10,
+      timePerQuestion: 60,
+      totalQuestions: 10,
+      grado: 11,
+      asignatura: 'sociales',
+      region: 'LATAM',
+      connectionMode: 'edge-mesh',
+      createdAt: new Date(),
+    });
+
+    expect(connectionService.getMode()).toBe('edge-mesh');
+    expect(p2p.iniciar).toHaveBeenCalledWith('Host A');
+    expect(p2p.unirseSalonExamen).toHaveBeenCalledWith('ROOM1');
+  });
+
+  it('should trigger room creation when mode is edge-mesh and intent is create', async () => {
+    await connectionService.connect({
+      id: 'create',
+      name: 'Asignatura Room',
+      hostId: 'h1',
+      nombreUsuario: 'Host B',
+      maxPlayers: 10,
+      timePerQuestion: 60,
+      totalQuestions: 10,
+      grado: 11,
+      asignatura: 'sociales',
+      region: 'LATAM',
+      connectionMode: 'edge-mesh',
+      meshIntent: 'create',
+      createdAt: new Date(),
+    });
+
+    expect(p2p.crearSalonExamen).toHaveBeenCalledWith(
+      'Asignatura Room',
+      10,
+      expect.objectContaining({ subject: 'sociales', grade: 11 })
+    );
+  });
+
+  it('should connect via Supabase mode when specified and enabled', async () => {
+    vi.mocked(isSupabaseMirrorEnabled).mockReturnValue(true);
+
+    await connectionService.connect({
+      id: 'SALA-SUPA',
+      nombreUsuario: 'Host C',
+      connectionMode: 'supabase',
+      grado: 11,
+      asignatura: 'lectura-critica',
+      createdAt: new Date(),
+    } as any);
+
+    expect(connectionService.getMode()).toBe('supabase');
+    expect(supabase.channel).toHaveBeenCalledWith('party:SALA-SUPA', expect.any(Object));
+    expect(mockChannel.subscribe).toHaveBeenCalled();
+  });
+
+  it('should throw error connecting via Supabase mode when disabled', async () => {
+    vi.mocked(isSupabaseMirrorEnabled).mockReturnValue(false);
+
+    await expect(
+      connectionService.connect({
+        id: 'SALA-SUPA',
+        connectionMode: 'supabase',
+      } as any)
+    ).rejects.toThrow('El modo Supabase para salones está desactivado');
+  });
+
+  it('should connect via local mode using Rust Backend', async () => {
+    await connectionService.connect({
+      id: 'SALA-RUST',
+      connectionMode: 'local',
+    } as any);
+
+    expect(connectionService.getMode()).toBe('local');
+    expect(rustBackend.connectToParty).toHaveBeenCalledWith('SALA-RUST');
+  });
+});
+
+describe('ConnectionService Communication and Status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await connectionService.disconnect();
+  });
+
+  it('should handle broadcast properly depending on active mode', async () => {
+    const dummyMsg = { type: 'chat_message', sender: 'Lucas', text: 'Hola' } as any;
+
+    // 1. Supabase Mode Broadcast
+    vi.mocked(isSupabaseMirrorEnabled).mockReturnValue(true);
+    await connectionService.connect({
+      id: 'SALA-BROAD',
+      connectionMode: 'supabase',
+    } as any);
+
+    connectionService.broadcast(dummyMsg);
+    expect(mockChannel.send).toHaveBeenCalledWith({
+      type: 'broadcast',
+      event: 'party_message',
+      payload: dummyMsg,
+    });
+
+    // 2. Local Mode Broadcast
+    await connectionService.connect({
+      id: 'SALA-BROAD-LOCAL',
+      connectionMode: 'local',
+    } as any);
+
+    connectionService.broadcast(dummyMsg);
+    expect(rustBackend.send).toHaveBeenCalledWith(dummyMsg);
+  });
+
+  it('should return correct connection status based on mode', async () => {
+    // 1. edge-mesh mode state lookup (uses store subscription we mocked to 'conectado')
+    await connectionService.connect({
+      id: 'SALA-STATUS-MESH',
+      connectionMode: 'edge-mesh',
+    } as any);
+    expect(connectionService.getConnectionStatus()).toBe('connected');
+
+    // 2. supabase mode state lookup (uses channel.state)
+    mockChannel.state = 'joined';
+    await connectionService.connect({
+      id: 'SALA-STATUS-SUPA',
+      connectionMode: 'supabase',
+    } as any);
+    expect(connectionService.getConnectionStatus()).toBe('connected');
+  });
+
+  it('should clear message handlers and trigger disconnect cleanup', async () => {
+    await connectionService.connect({
+      id: 'SALA-DISCONNECT',
+      connectionMode: 'edge-mesh',
+    } as any);
+
+    await connectionService.disconnect();
+    expect(p2p.salirSalonExamen).toHaveBeenCalled();
+    expect(p2p.cerrar).toHaveBeenCalled();
+  });
+
+  it('should return correct room code from getCodigoSala', async () => {
+    await connectionService.connect({
+      id: 'INITIAL-CODE',
+      connectionMode: 'edge-mesh',
+    } as any);
+
+    // Should return value from p2p.obtenerCodigoSalon first
+    expect(connectionService.getCodigoSala()).toBe('SALA-P2P');
+
+    // If p2p returns null, fallback to the one set in connect
+    vi.spyOn(p2p, 'obtenerCodigoSalon').mockReturnValue(null);
+    expect(connectionService.getCodigoSala()).toBe('INITIAL-CODE');
+  });
+});

--- a/saberparatodos/tests/unit/p2p-edge-mesh.unit.test.ts
+++ b/saberparatodos/tests/unit/p2p-edge-mesh.unit.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { p2p, estadoMesh, estadoSalon, estudiantesConectados } from '../../src/lib/p2p-edge-mesh';
+import { get } from 'svelte/store';
+
+// Define standard mock objects to inspect calls in hoisted block or inside mocks
+const {
+  mockEdgeMeshInstance,
+  mockSalonesManagerInstance,
+  mockSalonRegistryInstance,
+  mockExamenCompartidoInstance
+} = vi.hoisted(() => {
+  return {
+    mockEdgeMeshInstance: {
+      iniciar: vi.fn().mockResolvedValue(undefined),
+      detener: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+      off: vi.fn(),
+      yjsAdapter: {},
+    },
+    mockSalonesManagerInstance: {
+      crearSalon: vi.fn().mockResolvedValue({
+        id: 'MOCK-SALON-ID',
+        obtenerInfo: vi.fn().mockReturnValue({ creador: 'host', participantes: ['host'] }),
+      }),
+      unirsePorCodigo: vi.fn().mockResolvedValue({
+        id: 'JOINED-SALON-ID',
+        obtenerInfo: vi.fn().mockReturnValue({ creador: 'host', nombre: 'Test Room', participantes: ['host', 'player'] }),
+      }),
+      abandonarSalon: vi.fn().mockResolvedValue(undefined),
+    },
+    mockSalonRegistryInstance: {
+      anunciar: vi.fn().mockImplementation((ad) => ad),
+      listar: vi.fn().mockReturnValue([{ codigo: 'ROOM-1', nombre: 'Room 1' }]),
+      dispose: vi.fn(),
+    },
+    mockExamenCompartidoInstance: {
+      addEventListener: vi.fn(),
+      cargarPreguntas: vi.fn().mockResolvedValue(undefined),
+      agregarPregunta: vi.fn().mockResolvedValue(undefined),
+      enviarRespuesta: vi.fn().mockResolvedValue(undefined),
+      iniciarExamen: vi.fn().mockResolvedValue(undefined),
+      finalizarExamen: vi.fn().mockResolvedValue(undefined),
+      obtenerPreguntas: vi.fn().mockReturnValue([
+        { id: 'q-1', enunciado: 'P1', options: ['A'], respuestaCorrecta: 'A', puntaje: 10 }
+      ]),
+      obtenerRespuestas: vi.fn().mockReturnValue(new Map([['p1', 'A']])),
+      obtenerRespuestasDeEstudiante: vi.fn().mockReturnValue(new Map([['q-1', 'A']])),
+      obtenerEstado: vi.fn().mockReturnValue({ current: 'active' }),
+    }
+  };
+});
+
+vi.mock('edge-mesh', () => {
+  class MockEdgeMesh {
+    iniciar = mockEdgeMeshInstance.iniciar;
+    detener = mockEdgeMeshInstance.detener;
+    on = mockEdgeMeshInstance.on;
+    off = mockEdgeMeshInstance.off;
+    yjsAdapter = mockEdgeMeshInstance.yjsAdapter;
+  }
+
+  class MockSalonesManager {
+    crearSalon = mockSalonesManagerInstance.crearSalon;
+    unirsePorCodigo = mockSalonesManagerInstance.unirsePorCodigo;
+    abandonarSalon = mockSalonesManagerInstance.abandonarSalon;
+    usarRegistry = vi.fn();
+  }
+
+  class MockSalonRegistry {
+    anunciar = mockSalonRegistryInstance.anunciar;
+    listar = mockSalonRegistryInstance.listar;
+    dispose = mockSalonRegistryInstance.dispose;
+  }
+
+  class MockExamenCompartido {
+    addEventListener = mockExamenCompartidoInstance.addEventListener;
+    cargarPreguntas = mockExamenCompartidoInstance.cargarPreguntas;
+    agregarPregunta = mockExamenCompartidoInstance.agregarPregunta;
+    enviarRespuesta = mockExamenCompartidoInstance.enviarRespuesta;
+    iniciarExamen = mockExamenCompartidoInstance.iniciarExamen;
+    finalizarExamen = mockExamenCompartidoInstance.finalizarExamen;
+    obtenerPreguntas = mockExamenCompartidoInstance.obtenerPreguntas;
+    obtenerRespuestas = mockExamenCompartidoInstance.obtenerRespuestas;
+    obtenerRespuestasDeEstudiante = mockExamenCompartidoInstance.obtenerRespuestasDeEstudiante;
+    obtenerEstado = mockExamenCompartidoInstance.obtenerEstado;
+  }
+
+  return {
+    EdgeMesh: MockEdgeMesh,
+    SalonesManager: MockSalonesManager,
+    SalonRegistry: MockSalonRegistry,
+    ExamenCompartido: MockExamenCompartido,
+    TIPO_SALON: {
+      EXAMEN: 'EXAMEN',
+    },
+    TIPO_PREGUNTA: {
+      OPCION_MULTIPLE: 'opcion_multiple',
+      VERDADERO_FALSO: 'verdadero_falso',
+      RESPUESTA_CORTA: 'respuesta_corta',
+      ENSAYO: 'ensayo',
+    },
+  };
+});
+
+describe('P2PEdgeMesh Lifecycle and Setup', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await p2p.cerrar();
+  });
+
+  afterEach(async () => {
+    await p2p.cerrar();
+  });
+
+  it('should initialize correctly and transition estadoMesh store to conectado', async () => {
+    // Initial state before starting
+    expect(get(estadoMesh).conexion).toBe('desconectado');
+
+    // Start mesh
+    const nodoId = await p2p.iniciar('Lucas');
+
+    expect(nodoId).toContain('we-');
+    expect(get(estadoMesh).conexion).toBe('conectado');
+    expect(get(estadoMesh).miNodoId).toBe(nodoId);
+    expect(mockEdgeMeshInstance.iniciar).toHaveBeenCalled();
+  });
+
+  it('should skip double mesh initialization if already running', async () => {
+    const firstNodoId = await p2p.iniciar('Lucas');
+    const secondNodoId = await p2p.iniciar('Lucas');
+
+    expect(firstNodoId).toBe(secondNodoId);
+    expect(mockEdgeMeshInstance.iniciar).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reset stores and dispose elements when cerrar is called', async () => {
+    await p2p.iniciar('Lucas');
+    await p2p.cerrar();
+
+    expect(get(estadoMesh).conexion).toBe('desconectado');
+    expect(get(estadoMesh).miNodoId).toBeNull();
+    expect(mockEdgeMeshInstance.detener).toHaveBeenCalled();
+    expect(mockSalonRegistryInstance.dispose).toHaveBeenCalled();
+  });
+});
+
+describe('P2PEdgeMesh Rooms and Exams Sync', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await p2p.iniciar('Profesor');
+  });
+
+  afterEach(async () => {
+    await p2p.cerrar();
+  });
+
+  it('should create a new salon and update estadoSalon correctly', async () => {
+    const roomCode = await p2p.crearSalonExamen('Examen Matematicas', 40, { region: 'ES' });
+
+    expect(roomCode).toBe('MOCK-SALON-ID');
+    expect(mockSalonesManagerInstance.crearSalon).toHaveBeenCalledWith(
+      'Examen Matematicas',
+      'EXAMEN',
+      40,
+      { region: 'ES' }
+    );
+
+    const activeSalon = get(estadoSalon);
+    expect(activeSalon).not.toBeNull();
+    expect(activeSalon?.id).toBe('MOCK-SALON-ID');
+    expect(activeSalon?.nombre).toBe('Examen Matematicas');
+    expect(activeSalon?.estado).toBe('esperando');
+  });
+
+  it('should join an existing salon and update state', async () => {
+    await p2p.unirseSalonExamen('SALA-123');
+
+    expect(mockSalonesManagerInstance.unirsePorCodigo).toHaveBeenCalledWith('SALA-123');
+    const activeSalon = get(estadoSalon);
+    expect(activeSalon?.id).toBe('SALA-123');
+    expect(activeSalon?.nombre).toBe('Test Room');
+  });
+
+  it('should leave current salon and set store to null', async () => {
+    await p2p.unirseSalonExamen('SALA-123');
+    await p2p.salirSalonExamen();
+
+    expect(mockSalonesManagerInstance.abandonarSalon).toHaveBeenCalledWith('JOINED-SALON-ID');
+    expect(get(estadoSalon)).toBeNull();
+  });
+
+  it('should list and announce salons correctly', () => {
+    const list = p2p.listarSalones('ES');
+    expect(mockSalonRegistryInstance.listar).toHaveBeenCalledWith('ES');
+    expect(list).toHaveLength(1);
+    expect(list[0].codigo).toBe('ROOM-1');
+
+    p2p.anunciarSalon({ id: 'MY-SALON', nombre: 'My Salon' } as any);
+    expect(mockSalonRegistryInstance.anunciar).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'MY-SALON', nombre: 'My Salon' })
+    );
+  });
+
+  it('should call examenCompartido actions correctly', async () => {
+    await p2p.crearSalonExamen('Math', 10);
+
+    // standard questions charging
+    const questions = [
+      { id: 'q-1', tipo: 'opcion_multiple' as const, enunciado: 'P1', puntaje: 10 }
+    ];
+    await p2p.cargarPreguntas(questions);
+    expect(mockExamenCompartidoInstance.cargarPreguntas).toHaveBeenCalled();
+
+    // add question
+    await p2p.agregarPregunta({ id: 'q-2', tipo: 'verdadero_falso' as const, enunciado: 'P2', puntaje: 5 });
+    expect(mockExamenCompartidoInstance.agregarPregunta).toHaveBeenCalled();
+
+    // send answer
+    await p2p.enviarRespuesta('q-1', 'A');
+    expect(mockExamenCompartidoInstance.enviarRespuesta).toHaveBeenCalled();
+
+    // start & finish
+    await p2p.iniciarExamen();
+    expect(mockExamenCompartidoInstance.iniciarExamen).toHaveBeenCalled();
+
+    await p2p.finalizarExamen();
+    expect(mockExamenCompartidoInstance.finalizarExamen).toHaveBeenCalled();
+
+    // getters
+    const qs = await p2p.obtenerPreguntas();
+    expect(qs).toHaveLength(1);
+    expect(qs[0].id).toBe('q-1');
+
+    const responses = await p2p.obtenerRespuestas();
+    expect(responses.get('p1')).toBe('A');
+
+    const studentResp = await p2p.obtenerRespuestasDeEstudiante('p1');
+    expect(studentResp.get('q-1')).toBe('A');
+
+    const state = await p2p.obtenerEstadoExamen();
+    expect(state.current).toBe('active');
+  });
+});

--- a/saberparatodos/tests/unit/reportGenerator.unit.test.ts
+++ b/saberparatodos/tests/unit/reportGenerator.unit.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { reportGeneratorService } from '../../src/modules/exam-room/services/reportGenerator';
+import type { RoomResults } from '../../src/modules/exam-room/types';
+
+// Mock jsPDF using standard variables to trace calls
+const mockText = vi.fn();
+const mockSetFontSize = vi.fn();
+const mockAddPage = vi.fn();
+const mockOutput = vi.fn().mockReturnValue(new Blob(['pdf-data'], { type: 'application/pdf' }));
+const mockInternal = {
+  pageSize: {
+    getWidth: () => 595,
+    getHeight: () => 842,
+  },
+};
+
+class MockjsPDF {
+  text = mockText;
+  setFontSize = mockSetFontSize;
+  addPage = mockAddPage;
+  output = mockOutput;
+  internal = mockInternal;
+  splitTextToSize(text: string) {
+    return [text];
+  }
+}
+
+vi.mock('jspdf', () => {
+  return {
+    jsPDF: MockjsPDF,
+  };
+});
+
+describe('ReportGenerator HTML Generation', () => {
+  let sampleResults: RoomResults;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sampleResults = {
+      roomId: 'ROOM123',
+      roomName: 'Examen de Prueba',
+      totalPlayers: 2,
+      completedPlayers: 2,
+      averageScore: 75,
+      averageTime: 45000,
+      generatedAt: new Date('2026-08-05T12:00:00Z'),
+      playerStats: [
+        {
+          playerId: 'p1',
+          playerName: 'Estudiante A',
+          score: 80,
+          correctAnswers: 8,
+          totalQuestions: 10,
+          averageTimePerQuestion: 4000,
+          suspiciousEvents: 0,
+          recommendation: 'Excelente desempeño.',
+        },
+        {
+          playerId: 'p2',
+          playerName: 'Estudiante B',
+          score: 70,
+          correctAnswers: 7,
+          totalQuestions: 10,
+          averageTimePerQuestion: 5000,
+          suspiciousEvents: 2,
+          recommendation: 'Buen trabajo, mantén el ritmo.',
+        },
+      ],
+      questionStats: [
+        { questionId: 'q1', correctCount: 2, incorrectCount: 0 },
+        { questionId: 'q2', correctCount: 1, incorrectCount: 1 },
+      ],
+    };
+  });
+
+  it('should generate a complete HTML report structure', async () => {
+    const report = await reportGeneratorService.generateFullReport(sampleResults, {
+      format: 'html',
+      includeCharts: true,
+      includeRecommendations: true,
+    });
+
+    expect(typeof report).toBe('string');
+    const htmlReport = report as string;
+
+    expect(htmlReport).toContain('Reporte de Examen');
+    expect(htmlReport).toContain('Examen de Prueba');
+    expect(htmlReport).toContain('Estudiante A');
+    expect(htmlReport).toContain('Estudiante B');
+    expect(htmlReport).toContain('Excelente desempeño.');
+    expect(htmlReport).toContain('Buen trabajo, mantén el ritmo.');
+    expect(htmlReport).toContain('scoreDistributionChart');
+  });
+
+  it('should generate HTML report without charts or recommendations when options are disabled', async () => {
+    const report = await reportGeneratorService.generateFullReport(sampleResults, {
+      format: 'html',
+      includeCharts: false,
+      includeRecommendations: false,
+    });
+
+    const htmlReport = report as string;
+    expect(htmlReport).not.toContain('Análisis Visual');
+    expect(htmlReport).not.toContain('Recomendaciones Personalizadas');
+  });
+});
+
+describe('ReportGenerator PDF Generation & Edge Cases', () => {
+  let sampleResults: RoomResults;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sampleResults = {
+      roomId: 'ROOM123',
+      roomName: 'Examen de Geometría',
+      totalPlayers: 3,
+      completedPlayers: 3,
+      averageScore: 85,
+      averageTime: 30000,
+      generatedAt: new Date('2026-08-05T12:00:00Z'),
+      playerStats: [
+        {
+          playerId: 'p1',
+          playerName: 'Lucía',
+          score: 90,
+          correctAnswers: 9,
+          totalQuestions: 10,
+          averageTimePerQuestion: 3000,
+          suspiciousEvents: 0,
+          recommendation: 'Dominio excepcional del tema.',
+        },
+        {
+          playerId: 'p2',
+          playerName: 'Hugo',
+          score: 90, // Tie
+          correctAnswers: 9,
+          totalQuestions: 10,
+          averageTimePerQuestion: 2800,
+          suspiciousEvents: 0,
+          recommendation: 'Sigue practicando.',
+        },
+        {
+          playerId: 'p3',
+          playerName: 'Martín',
+          score: 45, // Low Score
+          correctAnswers: 4,
+          totalQuestions: 10,
+          averageTimePerQuestion: 4500,
+          suspiciousEvents: 5, // High suspicious count
+          recommendation: 'Necesita repasar los conceptos básicos.',
+        },
+      ],
+      questionStats: [],
+    };
+  });
+
+  it('should generate a PDF report calling jsPDF methods', async () => {
+    const report = await reportGeneratorService.generateFullReport(sampleResults, {
+      format: 'pdf',
+      includeCharts: true,
+      includeRecommendations: true,
+    });
+
+    expect(report).toBeInstanceOf(Blob);
+    expect(mockSetFontSize).toHaveBeenCalled();
+    expect(mockText).toHaveBeenCalledWith(expect.stringContaining('Examen de Geometría'), expect.any(Number), expect.any(Number));
+    expect(mockText).toHaveBeenCalledWith(expect.stringContaining('Lucía'), expect.any(Number), expect.any(Number));
+    expect(mockText).toHaveBeenCalledWith(expect.stringContaining('Hugo'), expect.any(Number), expect.any(Number));
+    expect(mockText).toHaveBeenCalledWith(expect.stringContaining('Martín'), expect.any(Number), expect.any(Number));
+  });
+
+  it('should generate player-specific report correctly', async () => {
+    const report = await reportGeneratorService.generatePlayerReport(sampleResults, 'p3', {
+      format: 'pdf',
+      includeCharts: false,
+      includeRecommendations: true,
+    });
+
+    expect(report).toBeInstanceOf(Blob);
+    expect(mockText).toHaveBeenCalledWith(expect.stringContaining('Martín'), expect.any(Number), expect.any(Number));
+    // Hugo and Lucía shouldn't be included as playerStats is filtered to just Martín
+    expect(mockText).not.toHaveBeenCalledWith(expect.stringContaining('Lucía'), expect.any(Number), expect.any(Number));
+  });
+
+  it('should throw error when generating report for non-existent player', async () => {
+    await expect(
+      reportGeneratorService.generatePlayerReport(sampleResults, 'unknown-id')
+    ).rejects.toThrow('Player not found in results');
+  });
+
+  it('should handle edge case of 0 players', async () => {
+    const emptyResults: RoomResults = {
+      roomId: 'EMPTY',
+      roomName: 'No Players Room',
+      totalPlayers: 0,
+      completedPlayers: 0,
+      averageScore: 0,
+      averageTime: 0,
+      generatedAt: new Date(),
+      playerStats: [],
+      questionStats: [],
+    };
+
+    const report = await reportGeneratorService.generateFullReport(emptyResults, {
+      format: 'html',
+      includeCharts: false,
+      includeRecommendations: false,
+    });
+
+    expect(report).toContain('No Players Room');
+    expect(report).toContain('0'); // Average score & players
+  });
+
+  it('should trigger browser download on downloadReport', () => {
+    const mockAnchor = {
+      href: '',
+      download: '',
+      click: vi.fn(),
+    };
+
+    // Stub global document operations
+    const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor as any);
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(() => mockAnchor as any);
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation(() => mockAnchor as any);
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url');
+    const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    reportGeneratorService.downloadReport('dummy-html', 'mi-reporte', 'html');
+
+    expect(createElementSpy).toHaveBeenCalledWith('a');
+    expect(appendChildSpy).toHaveBeenCalledWith(mockAnchor);
+    expect(mockAnchor.download).toBe('mi-reporte.html');
+    expect(mockAnchor.click).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalledWith(mockAnchor);
+    expect(createObjectURLSpy).toHaveBeenCalled();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:url');
+  });
+});

--- a/saberparatodos/tests/unit/roomState.unit.test.ts
+++ b/saberparatodos/tests/unit/roomState.unit.test.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
+
+// Define the Svelte $state rune globally before importing roomState
+(globalThis as any).$state = (val: any) => val;
+
+import { connectionService } from '../../src/modules/exam-room/services/connection';
+import { antiCheatService } from '../../src/modules/exam-room/services/antiCheat';
+import { p2p } from '../../src/lib/p2p-edge-mesh';
+
+// Mock connectionService
+vi.mock('../../src/modules/exam-room/services/connection', () => {
+  return {
+    connectionService: {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      broadcast: vi.fn(),
+      onMessage: vi.fn(),
+      getCodigoSala: vi.fn().mockReturnValue('ROOM_MOCK_CODE'),
+    },
+  };
+});
+
+// Mock antiCheatService
+vi.mock('../../src/modules/exam-room/services/antiCheat', () => {
+  return {
+    antiCheatService: {
+      startMonitoring: vi.fn(),
+      stopMonitoring: vi.fn(),
+    },
+  };
+});
+
+// Mock p2p-edge-mesh
+vi.mock('../../src/lib/p2p-edge-mesh', () => {
+  return {
+    p2p: {
+      iniciar: vi.fn().mockResolvedValue('lobby-browser'),
+      listarSalones: vi.fn().mockReturnValue([
+        {
+          codigo: 'SALA-DISC',
+          nombre: 'Sala Publica',
+          hostPeerId: 'host-peer-1',
+          hostNodoId: 'host-node-1',
+          maxParticipantes: 50,
+          status: 'waiting',
+          createdAt: Date.now(),
+          region: 'ES',
+        }
+      ]),
+    },
+  };
+});
+
+// Mock authPersistence
+vi.mock('../../src/modules/exam-room/services/authPersistence', () => {
+  return {
+    getSupabaseMirrorUser: vi.fn().mockResolvedValue({ id: 'supabase-user-id' }),
+    isSupabaseMirrorEnabled: vi.fn().mockReturnValue(true),
+    maybePersistPartySession: vi.fn().mockResolvedValue(true),
+    maybePersistPartyResults: vi.fn().mockResolvedValue(true),
+    maybeAnalyzePartyResults: vi.fn().mockResolvedValue({ analysis: 'Análisis generado exitosamente.' }),
+  };
+});
+
+// Mock questions repository
+vi.mock('../../src/lib/questions', () => {
+  return {
+    defaultQuestionRepository: {
+      fetchQuestions: vi.fn().mockResolvedValue([
+        {
+          id: 'q-1',
+          text: '¿Cuánto es 2+2?',
+          options: [
+            { id: 'A', text: '4' },
+            { id: 'B', text: '5' },
+          ],
+          correctOptionId: 'A',
+          grade: 11,
+          category: 'matematicas',
+          difficulty: 3,
+        }
+      ]),
+    },
+    filterValidQuestions: vi.fn().mockReturnValue({
+      validQuestions: [
+        {
+          id: 'q-1',
+          text: '¿Cuánto es 2+2?',
+          options: [
+            { id: 'A', text: '4' },
+            { id: 'B', text: '5' },
+          ],
+          correctOptionId: 'A',
+          grade: 11,
+          category: 'matematicas',
+          difficulty: 3,
+        }
+      ],
+    }),
+    prepareStopModeQuestions: vi.fn().mockResolvedValue([
+      {
+        id: 'q-stop-1',
+        text: 'Stop Mode Question',
+        options: [
+          { id: 'A', text: 'A' },
+          { id: 'B', text: 'B' },
+        ],
+        correctOptionId: 'A',
+      }
+    ]),
+  };
+});
+
+// Import roomState dynamically after the global Svelte rune is defined
+let roomState: any;
+
+describe('RoomState Lifecycle & Creation', () => {
+  beforeAll(async () => {
+    const mod = await import('../../src/modules/exam-room/stores/roomState.svelte');
+    roomState = mod.roomState;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    roomState.currentPlan = 'free';
+  });
+
+  afterEach(() => {
+    roomState.leaveRoom();
+  });
+
+  it('should enforce limits for FREE plan and allow creating standard rooms', async () => {
+    roomState.currentPlan = 'free';
+    const roomId = await roomState.createRoom('Host Name', 'My Free Room', 11, 'matematicas', {
+      totalQuestions: 1,
+    });
+
+    expect(roomId).toBe('ROOM_MOCK_CODE');
+    expect(roomState.config?.maxPlayers).toBe(10); // Limit from free plan
+    expect(roomState.role).toBe('host');
+    expect(roomState.currentPlayer?.name).toBe('Host Name');
+    expect(roomState.currentPlayer?.isHost).toBe(true);
+    expect(roomState.players).toHaveLength(1);
+  });
+
+  it('should enforce exams per week limit on FREE plan', async () => {
+    roomState.currentPlan = 'free';
+    localStorage.setItem('weekly_exam_count', '10'); // Max limit is 10
+    localStorage.setItem('weekly_exam_reset', Date.now().toString());
+
+    await expect(
+      roomState.createRoom('Host Name', 'My Room', 11, 'matematicas', { totalQuestions: 1 })
+    ).rejects.toThrow('PLAN_LIMIT_REACHED');
+  });
+
+  it('should increase maxPlayers limit on PRO and INSTITUTIONAL plans', async () => {
+    // PRO Plan
+    roomState.currentPlan = 'pro';
+    await roomState.createRoom('Host Name', 'Pro Room', 11, 'matematicas', { totalQuestions: 1 });
+    expect(roomState.config?.maxPlayers).toBe(100);
+
+    // INSTITUTIONAL Plan
+    roomState.leaveRoom();
+    roomState.currentPlan = 'institutional';
+    await roomState.createRoom('Host Name', 'Inst Room', 11, 'matematicas', { totalQuestions: 1 });
+    expect(roomState.config?.maxPlayers).toBe(1000);
+  });
+
+  it('should initialize player and register monitors on joinRoom', async () => {
+    const configMock = {
+      id: 'JOIN-ROOM',
+      name: 'Existing Room',
+      hostId: 'h1',
+      hostName: 'Host B',
+      maxPlayers: 10,
+      timePerQuestion: 60,
+      totalQuestions: 5,
+      grado: 11,
+      asignatura: 'sociales',
+      connectionMode: 'edge-mesh',
+      createdAt: new Date(),
+    } as any;
+
+    await roomState.joinRoom('JOIN-ROOM', 'Player A', configMock);
+
+    expect(roomState.role).toBe('player');
+    expect(roomState.currentPlayer?.name).toBe('Player A');
+    expect(roomState.currentPlayer?.isHost).toBe(false);
+    expect(antiCheatService.startMonitoring).toHaveBeenCalled();
+    expect(connectionService.broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'player_joined', player_name: 'Player A' })
+    );
+  });
+
+  it('should handle Stop Mode configuration properly', async () => {
+    await roomState.createRoom('Host Name', 'Stop Game', 11, 'ingles', {
+      totalQuestions: 5,
+      mode: 'stop',
+      stopConfig: {
+        includeEnglish: true,
+        difficulty: 'medium',
+      },
+    });
+
+    expect(roomState.config?.mode).toBe('stop');
+    expect(roomState.questions).toHaveLength(1);
+    expect(roomState.questions[0].id).toBe('q-stop-1');
+  });
+
+  it('should fetch public rooms correctly via p2p listing', async () => {
+    await roomState.fetchPublicRooms('ES');
+    expect(p2p.iniciar).toHaveBeenCalledWith('lobby-browser');
+    expect(p2p.listarSalones).toHaveBeenCalledWith('ES');
+    expect(roomState.publicRooms).toHaveLength(1);
+    expect(roomState.publicRooms[0].party_code).toBe('SALA-DISC');
+  });
+});
+
+describe('RoomState Game Dynamics', () => {
+  beforeAll(async () => {
+    const mod = await import('../../src/modules/exam-room/stores/roomState.svelte');
+    roomState = mod.roomState;
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    roomState.currentPlan = 'pro';
+    await roomState.createRoom('Host Name', 'Game Room', 11, 'matematicas', {
+      totalQuestions: 2,
+      timePerQuestion: 30,
+    });
+  });
+
+  afterEach(() => {
+    roomState.leaveRoom();
+  });
+
+  it('should broadcast start_game when startGame is called', async () => {
+    await roomState.startGame();
+
+    expect(connectionService.broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'start_game',
+        room_code: 'ROOM_MOCK_CODE',
+        questions: roomState.questions,
+      })
+    );
+  });
+
+  it('should advance questions and finish game on reaching end index', () => {
+    roomState.gameState.status = 'active';
+    roomState.gameState.currentQuestionIndex = 0;
+
+    // Next question: index 1
+    roomState.nextQuestion();
+    expect(roomState.gameState.currentQuestionIndex).toBe(1);
+    expect(connectionService.broadcast).toHaveBeenCalledWith({
+      type: 'next_question',
+      questionIndex: 1,
+    });
+
+    // Next question: exceeds 2 totalQuestions → should finish game
+    const finishSpy = vi.spyOn(roomState, 'finishGame');
+    roomState.nextQuestion();
+    expect(finishSpy).toHaveBeenCalled();
+  });
+
+  it('should record answer, award score, speed-up sudden death timer on submitAnswer', () => {
+    // Setup active game
+    roomState.gameState.status = 'active';
+    roomState.gameState.currentQuestionIndex = 0;
+    // Set current question mock
+    roomState.questions = [
+      { id: 'q-1', correctOptionId: 'A' },
+      { id: 'q-2', correctOptionId: 'B' },
+    ];
+
+    // Player submits answer
+    roomState.submitAnswer('q-1', 'A', 5); // Spent 5s out of 30s
+
+    expect(connectionService.broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'question_answered',
+        question_id: 'q-1',
+        answer: 'A',
+        isCorrect: true,
+        score: 1833, // 1000 base + speed bonus (1000 * (25/30) = 833)
+        time_ms: 5000,
+      })
+    );
+  });
+
+  it('should request and broadcast AI analysis if plan limits allow', async () => {
+    roomState.currentPlan = 'pro';
+    await roomState.requestAIAnalysis();
+
+    expect(roomState.aiAnalysis).toBe('Análisis generado exitosamente.');
+    expect(connectionService.broadcast).toHaveBeenCalledWith({
+      type: 'ai_analysis_ready',
+      analysis: 'Análisis generado exitosamente.',
+    });
+  });
+
+  it('should alert/reject AI analysis request on FREE plan', async () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    roomState.currentPlan = 'free';
+
+    await roomState.requestAIAnalysis();
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('Plan Pro'));
+  });
+
+  it('should allow kicking a player if current user is Host', () => {
+    roomState.players = [
+      { id: 'host-id', name: 'Host Name', isHost: true } as any,
+      { id: 'player-id', name: 'Player A', isHost: false } as any,
+    ];
+
+    roomState.kickPlayer('player-id');
+    expect(connectionService.broadcast).toHaveBeenCalledWith({
+      type: 'player_kicked',
+      playerId: 'player-id',
+    });
+    expect(roomState.players).toHaveLength(1);
+    expect(roomState.players[0].id).toBe('host-id');
+  });
+
+  it('should handle all websocket handleMessage cases properly', () => {
+    // 1. player_list_update
+    roomState.players = [{ id: 'p1', name: 'Player One' }] as any;
+    roomState.handleMessage({
+      type: 'player_list_update',
+      players: [{ id: 'p1', name: 'Player One Upd' }, { id: 'p2', name: 'Player Two' }]
+    } as any);
+    expect(roomState.players).toHaveLength(2);
+    expect(roomState.players[0].name).toBe('Player One Upd');
+
+    // 2. player_left
+    roomState.handleMessage({
+      type: 'player_left',
+      playerId: 'p2'
+    } as any);
+    expect(roomState.players).toHaveLength(1);
+
+    // 3. player_kicked (for non-self)
+    roomState.players = [{ id: 'p1', name: 'P1' }, { id: 'p2', name: 'P2' }] as any;
+    roomState.handleMessage({
+      type: 'player_kicked',
+      playerId: 'p2'
+    } as any);
+    expect(roomState.players).toHaveLength(1);
+
+    // 4. game_started
+    roomState.handleMessage({
+      type: 'game_started',
+      startedAt: new Date().toISOString(),
+      questions: [{ id: 'q-ws-1' }]
+    } as any);
+    expect(roomState.gameState.status).toBe('active');
+    expect(roomState.questions).toHaveLength(1);
+
+    // 5. game_paused
+    roomState.handleMessage({
+      type: 'game_paused',
+      pausedAt: new Date().toISOString()
+    } as any);
+    expect(roomState.gameState.status).toBe('paused');
+
+    // 6. game_finished
+    roomState.handleMessage({
+      type: 'game_finished',
+      results: [
+        { player_id: 'p1', player_name: 'P1', score: 100, correct_answers: 5, total_questions: 5, average_time_ms: 1000 }
+      ]
+    } as any);
+    expect(roomState.gameState.status).toBe('finished');
+    expect(roomState.results?.totalPlayers).toBe(1);
+
+    // 7. ai_analysis_result
+    roomState.handleMessage({
+      type: 'ai_analysis_result',
+      analysis: 'AI Result'
+    } as any);
+    expect(roomState.aiAnalysis).toBe('AI Result');
+
+    // 8. player_answered
+    roomState.answers = [];
+    roomState.players = [{ id: 'p1', name: 'P1', score: 0, correctAnswers: 0 }] as any;
+    roomState.role = 'host';
+    roomState.handleMessage({
+      type: 'player_answered',
+      player_id: 'p1',
+      question_id: 'q-ws-1',
+      answer: 'A',
+      isCorrect: true,
+      score: 500,
+      time_ms: 1200
+    } as any);
+    expect(roomState.answers).toHaveLength(1);
+    expect(roomState.players[0].score).toBe(500);
+
+    // 9. suspicious_activity
+    roomState.players = [{ id: 'p1', name: 'P1', suspiciousActivity: [], leftScreenCount: 0 }] as any;
+    roomState.handleMessage({
+      type: 'suspicious_activity',
+      playerId: 'p1',
+      event: { type: 'window_blur', timestamp: new Date() }
+    } as any);
+    expect(roomState.players[0].leftScreenCount).toBe(1);
+
+    // 10. sync_state
+    roomState.handleMessage({
+      type: 'sync_state',
+      state: { status: 'waiting', currentQuestionIndex: 1, timeRemaining: 15 }
+    } as any);
+    expect(roomState.gameState.status).toBe('waiting');
+    expect(roomState.gameState.timeRemaining).toBe(15);
+  });
+});

--- a/saberparatodos/vitest.config.ts
+++ b/saberparatodos/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => {
       coverage: {
         provider: 'v8',
         reporter: ['text', 'json', 'html'],
-        include: ['src/lib/**/*.ts', 'src/utils/**/*.ts'],
+        include: ['src/lib/**/*.ts', 'src/utils/**/*.ts', 'src/modules/**/*.ts', 'src/modules/**/*.svelte.ts'],
         exclude: ['src/env.d.ts', 'src/**/*.d.ts'],
       },
     },


### PR DESCRIPTION
Added 5 new robust, offline-isolated, highly covered unit test files inside `saberparatodos/tests/unit/` covering `antiCheat.ts`, `reportGenerator.ts`, `connection.ts`, `roomState.svelte.ts`, and `p2p-edge-mesh.ts` to fully validate the multiplayer P2P exam module. Configured Vitest to track coverage on the exam-room module, easily exceeding the 70% combined line coverage target with 0 network calls.

Fixes #933

---
*PR created automatically by Jules for task [16036747026263399377](https://jules.google.com/task/16036747026263399377) started by @iberi22*