### PR TITLE
feat(ai): Add Chrome Built-in AI (Gemini Nano) provider

### DIFF
--- a/saberparatodos/src/lib/ai/chrome-nano-provider.test.ts
+++ b/saberparatodos/src/lib/ai/chrome-nano-provider.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildNanoSystemPrompt,
+  createChromeNanoSession,
+  generateNanoTutorResponse,
+  isChromeNanoAvailable,
+  ChromeNanoProvider,
+} from './chrome-nano-provider';
+import { TutorSession } from './tutor-session';
+
+describe('chrome-nano-provider', () => {
+  beforeEach(() => {
+    // Reset window and navigator mocks before each test
+    delete (globalThis as any).window;
+    delete (globalThis as any).navigator;
+  });
+
+  describe('buildNanoSystemPrompt', () => {
+    it('includes base tutor guidelines', () => {
+      const prompt = buildNanoSystemPrompt();
+      expect(prompt).toContain('Eres un tutor pedagógico on-device');
+      expect(prompt).toContain('NO reveles la letra o texto exacto');
+    });
+
+    it('formats context metadata into system prompt', () => {
+      const context = {
+        subject: 'Matemáticas',
+        grade: 11,
+        questionText: '¿Cuál es la derivada de x^2?',
+        userAnswer: '2x',
+        explanation: 'Se aplica la regla de la potencia.',
+        sessionSummary: 'El estudiante domina álgebra básica.',
+      };
+      const prompt = buildNanoSystemPrompt(context);
+      expect(prompt).toContain('Materia: Matemáticas.');
+      expect(prompt).toContain('Grado: 11.');
+      expect(prompt).toContain('Pregunta activa: ¿Cuál es la derivada de x^2?');
+      expect(prompt).toContain('Respuesta del estudiante: 2x');
+      expect(prompt).toContain('Notas internas (no citar literalmente como clave): Se aplica la regla de la potencia.');
+      expect(prompt).toContain('Informe reciente: El estudiante domina álgebra básica.');
+    });
+  });
+
+  describe('isChromeNanoAvailable', () => {
+    it('returns false if navigator and window ai are undefined', async () => {
+      const available = await isChromeNanoAvailable();
+      expect(available).toBe(false);
+    });
+
+    it('returns true if navigator.ai.languageModel.create exists and capabilities is readily available', async () => {
+      (globalThis as any).navigator = {
+        ai: {
+          languageModel: {
+            create: vi.fn(),
+            capabilities: vi.fn().mockResolvedValue({ available: 'readily' }),
+          },
+        },
+      };
+
+      const available = await isChromeNanoAvailable();
+      expect(available).toBe(true);
+    });
+
+    it('returns false if capabilities returns available: "no"', async () => {
+      (globalThis as any).navigator = {
+        ai: {
+          languageModel: {
+            create: vi.fn(),
+            capabilities: vi.fn().mockResolvedValue({ available: 'no' }),
+          },
+        },
+      };
+
+      const available = await isChromeNanoAvailable();
+      expect(available).toBe(false);
+    });
+
+    it('returns true if window.ai.languageModel is used', async () => {
+      (globalThis as any).window = {
+        ai: {
+          languageModel: {
+            create: vi.fn(),
+            availability: vi.fn().mockResolvedValue('readily'),
+          },
+        },
+      };
+
+      const available = await isChromeNanoAvailable();
+      expect(available).toBe(true);
+    });
+  });
+
+  describe('createChromeNanoSession', () => {
+    it('throws error if languageModel is not available', async () => {
+      await expect(createChromeNanoSession()).rejects.toThrow(
+        'Chrome Built-in AI (Gemini Nano) is not available'
+      );
+    });
+
+    it('calls navigator.ai.languageModel.create with options and temperature 0.5 default', async () => {
+      const mockCreate = vi.fn().mockResolvedValue({ prompt: vi.fn() });
+      (globalThis as any).navigator = {
+        ai: {
+          languageModel: {
+            create: mockCreate,
+          },
+        },
+      };
+
+      await createChromeNanoSession({ systemPrompt: 'Test Prompt', temperature: 0.5 });
+      expect(mockCreate).toHaveBeenCalledWith({
+        systemPrompt: 'Test Prompt',
+        temperature: 0.5,
+        topK: undefined,
+        signal: undefined,
+      });
+    });
+  });
+
+  describe('generateNanoTutorResponse', () => {
+    it('generates response via Gemini Nano session when available', async () => {
+      const mockDestroy = vi.fn();
+      const mockPrompt = vi.fn().mockResolvedValue('Recuerda aplicar la regla de exponentes.');
+      const mockCreate = vi.fn().mockResolvedValue({
+        prompt: mockPrompt,
+        destroy: mockDestroy,
+      });
+
+      (globalThis as any).navigator = {
+        ai: {
+          languageModel: {
+            create: mockCreate,
+            capabilities: vi.fn().mockResolvedValue({ available: 'readily' }),
+          },
+        },
+      };
+
+      const context = { subject: 'Física', grade: 10 };
+      const res = await generateNanoTutorResponse('¿Cómo calculo la velocidad?', context);
+
+      expect(res).toBe('Recuerda aplicar la regla de exponentes.');
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 0.5,
+        })
+      );
+      expect(mockPrompt).toHaveBeenCalledWith('¿Cómo calculo la velocidad?');
+      expect(mockDestroy).toHaveBeenCalled();
+    });
+
+    it('uses fallbackFn if Chrome Nano is unavailable', async () => {
+      const fallbackFn = vi.fn().mockResolvedValue('Respuesta desde fallback tier.');
+      const res = await generateNanoTutorResponse('Hola', {}, fallbackFn);
+
+      expect(res).toBe('Respuesta desde fallback tier.');
+      expect(fallbackFn).toHaveBeenCalled();
+    });
+
+    it('uses fallbackFn if session.prompt throws an error', async () => {
+      const mockCreate = vi.fn().mockResolvedValue({
+        prompt: vi.fn().mockRejectedValue(new Error('Prompt error')),
+        destroy: vi.fn(),
+      });
+
+      (globalThis as any).navigator = {
+        ai: {
+          languageModel: {
+            create: mockCreate,
+            capabilities: vi.fn().mockResolvedValue({ available: 'readily' }),
+          },
+        },
+      };
+
+      const fallbackFn = vi.fn().mockResolvedValue('Respuesta fallback tras error Nano.');
+      const res = await generateNanoTutorResponse('Ayuda', {}, fallbackFn);
+
+      expect(res).toBe('Respuesta fallback tras error Nano.');
+      expect(fallbackFn).toHaveBeenCalled();
+    });
+  });
+
+  describe('ChromeNanoProvider class', () => {
+    it('manages context and calls generateNanoTutorResponse', async () => {
+      const provider = new ChromeNanoProvider({ subject: 'Química' });
+      provider.updateContext({ grade: 11 });
+
+      expect(provider.getContext()).toEqual({ subject: 'Química', grade: 11 });
+
+      const fallbackFn = vi.fn().mockResolvedValue('Respuesta provista.');
+      const response = await provider.generateResponse('Explicación', fallbackFn);
+
+      expect(response).toBe('Respuesta provista.');
+    });
+  });
+
+  describe('TutorSession integration', () => {
+    it('uses Chrome Nano when available, otherwise falls back smoothly', async () => {
+      const session = new TutorSession({ subject: 'Historia', grade: 11 });
+      const turn = await session.respondText('¿Cuándo comenzó la Independencia?', { speak: false });
+
+      expect(turn.userText).toBe('¿Cuándo comenzó la Independencia?');
+      expect(turn.assistantText).toBeTruthy();
+      expect(session.getHistory().length).toBe(1);
+    });
+  });
+});

--- a/saberparatodos/src/lib/ai/chrome-nano-provider.ts
+++ b/saberparatodos/src/lib/ai/chrome-nano-provider.ts
@@ -1,0 +1,207 @@
+/**
+ * Chrome Built-in AI (Gemini Nano) LLM Provider for SaberParaTodos / WorldExams.
+ * Uses Chrome Prompt API (navigator.ai.languageModel or window.ai.languageModel).
+ */
+
+import type { TutorContext } from './tutor-session';
+
+/** Ambient types for Chrome Built-in AI Prompt API */
+export interface AILanguageModelSession {
+  prompt(input: string): Promise<string>;
+  promptStreaming?(input: string): AsyncIterable<string>;
+  destroy?(): void;
+  close?(): void;
+}
+
+export interface ChromeNanoCreateOptions {
+  systemPrompt?: string;
+  temperature?: number;
+  topK?: number;
+  signal?: AbortSignal;
+}
+
+export interface ChromeNanoModelCapabilities {
+  available: 'readily' | 'after-download' | 'no';
+  defaultTemperature?: number;
+  defaultTopK?: number;
+  maxTopK?: number;
+}
+
+export interface ChromeLanguageModelAPI {
+  capabilities?: () => Promise<ChromeNanoModelCapabilities>;
+  availability?: () => Promise<'readily' | 'after-download' | 'no'>;
+  create?: (options?: ChromeNanoCreateOptions) => Promise<AILanguageModelSession>;
+}
+
+declare global {
+  interface Navigator {
+    ai?: {
+      languageModel?: ChromeLanguageModelAPI;
+    };
+  }
+  interface Window {
+    ai?: {
+      languageModel?: ChromeLanguageModelAPI;
+    };
+  }
+}
+
+/**
+ * Builds system prompt for Gemini Nano from tutor context.
+ */
+export function buildNanoSystemPrompt(context: TutorContext = {}): string {
+  return [
+    'Eres un tutor pedagógico on-device para SaberParaTodos / WorldExams.',
+    'Habla en español claro y breve (2-5 oraciones).',
+    'NO reveles la letra o texto exacto de la respuesta correcta.',
+    'Da pistas, corrige conceptos y anima a razonar.',
+    context.subject ? `Materia: ${context.subject}.` : '',
+    context.grade ? `Grado: ${context.grade}.` : '',
+    context.questionText ? `Pregunta activa: ${context.questionText}` : '',
+    context.userAnswer ? `Respuesta del estudiante: ${context.userAnswer}` : '',
+    context.explanation
+      ? `Notas internas (no citar literalmente como clave): ${context.explanation.slice(0, 400)}`
+      : '',
+    context.sessionSummary ? `Informe reciente: ${context.sessionSummary.slice(0, 300)}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+/**
+ * Retrieves Chrome AI languageModel interface from navigator or window.
+ */
+function getChromeLanguageModelAPI(): ChromeLanguageModelAPI | undefined {
+  if (typeof navigator !== 'undefined' && navigator.ai?.languageModel) {
+    return navigator.ai.languageModel;
+  }
+  if (typeof window !== 'undefined' && (window as any).ai?.languageModel) {
+    return (window as any).ai.languageModel;
+  }
+  return undefined;
+}
+
+/**
+ * Checks if Chrome Built-in AI (Gemini Nano) languageModel API is available in the current runtime environment.
+ */
+export async function isChromeNanoAvailable(): Promise<boolean> {
+  const api = getChromeLanguageModelAPI();
+  if (!api || typeof api.create !== 'function') {
+    return false;
+  }
+
+  try {
+    if (typeof api.capabilities === 'function') {
+      const caps = await api.capabilities();
+      if (caps && caps.available === 'no') {
+        return false;
+      }
+    } else if (typeof api.availability === 'function') {
+      const avail = await api.availability();
+      if (avail === 'no') {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Creates a language model session using Chrome Prompt API: navigator.ai.languageModel.create()
+ */
+export async function createChromeNanoSession(
+  options: ChromeNanoCreateOptions = {}
+): Promise<AILanguageModelSession> {
+  const api = getChromeLanguageModelAPI();
+  if (!api || typeof api.create !== 'function') {
+    throw new Error('Chrome Built-in AI (Gemini Nano) is not available in this environment');
+  }
+
+  const { systemPrompt, temperature = 0.5, topK, signal } = options;
+  return await api.create({
+    systemPrompt,
+    temperature,
+    topK,
+    signal,
+  });
+}
+
+/**
+ * Generates a tutor response locally via Gemini Nano using prompt API.
+ * Falls back gracefully to `fallbackFn` if unavailable or on error.
+ */
+export async function generateNanoTutorResponse(
+  userText: string,
+  context: TutorContext = {},
+  fallbackFn?: () => Promise<string>
+): Promise<string> {
+  try {
+    const available = await isChromeNanoAvailable();
+    if (!available) {
+      if (fallbackFn) {
+        return await fallbackFn();
+      }
+      throw new Error('Chrome Nano is not available and no fallback function was provided');
+    }
+
+    const systemPrompt = buildNanoSystemPrompt(context);
+    const session = await createChromeNanoSession({ systemPrompt, temperature: 0.5 });
+
+    let response = '';
+    try {
+      response = await session.prompt(userText);
+    } finally {
+      if (typeof session.destroy === 'function') {
+        session.destroy();
+      } else if (typeof session.close === 'function') {
+        session.close();
+      }
+    }
+
+    if (!response || !response.trim()) {
+      if (fallbackFn) {
+        return await fallbackFn();
+      }
+    }
+
+    return response;
+  } catch (err) {
+    console.warn('[ChromeNanoProvider] Failed to generate response via Chrome Nano, calling fallback:', err);
+    if (fallbackFn) {
+      return await fallbackFn();
+    }
+    throw err;
+  }
+}
+
+/**
+ * Stateful provider wrapper for Chrome Built-in AI (Gemini Nano).
+ */
+export class ChromeNanoProvider {
+  private context: TutorContext;
+
+  constructor(context: TutorContext = {}) {
+    this.context = { ...context };
+  }
+
+  updateContext(partial: Partial<TutorContext>): void {
+    this.context = { ...this.context, ...partial };
+  }
+
+  getContext(): TutorContext {
+    return { ...this.context };
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return isChromeNanoAvailable();
+  }
+
+  async generateResponse(
+    userText: string,
+    fallbackFn?: () => Promise<string>
+  ): Promise<string> {
+    return generateNanoTutorResponse(userText, this.context, fallbackFn);
+  }
+}

--- a/saberparatodos/src/lib/ai/tutor-session.ts
+++ b/saberparatodos/src/lib/ai/tutor-session.ts
@@ -4,6 +4,7 @@
  */
 
 import { getAiCore } from './ai-core-client';
+import { generateNanoTutorResponse } from './chrome-nano-provider';
 import { recordMejoraInterna } from '../mejora-interna-telemetry';
 
 export interface TutorContext {
@@ -60,12 +61,14 @@ export class TutorSession {
 
   async respondText(userText: string, opts?: { speak?: boolean }): Promise<TutorTurn> {
     const ai = getAiCore();
-    const prompt = `${this.buildSystemPrompt()}\n\nEstudiante: ${userText}\nTutor:`;
     let assistantText: string;
     try {
-      assistantText = await ai.llm.generate(prompt, { maxNewTokens: 256, temperature: 0.5 });
-      // Strip stub headers if template mode
-      if (assistantText.includes('Respuesta local (modo plantilla)')) {
+      assistantText = await generateNanoTutorResponse(userText, this.context, async () => {
+        const prompt = `${this.buildSystemPrompt()}\n\nEstudiante: ${userText}\nTutor:`;
+        return await ai.llm.generate(prompt, { maxNewTokens: 256, temperature: 0.5 });
+      });
+      // Provide default pedagogical guidance if response is empty or template stub
+      if (!assistantText || !assistantText.trim() || assistantText.includes('Respuesta local (modo plantilla)')) {
         assistantText =
           'Vamos por partes: revisa el enunciado, descarta opciones imposibles y justifica tu elección con el concepto clave. Si quieres, dime qué opción te confunde.';
       }


### PR DESCRIPTION
Created `chrome-nano-provider.ts` to support local Gemini Nano response generation via Chrome Built-in AI Prompt API (`navigator.ai.languageModel.create`).

Key highlights:
- Ambient types for Chrome Prompt API (`navigator.ai.languageModel` / `window.ai.languageModel`).
- System prompt generation formatting tutor context (subject, grade, question, answer, explanation, session summary).
- Default temperature 0.5 for Gemini Nano prompt session creation.
- Graceful error handling and fallback mechanism.
- Seamless integration with `TutorSession.respondText` in `tutor-session.ts`.
- 13 comprehensive unit tests added and all 38 test suites passing.

Fixes #1001

---
*PR created automatically by Jules for task [7674074068441718525](https://jules.google.com/task/7674074068441718525) started by @iberi22*