### PR TITLE
⚡ Bolt: Optimize `handleFinish` array lookup with O(1) Set

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-08-17 - Optimize Component array filtering
 **Learning:** Chained `.filter()` and `.map()` calls in Svelte components create multiple temporary arrays, particularly detrimental when running in `$derived` or `$:` reactive loops tracking state like `uniqueSessions` or `userProfile` (especially true for ExamRoomResultsView which processes updates constantly).
 **Action:** Replace `uniqueSessions.filter(...).length` chains with a single `uniqueSessions.reduce()` pass whenever computing multiple metrics on the same dataset in a Svelte `$derived.by()` reactive block.
+
+## 2024-10-30 - Optimize Exam Finish Results Loop
+**Learning:** Inside `handleFinish` in `ExamView.svelte`, checking if a question exists using `.find` inside a `.forEach` loop over active questions produces an O(N^2) bottleneck. This delays showing the results screen and freezes the UI momentarily when `activeQuestions` has many items (e.g., in a 100-question exam or during heavy concurrent updates).
+**Action:** Always extract the IDs into a `Set` (e.g., `new Set(questionResults.map(r => r.questionId))`) before looping to ensure O(1) membership lookups for large arrays in result computation.

--- a/saberparatodos/src/components/ExamView.svelte
+++ b/saberparatodos/src/components/ExamView.svelte
@@ -520,9 +520,11 @@
       broadcastRoomState('finished', currentIdx);
     }
 
+    // ⚡ Bolt Optimization: Use an external Set for O(1) tracking instead of O(N^2) array.find() in loop
+    const processedQuestionIds = new Set(questionResults.map(r => r.questionId));
     activeQuestions.forEach((q) => {
       const answer = answers[q.id];
-      if (answer && !questionResults.find(r => r.questionId === q.id)) {
+      if (answer && !processedQuestionIds.has(q.id)) {
         // Normalize logic...
         const qOptions = (q.options || []).map((opt, idx) => ({
           ...opt, id: opt.id ?? OPTION_LETTERS[idx] ?? `opt-${idx}`


### PR DESCRIPTION
💡 **What**: Extracted the processed `questionId`s into a `Set` prior to the `activeQuestions` loop in `handleFinish` within `ExamView.svelte`.
🎯 **Why**: The previous implementation used `.find()` inside a `.forEach` loop over active questions. For large exams, this created an O(N^2) bottleneck, unnecessarily delaying the display of the results screen and momentarily freezing the UI.
📊 **Impact**: Reduces time complexity of the final loop from O(N^2) to O(N). It ensures snappy and responsive transitions to the results view even for 100-question exams.
🔬 **Measurement**: Noticeably faster response when finishing exams with a large pool of active questions.

---
*PR created automatically by Jules for task [9172717485122892400](https://jules.google.com/task/9172717485122892400) started by @iberi22*