### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rate limiting to report-problem API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,7 @@
 **Vulnerability:** The API route `saberparatodos/src/pages/api/packs/[...slug].ts` proxied requests to a backend URL using user-supplied path components (`slug`) without validating them against path traversal (`..` or `%2e%2e`). This could allow an attacker to bypass the intended `/v1/packs/` directory and issue requests to other endpoints on the target origin (e.g. `../../admin`).
 **Learning:** Whenever proxying requests by concatenating user inputs into a backend URL, it's essential to validate the input to ensure it doesn't navigate upwards in the directory tree using URL decoding.
 **Prevention:** Added a check to URL-decode the `slug` and reject it if it contains `..`. This is a defensive-in-depth measure.
+## 2026-08-17 - Rate Limit Bypass due to missing IP-based restrictions
+**Vulnerability:** The API route \`/api/report_problem.ts\` was directly forwarding arbitrary POST bodies to a backend Edge Function without checking payload sizes or applying rate limits.
+**Learning:** Endpoints that proxy requests to cloud functions or third-party services can become vectors for Denial of Service (DoS) attacks or result in uncontrollable resource consumption if not adequately rate-limited based on the user's IP.
+**Prevention:** Implement standard in-memory rate limiting (using `cf-connecting-ip` to securely identify clients) across all public-facing endpoints, especially those that trigger downstream functions or external notifications (like Telegram bots).

--- a/saberparatodos/src/pages/api/report_problem.ts
+++ b/saberparatodos/src/pages/api/report_problem.ts
@@ -21,6 +21,49 @@ function jsonResponse(body: Record<string, unknown>, status: number) {
   });
 }
 
+// Rate limiting: max 5 POST requests per IP per minute
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const CLEANUP_PROBABILITY = 0.05; // 5% chance to run cleanup on request to prevent memory leaks
+
+function cleanupRateLimitMap(now: number) {
+  for (const [key, value] of rateLimitMap.entries()) {
+    if (value.resetAt < now) {
+      rateLimitMap.delete(key);
+    }
+  }
+}
+
+function getClientIp(request: Request | globalThis.Request): string {
+  // Trust Cloudflare's connecting IP first to prevent spoofing
+  const cfIp = request.headers.get('cf-connecting-ip');
+  if (cfIp) {
+    return cfIp.trim();
+  }
+  return 'unknown';
+}
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+
+  // Sweep expired entries occasionally to prevent memory leaks
+  if (Math.random() < CLEANUP_PROBABILITY) {
+    cleanupRateLimitMap(now);
+  }
+
+  const entry = rateLimitMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+  if (entry.count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+  entry.count++;
+  return true;
+}
+
 export const ALL: APIRoute = async ({ request, locals }) => {
   if (request.method === 'OPTIONS') {
     return new Response(null, {
@@ -31,6 +74,11 @@ export const ALL: APIRoute = async ({ request, locals }) => {
 
   if (request.method !== 'POST') {
     return jsonResponse({ error: 'Method not allowed' }, 405);
+  }
+
+  const clientIp = getClientIp(request);
+  if (!checkRateLimit(clientIp)) {
+    return jsonResponse({ error: 'Demasiadas solicitudes. Intenta de nuevo en un minuto.' }, 429);
   }
 
   try {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/report_problem.ts` endpoint lacked rate limiting, allowing unrestricted POST requests to be forwarded to the backend Edge Function.
🎯 Impact: Attackers could flood the endpoint with requests, potentially causing Denial of Service (DoS) and exhausting downstream resources like Supabase function quotas or Telegram bot limits.
🔧 Fix: Implemented IP-based rate limiting (using `cf-connecting-ip`) utilizing an in-memory `Map` with probabilistic cleanup to restrict clients to 5 requests per minute, matching patterns used in other API endpoints.
✅ Verification: Ran `pnpm lint` and `pnpm test:unit` inside `saberparatodos` to verify that existing functionality remains intact and tests pass. Code was manually reviewed to ensure `cf-connecting-ip` is prioritized.

---
*PR created automatically by Jules for task [17741843596574791945](https://jules.google.com/task/17741843596574791945) started by @iberi22*