### PR TITLE
feat(ai): add device capability detection for hybrid tutor

### DIFF
--- a/saberparatodos/src/lib/ai/device-capability.test.ts
+++ b/saberparatodos/src/lib/ai/device-capability.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  checkWebGPU,
+  checkChromeNano,
+  checkOllama,
+  checkCloudCredits,
+  determineRecommendedTier,
+  detectDeviceCapabilities,
+} from './device-capability';
+
+describe('device-capability', () => {
+  const originalNavigator = globalThis.navigator;
+  const originalWindow = globalThis.window;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: originalNavigator,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: originalWindow,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('checkWebGPU', () => {
+    it('returns false when navigator.gpu is undefined or missing', async () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {},
+        writable: true,
+        configurable: true,
+      });
+      expect(await checkWebGPU()).toBe(false);
+    });
+
+    it('returns true when navigator.gpu.requestAdapter returns an adapter', async () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          gpu: {
+            requestAdapter: vi.fn().mockResolvedValue({ name: 'Mock GPU' }),
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+      expect(await checkWebGPU()).toBe(true);
+    });
+
+    it('returns false when navigator.gpu.requestAdapter returns null or throws', async () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          gpu: {
+            requestAdapter: vi.fn().mockResolvedValue(null),
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+      expect(await checkWebGPU()).toBe(false);
+
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          gpu: {
+            requestAdapter: vi.fn().mockRejectedValue(new Error('GPU Disabled')),
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+      expect(await checkWebGPU()).toBe(false);
+    });
+  });
+
+  describe('checkChromeNano', () => {
+    it('returns false when navigator.ai and window.ai are missing', async () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {},
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(globalThis, 'window', {
+        value: {},
+        writable: true,
+        configurable: true,
+      });
+      expect(await checkChromeNano()).toBe(false);
+    });
+
+    it('returns true when navigator.ai.languageModel is available', async () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          ai: {
+            languageModel: {
+              capabilities: vi.fn().mockResolvedValue({ available: 'readily' }),
+            },
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+      expect(await checkChromeNano()).toBe(true);
+    });
+
+    it('returns false when languageModel capabilities returns available: "no"', async () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          ai: {
+            languageModel: {
+              capabilities: vi.fn().mockResolvedValue({ available: 'no' }),
+            },
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+      expect(await checkChromeNano()).toBe(false);
+    });
+  });
+
+  describe('checkOllama', () => {
+    it('returns true when localhost:11434 responds OK', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      const result = await checkOllama(mockFetch as any);
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:11434/api/tags',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('returns false when localhost:11434 fails or returns non-ok status', async () => {
+      const mockFetchBad = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+      expect(await checkOllama(mockFetchBad as any)).toBe(false);
+
+      const mockFetchErr = vi.fn().mockRejectedValue(new Error('Connection refused'));
+      expect(await checkOllama(mockFetchErr as any)).toBe(false);
+    });
+  });
+
+  describe('checkCloudCredits', () => {
+    it('returns hasCloudCredits true when credits > 0', async () => {
+      const mockGetProfile = vi.fn().mockResolvedValue({ credits: 25, subscription_tier: 'free' });
+      const res = await checkCloudCredits(mockGetProfile as any);
+      expect(res).toEqual({ hasCloudCredits: true, credits: 25 });
+    });
+
+    it('returns hasCloudCredits false when credits <= 0 or user is not logged in', async () => {
+      const mockGetProfileZero = vi.fn().mockResolvedValue({ credits: 0, subscription_tier: 'free' });
+      expect(await checkCloudCredits(mockGetProfileZero as any)).toEqual({
+        hasCloudCredits: false,
+        credits: 0,
+      });
+
+      const mockGetProfileNull = vi.fn().mockResolvedValue(null);
+      expect(await checkCloudCredits(mockGetProfileNull as any)).toEqual({
+        hasCloudCredits: false,
+        credits: 0,
+      });
+    });
+  });
+
+  describe('determineRecommendedTier', () => {
+    it('prioritizes chrome-nano over all other tiers', () => {
+      const tier = determineRecommendedTier({
+        hasChromeNano: true,
+        hasWebGPU: true,
+        hasOllama: true,
+        hasCloudCredits: true,
+      });
+      expect(tier).toBe('chrome-nano');
+    });
+
+    it('recommends webgpu when chrome-nano is unavailable', () => {
+      const tier = determineRecommendedTier({
+        hasChromeNano: false,
+        hasWebGPU: true,
+        hasOllama: true,
+        hasCloudCredits: true,
+      });
+      expect(tier).toBe('webgpu');
+    });
+
+    it('recommends ollama when chrome-nano and webgpu are unavailable', () => {
+      const tier = determineRecommendedTier({
+        hasChromeNano: false,
+        hasWebGPU: false,
+        hasOllama: true,
+        hasCloudCredits: true,
+      });
+      expect(tier).toBe('ollama');
+    });
+
+    it('recommends cloud when only cloud credits are available', () => {
+      const tier = determineRecommendedTier({
+        hasChromeNano: false,
+        hasWebGPU: false,
+        hasOllama: false,
+        hasCloudCredits: true,
+      });
+      expect(tier).toBe('cloud');
+    });
+
+    it('returns none when no capabilities are available', () => {
+      const tier = determineRecommendedTier({
+        hasChromeNano: false,
+        hasWebGPU: false,
+        hasOllama: false,
+        hasCloudCredits: false,
+      });
+      expect(tier).toBe('none');
+    });
+  });
+
+  describe('detectDeviceCapabilities', () => {
+    it('returns full capabilities object correctly', async () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          gpu: {
+            requestAdapter: vi.fn().mockResolvedValue({ name: 'WebGPU Adapter' }),
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      const mockGetProfile = vi.fn().mockResolvedValue({ credits: 100 });
+
+      const result = await detectDeviceCapabilities({
+        fetchFn: mockFetch as any,
+        getProfileFn: mockGetProfile as any,
+      });
+
+      expect(result).toEqual({
+        hasWebGPU: true,
+        hasChromeNano: false,
+        hasOllama: true,
+        hasCloudCredits: true,
+        cloudCredits: 100,
+        recommendedTier: 'webgpu',
+      });
+    });
+  });
+});

--- a/saberparatodos/src/lib/ai/device-capability.ts
+++ b/saberparatodos/src/lib/ai/device-capability.ts
@@ -1,0 +1,172 @@
+/**
+ * Device capability detection for Hybrid Tutor in SaberParaTodos / WorldExams.
+ * Detects: WebGPU, Chrome Built-in AI (Gemini Nano), Ollama local, and SWAL cloud credits.
+ */
+
+import { getUserProfile } from '../supabase';
+
+export type AiTier = 'chrome-nano' | 'webgpu' | 'ollama' | 'cloud' | 'none';
+
+export interface DeviceCapabilityResult {
+  hasWebGPU: boolean;
+  hasChromeNano: boolean;
+  hasOllama: boolean;
+  hasCloudCredits: boolean;
+  cloudCredits: number;
+  recommendedTier: AiTier;
+}
+
+export interface DetectCapabilitiesOptions {
+  fetchFn?: typeof fetch;
+  ollamaUrl?: string;
+  getProfileFn?: typeof getUserProfile;
+  timeoutMs?: number;
+}
+
+/**
+ * Checks if WebGPU is available in the current browser environment.
+ */
+export async function checkWebGPU(): Promise<boolean> {
+  if (typeof navigator === 'undefined' || !('gpu' in navigator) || !navigator.gpu) {
+    return false;
+  }
+  try {
+    const adapter = await navigator.gpu.requestAdapter();
+    return adapter !== null && adapter !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks if Chrome Built-in AI (Gemini Nano) is available via navigator.ai.languageModel
+ * or window.ai.languageModel.
+ */
+export async function checkChromeNano(): Promise<boolean> {
+  try {
+    const navAi = typeof navigator !== 'undefined' ? (navigator as any).ai : undefined;
+    const winAi = typeof window !== 'undefined' ? (window as any).ai : undefined;
+    const aiObj = navAi || winAi;
+
+    if (!aiObj || !aiObj.languageModel) {
+      return false;
+    }
+
+    if (typeof aiObj.languageModel.capabilities === 'function') {
+      const caps = await aiObj.languageModel.capabilities();
+      if (caps && caps.available === 'no') {
+        return false;
+      }
+    } else if (typeof aiObj.languageModel.availability === 'function') {
+      const availability = await aiObj.languageModel.availability();
+      if (availability === 'no' || availability === 'unavailable') {
+        return false;
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks if an Ollama instance is running locally on http://localhost:11434 (or custom URL).
+ */
+export async function checkOllama(
+  fetchFn: typeof fetch = fetch,
+  ollamaUrl: string = 'http://localhost:11434/api/tags',
+  timeoutMs: number = 1000
+): Promise<boolean> {
+  if (typeof fetchFn !== 'function') {
+    return false;
+  }
+
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+  const timeoutId = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+
+  try {
+    const res = await fetchFn(ollamaUrl, {
+      method: 'GET',
+      signal: controller ? controller.signal : undefined,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Queries SWAL user profile to check if cloud credits are available.
+ */
+export async function checkCloudCredits(
+  getProfileFn: typeof getUserProfile = getUserProfile
+): Promise<{ hasCloudCredits: boolean; credits: number }> {
+  try {
+    const profile = await getProfileFn();
+    if (profile && typeof profile.credits === 'number' && profile.credits > 0) {
+      return { hasCloudCredits: true, credits: profile.credits };
+    }
+    return { hasCloudCredits: false, credits: profile?.credits ?? 0 };
+  } catch {
+    return { hasCloudCredits: false, credits: 0 };
+  }
+}
+
+/**
+ * Determines recommended AI tier based on detected capabilities in priority order:
+ * 1. Chrome Gemini Nano
+ * 2. WebGPU
+ * 3. Ollama local
+ * 4. Cloud credits
+ * 5. None
+ */
+export function determineRecommendedTier(caps: {
+  hasChromeNano: boolean;
+  hasWebGPU: boolean;
+  hasOllama: boolean;
+  hasCloudCredits: boolean;
+}): AiTier {
+  if (caps.hasChromeNano) return 'chrome-nano';
+  if (caps.hasWebGPU) return 'webgpu';
+  if (caps.hasOllama) return 'ollama';
+  if (caps.hasCloudCredits) return 'cloud';
+  return 'none';
+}
+
+/**
+ * Runs all 4 capability checks in parallel and returns full DeviceCapabilityResult.
+ */
+export async function detectDeviceCapabilities(
+  options: DetectCapabilitiesOptions = {}
+): Promise<DeviceCapabilityResult> {
+  const fetchFn = options.fetchFn ?? (typeof fetch !== 'undefined' ? fetch : undefined);
+  const getProfileFn = options.getProfileFn ?? getUserProfile;
+  const ollamaUrl = options.ollamaUrl ?? 'http://localhost:11434/api/tags';
+  const timeoutMs = options.timeoutMs ?? 1000;
+
+  const [hasWebGPU, hasChromeNano, hasOllama, cloudResult] = await Promise.all([
+    checkWebGPU(),
+    checkChromeNano(),
+    fetchFn ? checkOllama(fetchFn, ollamaUrl, timeoutMs) : Promise.resolve(false),
+    checkCloudCredits(getProfileFn),
+  ]);
+
+  const recommendedTier = determineRecommendedTier({
+    hasChromeNano,
+    hasWebGPU,
+    hasOllama,
+    hasCloudCredits: cloudResult.hasCloudCredits,
+  });
+
+  return {
+    hasWebGPU,
+    hasChromeNano,
+    hasOllama,
+    hasCloudCredits: cloudResult.hasCloudCredits,
+    cloudCredits: cloudResult.credits,
+    recommendedTier,
+  };
+}


### PR DESCRIPTION
Implement device capability detection for the hybrid tutor, checking for WebGPU, Chrome Gemini Nano, Ollama, and Cloud Credits, and determining the recommended tier based on priority.

Fixes #1000

---
*PR created automatically by Jules for task [2860418234389285364](https://jules.google.com/task/2860418234389285364) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of available AI capabilities, including WebGPU, Chrome Built-in AI, local Ollama, and cloud credits.
  * Added recommended AI tier selection based on detected capabilities.
  * Added capability status reporting with graceful handling of unavailable services or connection failures.
* **Tests**
  * Added comprehensive coverage for capability detection, tier selection, failure scenarios, and environment conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->