### PR TITLE
🎨 Palette: Accessibility context for disabled login buttons

### DIFF
--- a/saberparatodos/src/components/Login.svelte
+++ b/saberparatodos/src/components/Login.svelte
@@ -79,6 +79,9 @@
 
       <button
         disabled
+        aria-label="Acceso de usuario no disponible por el momento"
+        title="Acceso de usuario no disponible por el momento"
+        aria-disabled="true"
         class="w-full py-3 bg-gray-500/10 border border-white/10 rounded-lg text-gray-500 font-bold uppercase tracking-widest cursor-not-allowed"
       >
         Pronto

--- a/saberparatodos/src/components/LoginButton.svelte
+++ b/saberparatodos/src/components/LoginButton.svelte
@@ -57,6 +57,9 @@
   {:else}
     <button
       disabled
+      aria-label="Acceso mediante GitHub no disponible por el momento"
+      title="Acceso mediante GitHub no disponible por el momento"
+      aria-disabled="true"
       class="flex items-center gap-2 px-4 py-2 bg-gray-500/20 text-gray-400 text-xs font-bold uppercase tracking-widest rounded transition-all border border-white/10 cursor-not-allowed"
     >
       <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">


### PR DESCRIPTION
💡 What: Added ARIA attributes and titles to the disabled "Pronto" placeholder buttons in `Login.svelte` and `LoginButton.svelte`.
🎯 Why: Screen readers previously announced a generic disabled button without explaining why it was disabled. Mouse users had no tooltip. Now both get clear context ("Acceso... no disponible por el momento").
♿ Accessibility: Improved screen reader support with `aria-label` and `aria-disabled`, and general UX with `title`.

---
*PR created automatically by Jules for task [3633171822184195354](https://jules.google.com/task/3633171822184195354) started by @iberi22*