### PR TITLE
🎨 Palette: Improve FlashlightCard keyboard and screen reader accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2026-08-08 - Accessible Disclosure Widgets
-**Learning:** Using `div` with `on:click` for expandable sections (like organization lists) completely breaks keyboard navigation for screen readers and power users. It lacks focus states, keyboard event handling (Enter/Space), and semantic meaning.
-**Action:** Always replace clickable `div`s used for expansion with native `<button>` elements. Ensure they include `aria-expanded` and `aria-controls` to properly communicate state to assistive technologies, and use native focus styling (e.g., `focus-visible:ring-2`).
+## 2026-08-13 - FlashlightCard Accessibility
+**Learning:** We had `FlashlightCard.svelte` using a generic `div` tag acting as a button with `role="button"` and `tabindex="0"`. While visually it acts like a card, generic clickable elements fail to provide native keyboard interaction behaviors (like Enter/Space handling) which compromises the screen reader and keyboard-only user experience.
+**Action:** Always prefer native semantic HTML elements (`<button type="button">` instead of `<div role="button">`) for interactive, clickable components. Use Tailwind utility classes such as `w-full text-left block` on buttons to neutralize user-agent stylesheet overrides and maintain the intended layout of complex nested cards without losing accessibility support.

--- a/saberparatodos/src/components/FlashlightCard.svelte
+++ b/saberparatodos/src/components/FlashlightCard.svelte
@@ -5,7 +5,7 @@
   export let isActive = false;
   export let onClick: (() => void) | undefined = undefined;
 
-  let divRef: HTMLDivElement;
+  let buttonRef: HTMLButtonElement;
   let position = { x: 0, y: 0 };
   let opacity = 0;
 
@@ -15,8 +15,8 @@
   const SCROLL_THRESHOLD = 10; // pixels of movement before considering it a scroll
 
   function handleMouseMove(e: MouseEvent) {
-    if (!divRef) return;
-    const rect = divRef.getBoundingClientRect();
+    if (!buttonRef) return;
+    const rect = buttonRef.getBoundingClientRect();
     position = { x: e.clientX - rect.left, y: e.clientY - rect.top };
   }
 
@@ -58,10 +58,9 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
-  bind:this={divRef}
+<button
+  type="button"
+  bind:this={buttonRef}
   onmousemove={handleMouseMove}
   onmouseenter={handleMouseEnter}
   onmouseleave={handleMouseLeave}
@@ -69,12 +68,10 @@
   ontouchstart={handleTouchStart}
   ontouchmove={handleTouchMove}
   ontouchend={handleTouchEnd}
-  role="button"
-  tabindex="0"
   class={`
-    relative overflow-hidden rounded-xl border transition-all duration-300
+    w-full text-left block relative overflow-hidden rounded-xl border transition-all duration-300
     ${isActive ? 'border-emerald-500 bg-emerald-900/10' : 'border-white/10 bg-[#1E1E1E]/40'}
-    backdrop-blur-sm group cursor-pointer
+    backdrop-blur-sm group cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500
     ${className}
   `}
 >
@@ -88,7 +85,7 @@
   <div class="relative z-10 w-full h-full">
     <slot />
   </div>
-</div>
+</button>
 
 <style>
   /* 🔥 CRITICAL: Disable flashlight effect on touch devices to prevent sticky hover */


### PR DESCRIPTION
💡 **What**: Converted the `div` in `FlashlightCard.svelte` to a `button`.
🎯 **Why**: Using generic `div` tags with `role="button"` fails to provide native keyboard interactions, requiring manual implementations. Changing to a semantic `<button>` fixes these accessibility issues.
♿ **Accessibility**: Better support for keyboard navigation (native `Space`/`Enter` triggering, visual focus indicators) and better screen reader announcements.

---
*PR created automatically by Jules for task [6941478672939712392](https://jules.google.com/task/6941478672939712392) started by @iberi22*