### PR TITLE
🎨 Palette: Improve InstallPrompt button accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-06 - [Install Prompt Accessibility Enhancement]
+**Learning:** Fixed overlay components like custom install prompts often lack proper focus rings and aria-disabled states for their buttons because they are built from scratch rather than using native browser dialogues. Users relying on keyboard navigation could easily lose their place or get stuck on buttons without visible focus indicators or screen-reader context for loading states.
+**Action:** Always ensure that custom overlay components include `focus-visible` utility classes on interactive elements, and pair `disabled` state with `aria-disabled` and descriptive `title` attributes to provide full context to all users during async operations.

--- a/saberparatodos/src/components/InstallPrompt.svelte
+++ b/saberparatodos/src/components/InstallPrompt.svelte
@@ -71,14 +71,17 @@
     </div>
     <button
       type="button"
-      class="px-3 py-2 rounded-lg bg-emerald-500/20 border border-emerald-400/30 text-emerald-100 text-xs font-bold disabled:opacity-50"
+      class="px-3 py-2 rounded-lg bg-emerald-500/20 border border-emerald-400/30 text-emerald-100 text-xs font-bold disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
       disabled={installing}
+      aria-disabled={installing}
+      title={installing ? 'Instalación en curso...' : 'Instalar aplicación'}
       onclick={install}
     >{installing ? 'Instalando…' : 'Instalar'}</button>
     <button
       type="button"
-      class="px-2 py-2 rounded-lg text-white/40 hover:text-white/80 text-sm"
-      aria-label="Cerrar"
+      class="px-2 py-2 rounded-lg text-white/40 hover:text-white/80 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+      aria-label="Cerrar prompt de instalación"
+      title="Cerrar prompt de instalación"
       onclick={dismiss}
     >✕</button>
   </div>


### PR DESCRIPTION
This PR addresses accessibility issues in `InstallPrompt.svelte` where the overlay's action buttons lacked sufficient keyboard focus indicators and proper ARIA states for their disabled behaviors. 

### Changes
* Added `aria-disabled` and `title` attributes to provide better context during asynchronous install operations.
* Included `focus-visible` ring utility classes across all interactive buttons within the prompt to ensure users navigating via keyboard do not lose their place.
* Logged learnings about overlay component accessibility in `.jules/palette.md`.

---
*PR created automatically by Jules for task [2238852582798974373](https://jules.google.com/task/2238852582798974373) started by @iberi22*