### PR TITLE
🎨 Palette: Add ARIA controls and IDs to toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-08-13 - FlashlightCard Accessibility
 **Learning:** We had `FlashlightCard.svelte` using a generic `div` tag acting as a button with `role="button"` and `tabindex="0"`. While visually it acts like a card, generic clickable elements fail to provide native keyboard interaction behaviors (like Enter/Space handling) which compromises the screen reader and keyboard-only user experience.
 **Action:** Always prefer native semantic HTML elements (`<button type="button">` instead of `<div role="button">`) for interactive, clickable components. Use Tailwind utility classes such as `w-full text-left block` on buttons to neutralize user-agent stylesheet overrides and maintain the intended layout of complex nested cards without losing accessibility support.
+## 2024-05-25 - Accessibility on Toggle Buttons
+**Learning:** When adding `aria-controls` to toggle buttons (e.g., CacheIndicator and ScoreDisplay), the corresponding target container must explicitly define the matching `id` attribute. If the `id` is omitted, the `aria-controls` reference is broken, rendering the accessibility enhancement ineffective for screen readers.
+**Action:** Always verify that both `aria-controls` on the trigger and `id` on the target container are paired properly when implementing disclosure widgets.

--- a/saberparatodos/src/components/CacheIndicator.svelte
+++ b/saberparatodos/src/components/CacheIndicator.svelte
@@ -42,7 +42,7 @@
       <span class="text">Cargando...</span>
     </button>{pwaStatus.isPWA ? '📱' : '📦'}
   {:else if hasCache}
-    <button class="cache-btn active" on:click={() => showDetails = !showDetails}>
+    <button class="cache-btn active" on:click={() => showDetails = !showDetails} aria-expanded={showDetails} aria-controls="cache-details">
       <span class="icon">📦</span>
       <span class="text">{totalQuestions} preguntas</span>
       <span class="badge-mini">{cacheStats[0]?.isGuest ? '🔒' : '🔓'}</span>
@@ -55,7 +55,7 @@
   {/if}
 
   {#if showDetails && hasCache}
-    <div class="cache-details">
+    <div id="cache-details" class="cache-details">
       <div class="details-header">
         <h3>Estado de la Caché {pwaStatus.isPWA ? '📱' : ''}</h3>
         <button class="close-btn" on:click={() => showDetails = false} aria-label="Cerrar detalles">✕</button>

--- a/saberparatodos/src/components/ScoreDisplay.svelte
+++ b/saberparatodos/src/components/ScoreDisplay.svelte
@@ -94,7 +94,7 @@
             type="button"
             on:click={() => showScoreHelp = true}
             class="w-8 h-8 rounded-full border border-cyan-400/30 bg-cyan-400/10 text-cyan-300 hover:bg-cyan-400/20 transition-colors flex items-center justify-center"
-            aria-label="Explicar como funciona el puntaje"
+            aria-label="Explicar como funciona el puntaje" aria-expanded={showScoreHelp} aria-controls="score-help-modal"
             title="Como funciona este puntaje"
           >
             <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -276,7 +276,7 @@
     class="fixed inset-0 z-[90] bg-black/70 backdrop-blur-sm px-4 py-8 overflow-y-auto"
     role="dialog"
     aria-modal="true"
-    aria-labelledby="score-help-title"
+    id="score-help-modal" aria-labelledby="score-help-title"
     on:click={(event) => {
       if (event.currentTarget === event.target) {
         closeScoreHelp();


### PR DESCRIPTION
💡 What: Added proper ARIA attributes to the CacheIndicator and ScoreDisplay toggle buttons.
🎯 Why: Screen reader users need to know the state (expanded/collapsed) and the exact content a toggle button controls. Without these attributes, the relationship between the button and its content is broken.
♿ Accessibility: Added `aria-expanded`, `aria-controls` to the trigger buttons and the corresponding `id` tags to their targets (`cache-details` and `score-help-modal`).

---
*PR created automatically by Jules for task [9829196551828492130](https://jules.google.com/task/9829196551828492130) started by @iberi22*