### PR TITLE
🎨 Palette: Make dashboard organization toggle accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2026-08-06 - [Install Prompt Accessibility Enhancement]
-**Learning:** Fixed overlay components like custom install prompts often lack proper focus rings and aria-disabled states for their buttons because they are built from scratch rather than using native browser dialogues. Users relying on keyboard navigation could easily lose their place or get stuck on buttons without visible focus indicators or screen-reader context for loading states.
-**Action:** Always ensure that custom overlay components include `focus-visible` utility classes on interactive elements, and pair `disabled` state with `aria-disabled` and descriptive `title` attributes to provide full context to all users during async operations.
+## 2026-08-08 - Accessible Disclosure Widgets
+**Learning:** Using `div` with `on:click` for expandable sections (like organization lists) completely breaks keyboard navigation for screen readers and power users. It lacks focus states, keyboard event handling (Enter/Space), and semantic meaning.
+**Action:** Always replace clickable `div`s used for expansion with native `<button>` elements. Ensure they include `aria-expanded` and `aria-controls` to properly communicate state to assistive technologies, and use native focus styling (e.g., `focus-visible:ring-2`).

--- a/saberparatodos/src/components/dashboard/DashboardMain.svelte
+++ b/saberparatodos/src/components/dashboard/DashboardMain.svelte
@@ -82,9 +82,14 @@
       <div class="space-y-6">
         {#each organizations as org}
           <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-6 hover:shadow-lg transition-shadow">
-            <div class="flex justify-between items-start cursor-pointer" on:click={() => toggleOrg(org.id)}>
-              <div class="flex items-center gap-4">
-                <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center text-white font-bold text-xl">
+            <button
+              class="w-full flex justify-between items-start cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-lg"
+              on:click={() => toggleOrg(org.id)}
+              aria-expanded={selectedOrgId === org.id}
+              aria-controls={`org-students-${org.id}`}
+            >
+              <div class="flex items-center gap-4 text-left">
+                <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center text-white font-bold text-xl shrink-0">
                     {org.name.substring(0,2).toUpperCase()}
                 </div>
                 <div>
@@ -92,16 +97,16 @@
                     <p class="text-xs text-zinc-500 font-mono">@{org.slug}</p>
                 </div>
               </div>
-              <div class="flex items-center gap-3">
+              <div class="flex items-center gap-3 shrink-0">
                  <span class="px-2 py-1 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 text-xs rounded-full font-medium capitalize">
                     {org.plan_tier}
                  </span>
-                 <span class="text-zinc-400 text-sm">{selectedOrgId === org.id ? '▲' : '▼'}</span>
+                 <span class="text-zinc-400 text-sm" aria-hidden="true">{selectedOrgId === org.id ? '▲' : '▼'}</span>
               </div>
-            </div>
+            </button>
 
             {#if selectedOrgId === org.id}
-                <div class="mt-6 border-t border-zinc-100 dark:border-zinc-800 pt-6 animate-fade-in">
+                <div id={`org-students-${org.id}`} class="mt-6 border-t border-zinc-100 dark:border-zinc-800 pt-6 animate-fade-in">
                     <OrgStudents organizationId={org.id} />
                 </div>
             {/if}


### PR DESCRIPTION
💡 What: Converted the organization toggle in the dashboard from a clickable `div` into an accessible `<button>`. Added `aria-expanded` and `aria-controls` states, and used standard focus ring styling.

🎯 Why: Clickable `div`s lack native keyboard support (focus, Space/Enter activation) and do not communicate their state to assistive technologies, making the dashboard less accessible for power users and screen readers.

♿ Accessibility: Added `aria-expanded`, `aria-controls`, `aria-hidden` to decorative icons, and native focus styling to the button.

---
*PR created automatically by Jules for task [11315710992865086752](https://jules.google.com/task/11315710992865086752) started by @iberi22*