### PR TITLE
🎨 Palette: Enhance accessibility and visual feedback for disabled invite button

### DIFF
--- a/saberparatodos/src/components/dashboard/OrgStudents.svelte
+++ b/saberparatodos/src/components/dashboard/OrgStudents.svelte
@@ -97,7 +97,14 @@
           />
           <div class="flex justify-end gap-2">
             <button type="button" on:click={() => showInviteModal = false} class="px-3 py-1.5 text-zinc-500">Cancelar</button>
-            <button type="submit" disabled={inviting} class="px-3 py-1.5 bg-blue-600 text-white rounded-lg">
+            <button
+              type="submit"
+              disabled={inviting}
+              aria-disabled={inviting}
+              title={inviting ? 'Enviando invitación, por favor espere' : undefined}
+              aria-label={inviting ? 'Enviando invitación, por favor espere' : undefined}
+              class="px-3 py-1.5 bg-blue-600 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+            >
               {inviting ? 'Enviando...' : 'Enviar Invitación'}
             </button>
           </div>


### PR DESCRIPTION
This PR improves the accessibility and user experience of the 'Invite' button in `OrgStudents.svelte` when it is in a loading/disabled state.

**What:** Added `aria-disabled`, `aria-label`, and `title` attributes to the button. Additionally, implemented visual feedback using Tailwind CSS classes (`disabled:opacity-50 disabled:cursor-not-allowed`).
**Why:** To ensure screen readers properly communicate the button's disabled state during asynchronous operations and to provide clear visual cues to all users that the action is currently unavailable because it is processing.

---
*PR created automatically by Jules for task [14817277313676089208](https://jules.google.com/task/14817277313676089208) started by @iberi22*