### PR TITLE
🎨 Palette: Add accessibility attributes to score details toggle

### DIFF
--- a/saberparatodos/src/components/ScoreDisplay.svelte
+++ b/saberparatodos/src/components/ScoreDisplay.svelte
@@ -211,13 +211,15 @@
   {#if showBreakdown}
     <button
       on:click={() => showDetails = !showDetails}
+      aria-expanded={showDetails}
+      aria-controls="score-details-panel"
       class="w-full py-3 text-xs uppercase tracking-widest text-white/40 hover:text-white/80 transition-colors flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded"
     >
       {showDetails ? 'Ocultar' : 'Ver'} detalle por pregunta
     </button>
 
     {#if showDetails}
-      <div class="space-y-2 max-h-64 overflow-y-auto">
+      <div id="score-details-panel" class="space-y-2 max-h-64 overflow-y-auto">
         {#each examScore.questionScores as qs, index}
           <div
             class={`p-3 rounded-lg border text-sm ${qs.totalScore > 0


### PR DESCRIPTION
- 💡 **What:** Added `aria-expanded` and `aria-controls` attributes to the "Ver detalle por pregunta" disclosure button, along with the corresponding `id` on the target container.
- 🎯 **Why:** Improves screen reader support for disclosure widgets, allowing assistive technologies to announce the expanded/collapsed state and associate the button with the content it controls.
- ♿ **Accessibility:** Yes, improves screen reader accessibility for the score breakdown section.

---
*PR created automatically by Jules for task [16999627872687653193](https://jules.google.com/task/16999627872687653193) started by @iberi22*