### PR TITLE
🎨 Palette: Improve MemoryStatus disclosure widgets accessibility

### DIFF
--- a/saberparatodos/src/components/MemoryStatus.svelte
+++ b/saberparatodos/src/components/MemoryStatus.svelte
@@ -47,7 +47,9 @@
   <!-- Compact Mode - For header -->
   <button
     on:click={() => showDetails = !showDetails}
-    class="flex items-center gap-2 px-3 py-1.5 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg text-xs transition-all"
+    aria-expanded={showDetails}
+    aria-controls="memory-details"
+    class="flex items-center gap-2 px-3 py-1.5 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg text-xs transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
     title="Ver progreso de preguntas"
   >
     <div class="relative w-16 h-1.5 bg-white/10 rounded-full overflow-hidden">
@@ -71,7 +73,9 @@
       </h3>
       <button
         on:click={() => showDetails = !showDetails}
-        class="min-h-[44px] min-w-[44px] flex items-center justify-center px-3 py-2 text-xs font-medium text-emerald-500 active:text-emerald-300 active:bg-emerald-500/10 rounded-lg transition-colors"
+        aria-expanded={showDetails}
+        aria-controls="memory-details"
+        class="min-h-[44px] min-w-[44px] flex items-center justify-center px-3 py-2 text-xs font-medium text-emerald-500 active:text-emerald-300 active:bg-emerald-500/10 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
       >
         {showDetails ? 'Ocultar' : 'Ver detalles'}
       </button>
@@ -128,7 +132,7 @@
 
     <!-- Details Section - Mobile Optimized -->
     {#if showDetails && questionStats}
-      <div class="space-y-5 pt-5 border-t border-white/10" transition:slide>
+      <div id="memory-details" class="space-y-5 pt-5 border-t border-white/10" transition:slide>
 
         <!-- Explanation Banner -->
         <div class="p-3 bg-blue-500/10 border border-blue-500/20 rounded-xl text-xs text-blue-300/80 leading-relaxed">


### PR DESCRIPTION
### 💡 What
Added essential ARIA attributes (`aria-expanded`, `aria-controls`) and focus ring styling to the disclosure toggle buttons in the `MemoryStatus.svelte` component. 

### 🎯 Why
The buttons that toggle the memory details view were missing ARIA states, meaning screen readers couldn't announce whether the section was expanded or collapsed, or what content they controlled. Furthermore, there was poor visual feedback for keyboard users navigating the toggles.

### ♿ Accessibility
- Added `aria-expanded` tied to the `showDetails` state.
- Added `aria-controls="memory-details"` pointing to the expandable container.
- Added `focus-visible:ring-2 focus-visible:ring-emerald-500` and `focus-visible:outline-none` for clearer keyboard focus indicators.

---
*PR created automatically by Jules for task [4821832923385350364](https://jules.google.com/task/4821832923385350364) started by @iberi22*