### PR TITLE
feat(anti-cheat): extend antiCheat with screen monitoring detection

### DIFF
--- a/saberparatodos/src/modules/exam-room/services/antiCheat.ts
+++ b/saberparatodos/src/modules/exam-room/services/antiCheat.ts
@@ -12,6 +12,8 @@ class AntiCheatService {
   private lastActivityTime = Date.now();
   private inactivityCheckInterval?: number;
   private hiddenTime?: number;
+  private lastWidth = 0;
+  private lastHeight = 0;
 
   /**
    * Inicia el monitoreo anti-cheat
@@ -22,6 +24,8 @@ class AntiCheatService {
     this.listeners.push(onSuspiciousActivity);
     this.isMonitoring = true;
     this.lastActivityTime = Date.now();
+    this.lastWidth = typeof window !== 'undefined' ? window.innerWidth : 0;
+    this.lastHeight = typeof window !== 'undefined' ? window.innerHeight : 0;
 
     // Page Visibility API - detecta cuando el tab está oculto
     document.addEventListener('visibilitychange', this.handleVisibilityChange);
@@ -29,6 +33,15 @@ class AntiCheatService {
     // Window blur - detecta cuando pierdes el foco de la ventana
     window.addEventListener('blur', this.handleWindowBlur);
     window.addEventListener('focus', this.handleWindowFocus);
+
+    // Fullscreen exit detection
+    document.addEventListener('fullscreenchange', this.handleFullscreenChange);
+
+    // Orientation change detection
+    window.addEventListener('orientationchange', this.handleOrientationChange);
+
+    // Window resize detection (large resize = split screen / suspicious)
+    window.addEventListener('resize', this.handleResize);
 
     // Detectar inactividad prolongada (5 segundos sin interacción)
     this.startInactivityCheck();
@@ -45,6 +58,9 @@ class AntiCheatService {
     document.removeEventListener('visibilitychange', this.handleVisibilityChange);
     window.removeEventListener('blur', this.handleWindowBlur);
     window.removeEventListener('focus', this.handleWindowFocus);
+    document.removeEventListener('fullscreenchange', this.handleFullscreenChange);
+    window.removeEventListener('orientationchange', this.handleOrientationChange);
+    window.removeEventListener('resize', this.handleResize);
 
     if (this.inactivityCheckInterval) {
       clearInterval(this.inactivityCheckInterval);
@@ -94,6 +110,43 @@ class AntiCheatService {
   private handleWindowFocus = () => {
     // Usuario regresó a la ventana
     this.recordActivity();
+  };
+
+  private handleFullscreenChange = () => {
+    if (!document.fullscreenElement) {
+      this.emitEvent({
+        type: 'fullscreen_exit',
+        timestamp: new Date(),
+      });
+    }
+  };
+
+  private handleOrientationChange = () => {
+    this.emitEvent({
+      type: 'orientation_change',
+      timestamp: new Date(),
+    });
+  };
+
+  private handleResize = () => {
+    if (typeof window === 'undefined') return;
+    const currentWidth = window.innerWidth;
+    const currentHeight = window.innerHeight;
+
+    if (this.lastWidth > 0 && this.lastHeight > 0) {
+      const widthChange = Math.abs(currentWidth - this.lastWidth) / this.lastWidth;
+      const heightChange = Math.abs(currentHeight - this.lastHeight) / this.lastHeight;
+
+      if (widthChange > 0.5 || heightChange > 0.5) {
+        this.emitEvent({
+          type: 'resize_suspicious',
+          timestamp: new Date(),
+        });
+      }
+    }
+
+    this.lastWidth = currentWidth;
+    this.lastHeight = currentHeight;
   };
 
   private startInactivityCheck() {

--- a/saberparatodos/src/modules/exam-room/types.ts
+++ b/saberparatodos/src/modules/exam-room/types.ts
@@ -75,7 +75,14 @@ export interface Player {
 }
 
 export interface SuspiciousEvent {
-  type: 'tab_switch' | 'window_blur' | 'page_hidden' | 'long_inactivity';
+  type:
+    | 'tab_switch'
+    | 'window_blur'
+    | 'page_hidden'
+    | 'long_inactivity'
+    | 'fullscreen_exit'
+    | 'orientation_change'
+    | 'resize_suspicious';
   timestamp: Date;
   duration?: number; // ms
 }

--- a/saberparatodos/tests/unit/antiCheat.unit.test.ts
+++ b/saberparatodos/tests/unit/antiCheat.unit.test.ts
@@ -16,15 +16,23 @@ describe('AntiCheatService Lifecycle', () => {
   });
 
   it('should start and stop monitoring correctly', () => {
-    const addEventSpy = vi.spyOn(document, 'addEventListener');
-    const removeEventSpy = vi.spyOn(document, 'removeEventListener');
+    const addDocEventSpy = vi.spyOn(document, 'addEventListener');
+    const removeDocEventSpy = vi.spyOn(document, 'removeEventListener');
+    const addWinEventSpy = vi.spyOn(window, 'addEventListener');
+    const removeWinEventSpy = vi.spyOn(window, 'removeEventListener');
     const callback = vi.fn();
 
     antiCheatService.startMonitoring(callback);
-    expect(addEventSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    expect(addDocEventSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    expect(addDocEventSpy).toHaveBeenCalledWith('fullscreenchange', expect.any(Function));
+    expect(addWinEventSpy).toHaveBeenCalledWith('orientationchange', expect.any(Function));
+    expect(addWinEventSpy).toHaveBeenCalledWith('resize', expect.any(Function));
 
     antiCheatService.stopMonitoring();
-    expect(removeEventSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    expect(removeDocEventSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    expect(removeDocEventSpy).toHaveBeenCalledWith('fullscreenchange', expect.any(Function));
+    expect(removeWinEventSpy).toHaveBeenCalledWith('orientationchange', expect.any(Function));
+    expect(removeWinEventSpy).toHaveBeenCalledWith('resize', expect.any(Function));
   });
 
   it('should ignore multiple start monitoring requests', () => {
@@ -114,5 +122,57 @@ describe('AntiCheatService Activity Monitoring', () => {
     vi.advanceTimersByTime(20000);
 
     expect(detectedEvents).toHaveLength(0);
+  });
+
+  it('should detect fullscreen exit', () => {
+    Object.defineProperty(document, 'fullscreenElement', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    expect(detectedEvents).toHaveLength(1);
+    expect(detectedEvents[0].type).toBe('fullscreen_exit');
+    expect(detectedEvents[0].timestamp).toBeInstanceOf(Date);
+
+    // Should not emit if entering fullscreen
+    detectedEvents = [];
+    document.fullscreenElement = document.createElement('div');
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    expect(detectedEvents).toHaveLength(0);
+  });
+
+  it('should detect orientation change', () => {
+    window.dispatchEvent(new Event('orientationchange'));
+
+    expect(detectedEvents).toHaveLength(1);
+    expect(detectedEvents[0].type).toBe('orientation_change');
+    expect(detectedEvents[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  it('should detect suspicious resize (>50% change) and ignore small resizes', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1000, writable: true, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 1000, writable: true, configurable: true });
+
+    // Restart monitoring so initial dimensions are 1000 x 1000
+    antiCheatService.stopMonitoring();
+    antiCheatService.startMonitoring(callback);
+
+    // Small resize (10% change) - 1000 -> 900
+    window.innerWidth = 900;
+    window.dispatchEvent(new Event('resize'));
+
+    expect(detectedEvents).toHaveLength(0);
+
+    // Large resize (>50% change relative to 900) - 900 -> 400 (55.5% change)
+    window.innerWidth = 400;
+    window.dispatchEvent(new Event('resize'));
+
+    expect(detectedEvents).toHaveLength(1);
+    expect(detectedEvents[0].type).toBe('resize_suspicious');
+    expect(detectedEvents[0].timestamp).toBeInstanceOf(Date);
   });
 });


### PR DESCRIPTION
Added screen monitoring anti-cheat capabilities to AntiCheatService and SuspiciousEvent:
- Added 'fullscreen_exit', 'orientation_change', and 'resize_suspicious' to SuspiciousEvent type.
- Extended AntiCheatService to listen for 'fullscreenchange' (exit detection when !document.fullscreenElement), 'orientationchange', and 'resize' (>50% width or height change).
- Cleaned up event listeners on stopMonitoring.
- Added comprehensive unit test suite in antiCheat.unit.test.ts verifying all screen monitoring detection handlers.

Fixes #1004

---
*PR created automatically by Jules for task [9885668416505995527](https://jules.google.com/task/9885668416505995527) started by @iberi22*