### PR TITLE
⚡ Bolt: Optimize filteredLocalQuestions derived statement

### DIFF
--- a/saberparatodos/.jules/bolt.md
+++ b/saberparatodos/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Avoid unnecessary array `.filter()` inside `$derived` when filtering is inactive
+**Learning:** In Svelte components, using `.filter(condition ? true : ...)` inside `$derived` or reactive blocks still creates a new array instance and iterates N times, causing unnecessary overhead when the condition isn't active.
+**Action:** When conditionally filtering an array in `$derived` based on a reactive variable (e.g., a filter toggle or selected value), early return the original array reference (`condition ? array.filter(...) : array`) to make it an O(1) operation and avoid redundant garbage collection allocations.

--- a/saberparatodos/src/components/App.svelte
+++ b/saberparatodos/src/components/App.svelte
@@ -206,9 +206,11 @@
     }
   });
 
-  // Derived: Filtered questions for current grade
+  // ⚡ Bolt Optimization: Avoid O(N) array recreation and iteration when no grade is selected by returning reference directly
   let filteredLocalQuestions = $derived(
-    loadedQuestions.filter(q => selectedGrade ? q.grade === selectedGrade : true)
+    selectedGrade
+      ? loadedQuestions.filter(q => q.grade === selectedGrade)
+      : loadedQuestions
   );
 
   // Derived: Exam questions based on generatedExamQuestions or filtered


### PR DESCRIPTION
💡 **What**: The `$derived` reactive block for `filteredLocalQuestions` in `App.svelte` was optimized to early-return the original array when filtering by grade isn't active, instead of running an unconditional `filter(q => selectedGrade ? q.grade === selectedGrade : true)`.

🎯 **Why**: In Svelte components, using `.filter()` inside `$derived` or reactive blocks still creates a new array instance and iterates N times, causing unnecessary CPU cycles and memory allocations when the condition isn't active (e.g., when no grade is selected).

📊 **Impact**: Turns an O(N) filtering operation into an O(1) operation when `selectedGrade` is falsy. This prevents redundant garbage collection allocations and improves responsiveness, especially when `loadedQuestions` contains a large number of questions.

🔬 **Measurement**: Verify by running `pnpm test:unit` inside `saberparatodos/`. All tests pass successfully, confirming no regressions. The optimization is observable via stable array references when `selectedGrade` is unselected.

---
*PR created automatically by Jules for task [1060852671515497611](https://jules.google.com/task/1060852671515497611) started by @iberi22*