### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limit bypass via IP spoofing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -37,3 +37,8 @@
 **Learning:** When using the Supabase JS client's string-based `.or()` filters, standard string concatenation is highly dangerous if the input contains PostgREST reserved characters like commas (`,`) or unescaped wildcard percent signs (`%`). It effectively leads to NoSQL/Filter injection.
 **Prevention:** Always explicitly sanitize or strip commas and other filter control characters when building string-based PostgREST filter clauses. Alternatively, use safer, parameterized matching methods if supported by the client library, but if concatenation is necessary, use `query.replace(/[,%]/g, ' ')` or similar robust stripping.
 
+
+## 2026-08-13 - [Fix Rate Limit Bypass via IP Spoofing]
+**Vulnerability:** IP extraction logic in `api/comments.ts`, `api/developers/auth/magic-link.ts`, `api-gateway/index.ts`, and `get-questions/index.ts` was falling back to extracting the `x-forwarded-for` header and using it for rate limiting and logging if `cf-connecting-ip` was not present or spoofed. This is dangerous because `x-forwarded-for` is easily spoofed by the client, allowing attackers to bypass rate limits or spoof IP logs.
+**Learning:** Never trust `x-forwarded-for` as a fallback unless its origin is strictly verified as a trusted proxy. If `cf-connecting-ip` (or the specific proxy header) is not present or reliable, the application should fall back to a safe default like `'unknown'` rather than trusting client-provided headers that bypass security mechanisms.
+**Prevention:** Remove `x-forwarded-for` from `getClientIp` helpers or explicitly ensure it is only used when validated. Provide a safe fallback (e.g. `'unknown'`) if no trusted IP header can be found to avoid spoofing vulnerabilities.

--- a/saberparatodos/src/pages/api/comments.ts
+++ b/saberparatodos/src/pages/api/comments.ts
@@ -22,23 +22,19 @@ function cleanupRateLimitMap(now: number) {
   }
 }
 
-function getClientIp(request: Request): string {
-  // Trust Cloudflare's connecting IP first to prevent X-Forwarded-For spoofing
+function getClientIp(request: Request | globalThis.Request): string {
+  // Trust Cloudflare's connecting IP first to prevent spoofing
   const cfIp = request.headers.get('cf-connecting-ip');
   if (cfIp) {
     return cfIp.trim();
   }
 
-  const forwarded = request.headers.get('x-forwarded-for');
-  if (forwarded) {
-    // Note: The first IP in X-Forwarded-For can be spoofed by the client.
-    return forwarded.split(',')[0].trim();
-  }
+  // PR #977 specifically dictates NOT trusting x-forwarded-for as the primary source,
+  // or at all, because it can be spoofed, unless we can validate the proxy. Since we
+  // deploy on CF, if CF is bypassed, x-forwarded-for should not be trusted.
+  // We remove x-forwarded-for and x-real-ip extraction entirely, returning unknown
+  // if no trusted cf-connecting-ip is provided.
 
-  const realIp = request.headers.get('x-real-ip');
-  if (realIp) {
-    return realIp;
-  }
   return 'unknown';
 }
 

--- a/saberparatodos/src/pages/api/developers/auth/magic-link.ts
+++ b/saberparatodos/src/pages/api/developers/auth/magic-link.ts
@@ -15,21 +15,19 @@ function cleanupRateLimitMap(now: number) {
   }
 }
 
-function getClientIp(request: Request): string {
+function getClientIp(request: Request | globalThis.Request): string {
+  // Trust Cloudflare's connecting IP first to prevent spoofing
   const cfIp = request.headers.get('cf-connecting-ip');
   if (cfIp) {
     return cfIp.trim();
   }
 
-  const forwarded = request.headers.get('x-forwarded-for');
-  if (forwarded) {
-    return forwarded.split(',')[0].trim();
-  }
+  // PR #977 specifically dictates NOT trusting x-forwarded-for as the primary source,
+  // or at all, because it can be spoofed, unless we can validate the proxy. Since we
+  // deploy on CF, if CF is bypassed, x-forwarded-for should not be trusted.
+  // We remove x-forwarded-for and x-real-ip extraction entirely, returning unknown
+  // if no trusted cf-connecting-ip is provided.
 
-  const realIp = request.headers.get('x-real-ip');
-  if (realIp) {
-    return realIp;
-  }
   return 'unknown';
 }
 

--- a/saberparatodos/supabase/functions/api-gateway/index.ts
+++ b/saberparatodos/supabase/functions/api-gateway/index.ts
@@ -95,6 +95,15 @@ async function fetchPack(grade: string, subject: string) {
   return null
 }
 
+function getClientIp(req: Request | globalThis.Request): string {
+  const cfIp = req.headers.get("cf-connecting-ip")
+  if (cfIp) {
+    return cfIp.trim()
+  }
+
+  return "unknown"
+}
+
 async function sha256(value: string) {
   const encoder = new TextEncoder()
   const data = encoder.encode(value)
@@ -116,10 +125,7 @@ async function logRequest(
     api_key_id: apiKeyId,
     endpoint,
     status_code: statusCode,
-    ip_address:
-      request.headers.get("cf-connecting-ip") ||
-      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-      "unknown",
+    ip_address: getClientIp(request),
     user_agent: request.headers.get("user-agent") || "unknown",
     response_time_ms: responseTimeMs,
   })
@@ -173,7 +179,7 @@ serve(async (req: Request) => {
       .maybeSingle()
 
     if (keyError || !apiKey) {
-      console.log(`[api-gateway] Invalid API key from ${req.headers.get("cf-connecting-ip") || "unknown"}`)
+      console.log(`[api-gateway] Invalid API key from ${getClientIp(req)}`)
       return json({
         error: "Unauthorized",
         message: "Invalid API key",

--- a/saberparatodos/supabase/functions/get-questions/index.ts
+++ b/saberparatodos/supabase/functions/get-questions/index.ts
@@ -14,6 +14,15 @@ const QUESTIONS_BASE_URL =
 const ANCHOR_DATE_MS = Date.parse('2025-01-01T00:00:00Z');
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
+function getClientIp(req: Request | globalThis.Request): string {
+  const cfIp = req.headers.get('cf-connecting-ip');
+  if (cfIp) {
+    return cfIp.trim();
+  }
+
+  return 'unknown';
+}
+
 function getCurrentWeek(): number {
   const elapsed = Math.max(0, Date.now() - ANCHOR_DATE_MS);
   const week = Math.ceil(elapsed / ONE_WEEK_MS);
@@ -138,9 +147,7 @@ serve(async (req: Request) => {
     };
 
     if (isGuest) {
-      const clientIP = req.headers.get('cf-connecting-ip') ||
-                       req.headers.get('x-forwarded-for')?.split(',')[0] ||
-                       'unknown';
+      const clientIP = getClientIp(req);
 
       const { data: rateLimitData, error: rateLimitError } = await supabase
         .from('api_rate_limits')


### PR DESCRIPTION
This PR addresses an IP spoofing vulnerability where rate limiting and logging logic across multiple API routes and Supabase Edge Functions incorrectly trusted the `x-forwarded-for` header as a fallback. 

Attackers could manipulate this header to spoof their IP address, thereby bypassing rate limits or poisoning usage logs. The fix removes the `x-forwarded-for` extraction entirely, ensuring the system exclusively relies on the trusted `cf-connecting-ip` header (provided securely by Cloudflare) and falls back to `'unknown'` if not present.

---
*PR created automatically by Jules for task [14468249089702875846](https://jules.google.com/task/14468249089702875846) started by @iberi22*