### PR TITLE
🎨 Palette: Fix AdvancedSearch disclosure widget accessibility

### DIFF
--- a/saberparatodos/src/components/AdvancedSearch.svelte
+++ b/saberparatodos/src/components/AdvancedSearch.svelte
@@ -260,6 +260,8 @@
           <button
             on:click={() => showFilters = !showFilters}
             class="flex items-center gap-2 text-xs uppercase tracking-widest text-emerald-500 hover:text-emerald-400 transition-colors"
+            aria-expanded={showFilters}
+            aria-controls="filters-panel"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
@@ -275,7 +277,7 @@
 
         <!-- Filters Panel -->
         {#if showFilters}
-          <div class="p-4 sm:p-6 border-b border-white/10 bg-white/5" transition:slide={{ duration: 200 }}>
+          <div id="filters-panel" class="p-4 sm:p-6 border-b border-white/10 bg-white/5" transition:slide={{ duration: 200 }}>
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
               <!-- Grade Filter -->
               <div>


### PR DESCRIPTION
I identified an accessibility issue where the toggle button controlling the `Filters Panel` in `AdvancedSearch.svelte` was missing necessary `aria-expanded` and `aria-controls` properties. This PR resolves the issue by providing the proper ARIA links, ensuring screen readers can announce the component's state correctly. Tests and lint pass.

---
*PR created automatically by Jules for task [7652055419960699800](https://jules.google.com/task/7652055419960699800) started by @iberi22*