### PR TITLE
Update E2E Party Mode Tests Documentation and Validate Test Suite

### DIFF
--- a/docs/E2E_PARTY_MODE_TESTS.md
+++ b/docs/E2E_PARTY_MODE_TESTS.md
@@ -1,283 +1,85 @@
-# 🧪 Guía de Pruebas E2E - Party Mode
+# 🧪 Guía de Pruebas E2E - Party Mode (Lobbies / Sala de Exámenes)
 
 ## ✅ Estado Actual del Repositorio
 
-El repositorio **saberparatodos** está completamente configurado y listo para funcionar:
+El módulo de **Sala de Exámenes** de **saberparatodos** está estructurado con una arquitectura moderna de aula virtual multiplayer, usando principalmente **Svelte** y **Astro** en conjunción con el framework de networking on-device **edge-mesh**.
 
-### 📦 Componentes Implementados
+### 📦 Componentes y Arquitectura Actuales
 
-| Componente | Estado | Archivo |
-|------------|--------|---------|
-| **Party Host** | ✅ Completo | `src/components/PartyHost.svelte` |
-| **Party Join** | ✅ Completo | `src/components/PartyJoin.svelte` |
-| **Party Page** | ✅ Completo | `src/pages/party.astro` |
-| **Supabase Schema** | ✅ Migrado | `supabase/migrations/20251211_party_sessions.sql` |
-| **Realtime Channels** | ✅ Configurado | Supabase Realtime habilitado |
-| **RLS Policies** | ✅ Configurado | Lectura/escritura pública con rate limiting |
+Los antiguos componentes monolíticos (`PartyHost.svelte` y `PartyJoin.svelte`) ya no existen en el código y han sido reemplazados por la arquitectura en `saberparatodos/src/modules/exam-room/`:
 
-### 🧪 Tests E2E Mejorados
-
-#### Archivo: `tests/party-mode.spec.ts`
-
-**Funcionalidades probadas:**
-
-1. ✅ **Creación de Party**
-   - Host crea party con código único (6 caracteres)
-   - Genera URL compartible
-
-2. ✅ **Unión de 4 Estudiantes**
-   - Ana García
-   - Juan Pérez
-   - María López
-   - Carlos Rodríguez
-
-3. ✅ **Lobby Sincronizado**
-   - Host verifica que los 4 estudiantes están conectados
-   - Realtime tracking con Supabase
-
-4. ✅ **Inicio de Examen**
-   - Host inicia examen
-   - Todos los estudiantes reciben notificación
-
-5. ✅ **Simulación de Respuestas**
-   - Ana: Responde correctamente (A)
-   - Juan: Responde incorrectamente (B)
-   - María: Responde correctamente (A)
-   - Carlos: Responde incorrectamente (C)
-
-6. ✅ **Tracking de Progreso**
-   - Host ve respuestas en tiempo real (4/4)
-
-7. ✅ **Finalización de Examen**
-   - Host finaliza examen
-   - Genera vista de resultados
-
-8. ✅ **Informe del Administrador**
-   - Estadísticas generales
-   - Métricas individuales por estudiante
-   - Promedio de clase
-   - Tasa de participación
-
-9. ✅ **Análisis con IA**
-   - Generación de análisis pedagógico
-   - Recomendaciones personalizadas
-
-10. ✅ **Opciones de Exportación**
-    - Validación de botones de descarga/exportación
+| Componente | Archivo | Descripción |
+|------------|---------|-------------|
+| **RoomApp** | `src/modules/exam-room/components/RoomApp.svelte` | Punto de entrada que coordina el flujo (Crear Sala, Unirse a Sala, Explorar Salas). |
+| **RoomBrowser** | `src/modules/exam-room/components/RoomBrowser.svelte` | Panel para explorar salas activas en la red. |
+| **LobbyBrowser** | `src/modules/exam-room/components/LobbyBrowser.svelte` | Buscador y navegador de lobbies en curso. |
+| **PlayerView** | `src/modules/exam-room/components/PlayerView.svelte` | Vista del estudiante durante el examen. |
+| **HostControls** | `src/modules/exam-room/components/HostControls.svelte` | Controles del anfitrión / profesor (finalizar, pausar, siguiente pregunta). |
+| **StopModeSetup** / **SpeedChallengeSetup** | `src/modules/exam-room/components/StopModeSetup.svelte` | Configuración para el modo rápido Speed Challenge. |
+| **RoomResults** | `src/modules/exam-room/components/RoomResults.svelte` | Visualización del reporte de resultados al finalizar. |
 
 ---
 
-## 🚀 Cómo Ejecutar las Pruebas
+## 🧪 Pruebas E2E: Ejecución y Validación
 
-### Requisitos Previos
+### 🟢 Pruebas de Humo (Smoke Tests)
 
-```powershell
-# 1. Instalar dependencias (si no lo has hecho)
+Las pruebas básicas de humo que no dependen del servicio de red P2P están completamente validadas y son reproducibles en cualquier entorno local.
+
+- **Archivo de prueba:** `tests/party-smoke.spec.ts`
+- **Resultados:** ✅ **PASS** (passed)
+  - `Host can access party page and party is created automatically` - Sube la página `/party` con éxito y carga la UI del host.
+  - `Student can access party join page with code` - Carga el formulario para unirse con código correctamente.
+
+Comando para ejecutar:
+```bash
 cd saberparatodos
-npm install
-
-# 2. Instalar Playwright browsers (primera vez)
-npx playwright install
-```
-
-### Opción 1: Ejecutar Manualmente (Recomendado)
-
-**Terminal 1 - Servidor de Desarrollo:**
-```powershell
-cd saberparatodos
-npm run dev
-```
-
-Espera a que veas:
-```
-✔ Local    http://localhost:4321/
-```
-
-**Terminal 2 - Tests E2E:**
-```powershell
-cd saberparatodos
-npm run test:party          # Modo headless (sin UI)
-npm run test:party:headed   # Modo headed (con UI visible)
-```
-
-### Opción 2: Script Automatizado
-
-**Asegúrate de que el servidor esté corriendo**, luego:
-
-```powershell
-.\scripts\run-party-tests.ps1           # Headless
-.\scripts\run-party-tests.ps1 --headed  # Con UI
+pnpm exec playwright test tests/party-smoke.spec.ts
 ```
 
 ---
 
-## 📊 Output Esperado
+## ⚠️ Clasificación de Entorno (Env-Dependent Tests)
 
-```
-🧪 Preparando pruebas E2E de Party Mode...
+Algunos de los tests de la suite E2E requieren dependencias específicas de infraestructura y red que pueden fallar debido a limitaciones del entorno de ejecución (por ejemplo, en entornos de contenedores sin acceso a redes LAN o puertos cerrados/bloqueados para protocolos de señalización P2P).
 
-✅ Servidor de desarrollo ya está corriendo en http://localhost:4321
+### 1. Tests dependientes de la red Mesh P2P (`edge-mesh`)
 
-🚀 Ejecutando tests de Party Mode con 4 estudiantes...
+- **Tests afectados:**
+  - `tests/party-mode.spec.ts`
+  - `tests/party-mode-real-flow.spec.ts`
+  - `tests/party-focus.spec.ts`
+  - `tests/party-results-e2e.spec.ts`
+  - `tests/lan-discovery.spec.ts`
+- **Razón del bloqueo:**
+  El adaptador `src/lib/p2p-edge-mesh.ts` importa directamente el módulo compilado `edge-mesh` de un paquete hermano del repositorio (fuera de la carpeta `saberparatodos/`), el cual requiere compilación previa o dependencias del sistema nativas. En entornos de integración continua o sandboxes sin dicho paquete pre-compilado, el bundler de Vite reportará:
+  ```
+  [vite] Failed to run dependency scan. Skipping dependency pre-bundling. Error: The following dependencies are imported but could not be resolved: edge-mesh
+  ```
+  Por lo tanto, estos flujos completos P2P que simulan el tránsito de mensajes entre múltiples navegadores no se pueden ejecutar de manera nativa sin el módulo de red completo.
 
-==================================================
+### 2. Tests del Service Worker (`sw-p2p-recovery.spec.ts`)
 
-📝 FASE 1: Host creando party...
-✅ Party creada con código: ABC123
-
-👥 FASE 2: 4 estudiantes uniéndose...
-  → Ana García uniéndose...
-  ✅ Ana García unido exitosamente
-  → Juan Pérez uniéndose...
-  ✅ Juan Pérez unido exitosamente
-  → María López uniéndose...
-  ✅ María López unido exitosamente
-  → Carlos Rodríguez uniéndose...
-  ✅ Carlos Rodríguez unido exitosamente
-
-🔍 FASE 3: Verificando participantes en lobby...
-  ✅ Ana García visible en lobby
-  ✅ Juan Pérez visible en lobby
-  ✅ María López visible en lobby
-  ✅ Carlos Rodríguez visible en lobby
-
-🚀 FASE 4: Host iniciando examen...
-✅ Examen iniciado
-
-📝 FASE 5: Estudiantes respondiendo...
-  → Ana García respondiendo opción A...
-  ✅ Ana García respondió A
-  → Juan Pérez respondiendo opción B...
-  ✅ Juan Pérez respondió B
-  → María López respondiendo opción A...
-  ✅ María López respondió A
-  → Carlos Rodríguez respondiendo opción C...
-  ✅ Carlos Rodríguez respondió C
-
-📊 FASE 6: Verificando progreso en host...
-✅ Host recibió las 4 respuestas
-
-🏁 FASE 7: Finalizando examen...
-✅ Examen finalizado
-
-📈 FASE 8: Validando informe del administrador...
-  ✅ Sección "Estadísticas Generales" visible
-  ✅ Estadísticas de Ana García visibles
-  ✅ Estadísticas de Juan Pérez visibles
-  ✅ Estadísticas de María López visibles
-  ✅ Estadísticas de Carlos Rodríguez visibles
-  ✅ Métricas clave visibles
-
-✨ FASE 9: Generando análisis con IA...
-  ✅ Análisis de IA generado
-  ✅ Contenido del análisis visible
-
-💾 FASE 10: Validando opciones de exportación...
-  ✅ 2 opciones de descarga disponibles
-
-==================================================
-✅ PRUEBA E2E COMPLETADA EXITOSAMENTE
-==================================================
-Código de Party: ABC123
-Estudiantes: Ana García, Juan Pérez, María López, Carlos Rodríguez
-Respuestas: A, B, A, C
-Informe generado: ✅
-Análisis IA: ✅
-==================================================
-```
+- **Tests afectados:** `tests/sw-p2p-recovery.spec.ts`
+- **Razón del bloqueo:** Requiere el registro persistente de un Service Worker (`public/sw.js`) y APIs experimentales como `SyncManager` para el Background Sync en Chrome Headless, lo cual puede variar de comportamiento según la configuración del sandbox de Playwright y el puerto asignado.
 
 ---
 
-## 🐛 Troubleshooting
+## 🚀 Plan de Verificación Local (Cuando `edge-mesh` está disponible)
 
-### Error: `net::ERR_CONNECTION_REFUSED`
+Si estás ejecutando en una máquina de desarrollo con todas las dependencias locales construidas:
 
-**Causa:** El servidor de desarrollo no está corriendo.
+1. **Compilar/Asegurar la presencia de `edge-mesh`** en la raíz del monorepo.
+2. **Lanzar el servidor de desarrollo:**
+   ```bash
+   cd saberparatodos
+   pnpm dev
+   ```
+3. **Ejecutar la suite P2P:**
+   ```bash
+   cd saberparatodos
+   pnpm exec playwright test tests/party-smoke.spec.ts
+   ```
 
-**Solución:**
-```powershell
-cd saberparatodos
-npm run dev
-```
-
-Espera a que el servidor inicie completamente antes de ejecutar tests.
-
-### Error: `SUPABASE_URL is not defined`
-
-**Causa:** Variables de entorno no configuradas.
-
-**Solución:**
-```powershell
-# Verificar que existan las variables públicas en astro.config.mjs
-# O definir en archivo .env:
-PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-```
-
-### Playwright Browsers Missing
-
-**Solución:**
-```powershell
-npx playwright install
-```
-
----
-
-## 📝 Scripts Disponibles
-
-| Script | Comando | Descripción |
-|--------|---------|-------------|
-| Desarrollo | `npm run dev` | Inicia servidor Astro en localhost:4321 |
-| Build | `npm run build` | Construye para producción |
-| Preview | `npm run preview` | Preview del build |
-| Tests (todos) | `npm run test` | Ejecuta todos los tests Playwright |
-| Tests UI | `npm run test:ui` | Abre Playwright UI para debugging |
-| Tests Debug | `npm run test:debug` | Debug paso a paso |
-| Tests Headed | `npm run test:headed` | Ejecuta con navegadores visibles |
-| **Party Tests** | `npm run test:party` | Solo tests de Party Mode (headless) |
-| **Party Headed** | `npm run test:party:headed` | Party Mode con navegadores visibles |
-
----
-
-## 🎯 Próximos Pasos
-
-1. **Ejecutar Tests Localmente:**
-   - Iniciar servidor: `npm run dev`
-   - Ejecutar tests: `npm run test:party:headed`
-
-2. **CI/CD Integration:**
-   - Los tests están listos para integrarse en una capa de automatización futura si se decide
-   - Configurar workflow con:
-     ```yaml
-     - name: Run E2E Tests
-       run: |
-         npm run dev &
-         npx wait-on http://localhost:4321
-         npm run test:party
-     ```
-
-3. **Monitoring en Producción:**
-   - Configurar Sentry para errores de Party Mode
-   - Logs de Supabase Realtime
-
----
-
-## ✅ Checklist de Validación
-
-- [x] Servidor Astro funciona (`npm run dev`)
-- [x] Página `/party` carga correctamente
-- [x] Supabase Realtime configurado
-- [x] RLS policies habilitadas
-- [x] PartyHost.svelte implementado
-- [x] PartyJoin.svelte implementado
-- [x] Tests E2E con 4 estudiantes creados
-- [x] Validación de informe del admin
-- [x] Validación de análisis con IA
-- [x] Scripts npm configurados
-- [ ] **Tests ejecutados exitosamente** (pendiente: requiere servidor activo)
-
----
-
-**Fecha:** 2025-12-12
-**Autor:** GitHub Copilot
-**Versión:** 1.0
+**Fecha de actualización:** 2026-08-05
+**Validación completada:** Pruebas de Humo ✅ PASS | Pruebas Unitarias (Vitest) ✅ PASS (215 tests)

--- a/docs/E2E_PARTY_MODE_TESTS.md
+++ b/docs/E2E_PARTY_MODE_TESTS.md
@@ -82,4 +82,4 @@ Si estás ejecutando en una máquina de desarrollo con todas las dependencias lo
    ```
 
 **Fecha de actualización:** 2026-08-05
-**Validación completada:** Pruebas de Humo ✅ PASS | Pruebas Unitarias (Vitest) ✅ PASS (215 tests)
+**Validación completada:** Pruebas de Humo ✅ PASS | Pruebas Unitarias (Vitest) ✅ PASS (258 tests)


### PR DESCRIPTION
Updated E2E party mode documentation to align with current exam-room architecture, verified unit test suite is green, ran Playwright party-smoke tests, and documented edge-mesh network status.

Fixes #934

---
*PR created automatically by Jules for task [6386510116711345798](https://jules.google.com/task/6386510116711345798) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the outdated Party Mode testing guide with current exam-room architecture documentation.
  * Added smoke-test coverage, environment-dependent test guidance, failure conditions, execution commands, and local verification steps.
  * Updated validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->