### PR TITLE
feat(adaptive): expand adaptive engine beyond English/CEFR to all subjects

### DIFF
--- a/saberparatodos/src/lib/adaptive-engine.test.ts
+++ b/saberparatodos/src/lib/adaptive-engine.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { getNextAdaptiveQuestion } from './adaptive-engine';
+import {
+  getNextAdaptiveQuestion,
+  parseBloomLevel,
+  parseDifficultyBand,
+  BLOOM_LEVEL_NUM,
+  DIFFICULTY_BAND_NUM
+} from './adaptive-engine';
 import type { AppQuestion } from './api-service';
 import type { QuestionResult } from './english-proficiency';
 
 describe('Adaptive Testing Engine', () => {
 
-  // Mock a diverse question pool (A1 to C1)
-  const mockPool: AppQuestion[] = [
+  // Mock a diverse question pool for English (A1 to C1)
+  const englishMockPool: AppQuestion[] = [
     { id: 'q1', text: 'A1-Easy', cefr_level: 'A1', difficulty: 2, options: [], correctOptionId: 'A', category: 'ingles', grade: 11 },
     { id: 'q2', text: 'A2-Medium', cefr_level: 'A2', difficulty: 5, options: [], correctOptionId: 'A', category: 'ingles', grade: 11 },
     { id: 'q3', text: 'B1-Medium', cefr_level: 'B1', difficulty: 6, options: [], correctOptionId: 'A', category: 'ingles', grade: 11 },
@@ -14,17 +20,30 @@ describe('Adaptive Testing Engine', () => {
     { id: 'q5', text: 'C1-Expert', cefr_level: 'C1', difficulty: 10, options: [], correctOptionId: 'A', category: 'ingles', grade: 11 },
   ];
 
-  it('should return a calibration question when answered count is low', () => {
-    // 0 questions answered - should use default calibration (B1 / Diff 5)
-    // The closest is q3 (B1, diff 6)
+  // Mock STEM/Humanities question pools (Matemáticas, Lengua, Ciencias) with Bloom & Difficulty Bands
+  const stemMockPool: AppQuestion[] = [
+    { id: 'm1', text: 'Math Easy', difficulty: 2, options: [], correctOptionId: 'A', category: 'matematicas', grade: 11, bloom: 'Remember', difficulty_band: 'D1-D2' } as any,
+    { id: 'm2', text: 'Math Basic', difficulty: 4, options: [], correctOptionId: 'A', category: 'matematicas', grade: 11, bloom: 'Understand', difficulty_band: 'D3-D4' } as any,
+    { id: 'm3', text: 'Math Medium', difficulty: 6, options: [], correctOptionId: 'A', category: 'matematicas', grade: 11, bloom: 'Apply', difficulty_band: 'D5-D6' } as any,
+    { id: 'm4', text: 'Math Advanced', difficulty: 8, options: [], correctOptionId: 'A', category: 'matematicas', grade: 11, bloom: 'Analyze', difficulty_band: 'D7-D8' } as any,
+    { id: 'm5', text: 'Math Expert', difficulty: 10, options: [], correctOptionId: 'A', category: 'matematicas', grade: 11, bloom: 'Evaluate', difficulty_band: 'D9-D10' } as any,
+  ];
+
+  const cienciasMockPool: AppQuestion[] = [
+    { id: 'c1', text: 'Ciencias Recordar', difficulty: 3, options: [], correctOptionId: 'A', category: 'ciencias_naturales', grade: 11, bloom: 'Recordar', difficulty_band: 'D3-D4' } as any,
+    { id: 'c2', text: 'Ciencias Aplicar', difficulty: 6, options: [], correctOptionId: 'A', category: 'ciencias_naturales', grade: 11, bloom: 'Aplicar', difficulty_band: 'D5-D6' } as any,
+    { id: 'c3', text: 'Ciencias Evaluar', difficulty: 9, options: [], correctOptionId: 'A', category: 'ciencias_naturales', grade: 11, bloom: 'Evaluar', difficulty_band: 'D9-D10' } as any,
+  ];
+
+  it('should return a calibration question when answered count is low (English)', () => {
     const usedIds = new Set<string>();
-    const nextQ = getNextAdaptiveQuestion(mockPool, [], usedIds);
+    const nextQ = getNextAdaptiveQuestion(englishMockPool, [], usedIds);
 
     expect(nextQ).not.toBeNull();
     expect(nextQ?.cefr_level).toBe('B1');
   });
 
-  it('should scale up difficulty when student answers perfectly', () => {
+  it('should scale up difficulty when student answers perfectly (English)', () => {
     const answeredResults: QuestionResult[] = [
       { questionId: 'q1', isCorrect: true, cefrLevel: 'B1' },
       { questionId: 'q2', isCorrect: true, cefrLevel: 'B1' },
@@ -32,14 +51,12 @@ describe('Adaptive Testing Engine', () => {
     ];
     const usedIds = new Set<string>(['q1', 'q2', 'q3']);
 
-    // With 100% accuracy on B1, it should estimate B1/B1+ and push up to B2
-    const nextQ = getNextAdaptiveQuestion(mockPool, answeredResults, usedIds);
+    const nextQ = getNextAdaptiveQuestion(englishMockPool, answeredResults, usedIds);
     expect(nextQ).not.toBeNull();
-    // Because accuracy > 75%, it scales up from current estimate
     expect(['B2', 'B2+', 'C1']).toContain(nextQ?.cefr_level);
   });
 
-  it('should scale down difficulty when student struggles', () => {
+  it('should scale down difficulty when student struggles (English)', () => {
     const answeredResults: QuestionResult[] = [
       { questionId: 'qA', isCorrect: false, cefrLevel: 'B2' },
       { questionId: 'qB', isCorrect: false, cefrLevel: 'B2' },
@@ -47,17 +64,78 @@ describe('Adaptive Testing Engine', () => {
     ];
     const usedIds = new Set<string>(['qA', 'qB', 'qC']);
 
-    // Accuracy is ~33%, it should down-scale from the estimated level
-    const nextQ = getNextAdaptiveQuestion(mockPool, answeredResults, usedIds);
+    const nextQ = getNextAdaptiveQuestion(englishMockPool, answeredResults, usedIds);
     expect(nextQ).not.toBeNull();
-    // It should give an easier question (A1, A1+, A2)
     expect(['A1', 'A1+', 'A2', 'A2+']).toContain(nextQ?.cefr_level);
   });
 
   it('should return null when the pool is exhausted', () => {
-    const usedIds = new Set<string>(mockPool.map(q => q.id));
-    const nextQ = getNextAdaptiveQuestion(mockPool, [], usedIds);
+    const usedIds = new Set<string>(englishMockPool.map(q => q.id));
+    const nextQ = getNextAdaptiveQuestion(englishMockPool, [], usedIds);
     expect(nextQ).toBeNull();
+  });
+
+  describe('Subject-Agnostic Engine (Matemáticas, Ciencias, Lengua)', () => {
+    it('should select base Bloom / difficulty band during calibration phase', () => {
+      const usedIds = new Set<string>();
+      const nextQ = getNextAdaptiveQuestion(stemMockPool, [], usedIds);
+
+      expect(nextQ).not.toBeNull();
+      // Base config starts at baseDifficulty 5 (Apply / D5-D6), m3 is closest (diff 6, Apply, D5-D6)
+      expect(nextQ?.id).toBe('m3');
+    });
+
+    it('should scale up to higher Bloom / difficulty band on high accuracy (Matemáticas)', () => {
+      const answeredResults: QuestionResult[] = [
+        { questionId: 'm3', isCorrect: true, cefrLevel: 'A2', difficulty: 6 },
+        { questionId: 'm3b', isCorrect: true, cefrLevel: 'A2', difficulty: 6 },
+        { questionId: 'm3c', isCorrect: true, cefrLevel: 'A2', difficulty: 6 },
+      ]; // 100% accuracy on level 6 questions
+      const usedIds = new Set<string>(['m3']);
+
+      const nextQ = getNextAdaptiveQuestion(stemMockPool, answeredResults, usedIds);
+      expect(nextQ).not.toBeNull();
+      // Should scale up difficulty from 6 to ~8+ (Analyze / Evaluate, D7-D8 / D9-D10)
+      expect(['m4', 'm5']).toContain(nextQ?.id);
+    });
+
+    it('should scale down to lower Bloom / difficulty band on low accuracy (Ciencias)', () => {
+      const answeredResults: QuestionResult[] = [
+        { questionId: 'c2', isCorrect: false, cefrLevel: 'A2', difficulty: 6 },
+        { questionId: 'c2b', isCorrect: false, cefrLevel: 'A2', difficulty: 6 },
+        { questionId: 'c2c', isCorrect: true, cefrLevel: 'A2', difficulty: 6 },
+      ]; // 33% accuracy
+      const usedIds = new Set<string>(['c2']);
+
+      const nextQ = getNextAdaptiveQuestion(cienciasMockPool, answeredResults, usedIds);
+      expect(nextQ).not.toBeNull();
+      // Should scale down to c1 (Recordar / D3-D4)
+      expect(nextQ?.id).toBe('c1');
+    });
+  });
+
+  describe('Bloom & Difficulty Band Metadata Parsers', () => {
+    it('should parse Spanish and English Bloom taxonomy levels correctly', () => {
+      expect(parseBloomLevel('Remember')).toBe('Remember');
+      expect(parseBloomLevel('Recordar')).toBe('Remember');
+      expect(parseBloomLevel('comprender')).toBe('Understand');
+      expect(parseBloomLevel('APPLY')).toBe('Apply');
+      expect(parseBloomLevel('Analizar')).toBe('Analyze');
+      expect(parseBloomLevel('EVALUAR')).toBe('Evaluate');
+      expect(parseBloomLevel('Crear')).toBe('Create');
+      expect(parseBloomLevel(undefined)).toBeNull();
+      expect(parseBloomLevel('Invalid')).toBeNull();
+    });
+
+    it('should parse Difficulty Bands (D1-D2 through D9-D10) correctly', () => {
+      expect(parseDifficultyBand('D1-D2')).toBe('D1-D2');
+      expect(parseDifficultyBand('D3-D4')).toBe('D3-D4');
+      expect(parseDifficultyBand('d5-d6')).toBe('D5-D6');
+      expect(parseDifficultyBand('D7-D8')).toBe('D7-D8');
+      expect(parseDifficultyBand('D9-D10')).toBe('D9-D10');
+      expect(parseDifficultyBand('D5')).toBe('D5-D6');
+      expect(parseDifficultyBand(undefined)).toBeNull();
+    });
   });
 
   describe('3-Strike Protocol Logic', () => {
@@ -80,7 +158,6 @@ describe('Adaptive Testing Engine', () => {
         { questionId: 'any3', isCorrect: false, cefrLevel: 'B1' },
       ];
       const nextQ = getNextAdaptiveQuestion(protocolPool, results, new Set(['any1', 'any2', 'any3']));
-      // Should not be v4
       expect(nextQ?.protocol_version).toBeUndefined();
       expect(nextQ?.id).toMatch(/trad/);
     });

--- a/saberparatodos/src/lib/adaptive-engine.ts
+++ b/saberparatodos/src/lib/adaptive-engine.ts
@@ -2,14 +2,88 @@ import { calculateEnglishProficiencyV2, type QuestionResult, type CEFRLevel, CEF
 import type { AppQuestion } from './api-service';
 
 /**
+ * Bloom Taxonomy Levels ordered from lowest to highest
+ */
+export const BLOOM_LEVELS = ['Remember', 'Understand', 'Apply', 'Analyze', 'Evaluate', 'Create'] as const;
+export type BloomLevel = typeof BLOOM_LEVELS[number];
+
+export const BLOOM_LEVEL_NUM: Record<string, number> = {
+  'REMEMBER': 1, 'RECORDAR': 1,
+  'UNDERSTAND': 2, 'COMPRENDER': 2,
+  'APPLY': 3, 'APLICAR': 3,
+  'ANALYZE': 4, 'ANALIZAR': 4,
+  'EVALUATE': 5, 'EVALUAR': 5,
+  'CREATE': 6, 'CREAR': 6
+};
+
+export const NUM_TO_BLOOM: Record<number, BloomLevel> = {
+  1: 'Remember',
+  2: 'Understand',
+  3: 'Apply',
+  4: 'Analyze',
+  5: 'Evaluate',
+  6: 'Create'
+};
+
+/**
+ * Difficulty Bands from bundle formats (D1-D2, D3-D4, D5-D6, D7-D8, D9-D10)
+ */
+export const DIFFICULTY_BANDS = ['D1-D2', 'D3-D4', 'D5-D6', 'D7-D8', 'D9-D10'] as const;
+export type DifficultyBand = typeof DIFFICULTY_BANDS[number];
+
+export const DIFFICULTY_BAND_NUM: Record<string, number> = {
+  'D1-D2': 1, 'D1': 1, 'D2': 1,
+  'D3-D4': 2, 'D3': 2, 'D4': 2,
+  'D5-D6': 3, 'D5': 3, 'D6': 3,
+  'D7-D8': 4, 'D7': 4, 'D8': 4,
+  'D9-D10': 5, 'D9': 5, 'D10': 5
+};
+
+export const NUM_TO_DIFFICULTY_BAND: Record<number, DifficultyBand> = {
+  1: 'D1-D2',
+  2: 'D3-D4',
+  3: 'D5-D6',
+  4: 'D7-D8',
+  5: 'D9-D10'
+};
+
+/**
+ * Parse Bloom Level from metadata
+ */
+export function parseBloomLevel(bloomRaw?: any): BloomLevel | null {
+  if (!bloomRaw) return null;
+  const normalized = String(bloomRaw).trim().toUpperCase();
+  const num = BLOOM_LEVEL_NUM[normalized];
+  return num ? NUM_TO_BLOOM[num] || null : null;
+}
+
+/**
+ * Parse Difficulty Band from metadata
+ */
+export function parseDifficultyBand(bandRaw?: any): DifficultyBand | null {
+  if (!bandRaw) return null;
+  const normalized = String(bandRaw).trim().toUpperCase();
+  const num = DIFFICULTY_BAND_NUM[normalized];
+  if (num) return NUM_TO_DIFFICULTY_BAND[num];
+  if (normalized.includes('D1') || normalized.includes('D2')) return 'D1-D2';
+  if (normalized.includes('D3') || normalized.includes('D4')) return 'D3-D4';
+  if (normalized.includes('D5') || normalized.includes('D6')) return 'D5-D6';
+  if (normalized.includes('D7') || normalized.includes('D8')) return 'D7-D8';
+  if (normalized.includes('D9') || normalized.includes('D10')) return 'D9-D10';
+  return null;
+}
+
+/**
  * Configuration for the Adaptive Engine
  */
 export interface AdaptiveConfig {
-  calibrationQuestions: number; // Number of questions before adapting (e.g., 3)
-  targetAccuracyUpper: number;  // Threshold to increase difficulty (e.g., 75%)
-  targetAccuracyLower: number;  // Threshold to decrease difficulty (e.g., 40%)
-  baseDifficulty: number;       // Starting difficulty (1-10 scale usually mapped to CEFR)
-  baseCEFR: CEFRLevel;          // Starting CEFR level for calibration
+  calibrationQuestions: number;     // Number of questions before adapting (e.g., 3)
+  targetAccuracyUpper: number;      // Threshold to increase difficulty (e.g., 75%)
+  targetAccuracyLower: number;      // Threshold to decrease difficulty (e.g., 40%)
+  baseDifficulty: number;           // Starting difficulty (1-10 scale)
+  baseCEFR: CEFRLevel;              // Starting CEFR level for calibration (English)
+  baseBloom: BloomLevel;            // Starting Bloom level for STEM / Humanities
+  baseDifficultyBand: DifficultyBand; // Starting difficulty band
 }
 
 const DEFAULT_CONFIG: AdaptiveConfig = {
@@ -17,13 +91,31 @@ const DEFAULT_CONFIG: AdaptiveConfig = {
   targetAccuracyUpper: 75,
   targetAccuracyLower: 40,
   baseDifficulty: 5,
-  baseCEFR: 'B1'
+  baseCEFR: 'B1',
+  baseBloom: 'Apply',
+  baseDifficultyBand: 'D5-D6'
 };
 
 /**
+ * Interface extending question metadata for adaptive scoring
+ */
+export interface ExtendedQuestionMetadata {
+  bloom?: string;
+  bloom_level?: string;
+  difficulty_band?: string;
+  calibration?: {
+    difficulty_band?: string;
+    expected_success?: number;
+  };
+  cefr_level?: string;
+  difficulty?: number | string;
+}
+
+/**
  * Gets the next adaptive question from the pool based on the user's current performance.
+ * Works across all subjects (matemáticas, lengua, ciencias, sociales, inglés).
  *
- * @param pool The full pool of available questions (the adaptive pool)
+ * @param pool The full pool of available questions
  * @param answeredResults Array of QuestionResult for questions already answered
  * @param usedQuestionIds Set of question IDs to avoid repeating
  * @param config Optional configuration tweaks
@@ -45,8 +137,6 @@ export function getNextAdaptiveQuestion(
   }
 
   // --- 🆕 3-Strike Protocol Logic ---
-  // If the user fails the first 3 questions (calibration-like phase),
-  // we shift them away from the "New Protocol" (v4+) to traditional content.
   const isProtocolV4 = (q: AppQuestion) => {
     const protocolVal = parseFloat(q.protocol_version || '3.1');
     return !isNaN(protocolVal) && protocolVal >= 4.0;
@@ -72,63 +162,151 @@ export function getNextAdaptiveQuestion(
 
   // Phase 1: Calibration (Not enough data to adapt accurately yet)
   if (answeredResults.length < finalConfig.calibrationQuestions) {
-    return getClosestQuestion(availablePool, finalConfig.baseCEFR, finalConfig.baseDifficulty);
+    return getClosestQuestion(availablePool, {
+      targetCEFR: finalConfig.baseCEFR,
+      targetBloom: finalConfig.baseBloom,
+      targetDifficultyBand: finalConfig.baseDifficultyBand,
+      targetDifficulty: finalConfig.baseDifficulty
+    });
   }
 
-  // Phase 2: Adaptive Selection
-  // 1. Evaluate current proficiency
-  const proficiency = calculateEnglishProficiencyV2(answeredResults);
+  // Phase 2: Subject-Agnostic Adaptive Selection
+  // Detect if current questions or pool heavily utilize CEFR metadata
+  const isCEFRMode = isPoolOrResultsCEFR(availablePool, answeredResults);
 
-  let targetCEFRNum = proficiency.estimatedLevelNum;
+  if (isCEFRMode) {
+    // English / CEFR Path
+    const proficiency = calculateEnglishProficiencyV2(answeredResults);
+    let targetCEFRNum = proficiency.estimatedLevelNum;
 
-  // 2. Adjust target based on current accuracy
-  // If they are getting too many right, push them harder
-  if (proficiency.overallAccuracy >= finalConfig.targetAccuracyUpper) {
-    targetCEFRNum = Math.min(9, targetCEFRNum + 1); // Max C1
+    if (proficiency.overallAccuracy >= finalConfig.targetAccuracyUpper) {
+      targetCEFRNum = Math.min(9, targetCEFRNum + 1); // Max C1
+    } else if (proficiency.overallAccuracy <= finalConfig.targetAccuracyLower && proficiency.overallAccuracy > 0) {
+      targetCEFRNum = Math.max(1, targetCEFRNum - 1); // Min A1
+    }
+
+    const targetCEFR = NUM_TO_CEFR[targetCEFRNum] || 'A2';
+    const targetDifficulty = mapCEFRToAverageDifficulty(targetCEFR);
+
+    return getClosestQuestion(availablePool, {
+      targetCEFR,
+      targetDifficulty
+    });
   }
-  // If they are failing too much, ease off
-  else if (proficiency.overallAccuracy <= finalConfig.targetAccuracyLower && proficiency.overallAccuracy > 0) {
-    targetCEFRNum = Math.max(1, targetCEFRNum - 1); // Min A1
+
+  // STEM / Humanities / General Subject Path (Bloom taxonomy & Difficulty Bands)
+  const totalAnswered = answeredResults.length;
+  const correctCount = answeredResults.filter(r => r.isCorrect).length;
+  const overallAccuracy = totalAnswered > 0 ? (correctCount / totalAnswered) * 100 : 50;
+
+  // Calculate current baseline difficulty from answered questions
+  let currentAvgDiff = finalConfig.baseDifficulty;
+  const diffs = answeredResults.map(r => r.difficulty).filter((d): d is number => typeof d === 'number' && d > 0);
+  if (diffs.length > 0) {
+    currentAvgDiff = diffs.reduce((a, b) => a + b, 0) / diffs.length;
   }
 
-  const targetCEFR = NUM_TO_CEFR[targetCEFRNum] || 'A2';
+  // Adapt target difficulty based on performance thresholds
+  let targetDifficulty = currentAvgDiff;
+  if (overallAccuracy >= finalConfig.targetAccuracyUpper) {
+    targetDifficulty = Math.min(10, currentAvgDiff + 2);
+  } else if (overallAccuracy <= finalConfig.targetAccuracyLower && overallAccuracy > 0) {
+    targetDifficulty = Math.max(1, currentAvgDiff - 2);
+  }
 
-  // 3. Compute best difficulty for the NEW target CEFR
-  let targetDifficulty = mapCEFRToAverageDifficulty(targetCEFR);
+  // Infer target Bloom level (1-6) and Difficulty Band (D1-D2 to D9-D10)
+  const targetBloomNum = Math.min(6, Math.max(1, Math.round((targetDifficulty / 10) * 6)));
+  const targetBloom = NUM_TO_BLOOM[targetBloomNum] || 'Apply';
 
-  // 4. Find the best matching question in the pool
-  return getClosestQuestion(availablePool, targetCEFR, targetDifficulty);
+  const targetBandNum = Math.min(5, Math.max(1, Math.ceil(targetDifficulty / 2)));
+  const targetDifficultyBand = NUM_TO_DIFFICULTY_BAND[targetBandNum] || 'D5-D6';
+
+  return getClosestQuestion(availablePool, {
+    targetBloom,
+    targetDifficultyBand,
+    targetDifficulty
+  });
 }
 
 /**
- * Helper: Finds the question in the pool that best matches the target CEFR and difficulty.
+ * Helper: Detects whether questions/results use CEFR metadata
  */
-function getClosestQuestion(pool: AppQuestion[], targetCEFR: CEFRLevel, targetDifficulty: number): AppQuestion | null {
+function isPoolOrResultsCEFR(pool: AppQuestion[], answeredResults: QuestionResult[]): boolean {
+  const hasCEFRResult = answeredResults.some(r => Boolean(r.cefrLevel && r.cefrLevel !== 'A2'));
+  if (hasCEFRResult) return true;
+
+  const cefrInPool = pool.filter(q => {
+    const raw = q.cefr_level || (q.meta && (q.meta.cefr_level || (q.meta as any).cefrLevel));
+    return Boolean(raw);
+  });
+
+  return cefrInPool.length > pool.length * 0.3; // Over 30% of pool has explicit CEFR
+}
+
+/**
+ * Targets interface for adaptive selection
+ */
+export interface AdaptiveTargets {
+  targetCEFR?: CEFRLevel;
+  targetBloom?: BloomLevel;
+  targetDifficultyBand?: DifficultyBand;
+  targetDifficulty: number;
+}
+
+/**
+ * Helper: Finds the question in the pool that best matches the target CEFR, Bloom level, difficulty band, and difficulty.
+ */
+function getClosestQuestion(
+  pool: AppQuestion[],
+  targets: AdaptiveTargets
+): AppQuestion | null {
   if (!pool || pool.length === 0) return null;
 
-  const targetCEFRNum = CEFR_LEVEL_NUM[targetCEFR] || 1;
+  const targetCEFRNum = targets.targetCEFR ? (CEFR_LEVEL_NUM[targets.targetCEFR] || 1) : null;
+  const targetBloomNum = targets.targetBloom ? (BLOOM_LEVEL_NUM[targets.targetBloom.toUpperCase()] || 3) : null;
+  const targetBandNum = targets.targetDifficultyBand ? (DIFFICULTY_BAND_NUM[targets.targetDifficultyBand] || 3) : null;
 
-  // Map to calculate a "distance" score for each question
-    const scoredQuestions = pool.map(q => {
-      // Attempt to extract CEFR from various possible fields
-      const cefrRaw = q.cefr_level || (q.meta && (q.meta.cefr_level || q.meta.cefrLevel));
-      const qCEFR = parseCEFRLevel((cefrRaw as string) || undefined, q.grade);
-      const qCEFRNum = CEFR_LEVEL_NUM[qCEFR] || 1;
+  const scoredQuestions = pool.map(q => {
+    // 1. CEFR Level
+    const cefrRaw = q.cefr_level || (q.meta && ((q.meta as any).cefr_level || (q.meta as any).cefrLevel));
+    const qCEFR = parseCEFRLevel((cefrRaw as string) || undefined, q.grade);
+    const qCEFRNum = CEFR_LEVEL_NUM[qCEFR] || 1;
+    const cefrDistance = targetCEFRNum !== null ? Math.abs(qCEFRNum - targetCEFRNum) * 10 : 0;
 
-      // Extract difficulty
-      let qDiff = 3;
-      if (typeof q.difficulty === 'number') {
-        qDiff = q.difficulty;
-      } else if (q.meta && typeof q.meta.difficulty === 'number') {
-        qDiff = q.meta.difficulty;
+    // 2. Bloom Taxonomy Level
+    const bloomRaw = (q as any).bloom || (q as any).bloom_level || (q.meta && ((q.meta as any).bloom || (q.meta as any).bloom_level));
+    const qBloom = parseBloomLevel(bloomRaw);
+    const qBloomNum = qBloom ? (BLOOM_LEVEL_NUM[qBloom.toUpperCase()] || 3) : null;
+    const bloomDistance = (targetBloomNum !== null && qBloomNum !== null)
+      ? Math.abs(qBloomNum - targetBloomNum) * 5
+      : 0;
+
+    // 3. Difficulty Band (D3-D4, D5-D6, etc.)
+    const bandRaw = (q as any).difficulty_band ||
+      (q as any).calibration?.difficulty_band ||
+      (q.meta && ((q.meta as any).difficulty_band || (q.meta as any).calibration?.difficulty_band));
+    const qBand = parseDifficultyBand(bandRaw);
+    const qBandNum = qBand ? (DIFFICULTY_BAND_NUM[qBand] || 3) : null;
+    const bandDistance = (targetBandNum !== null && qBandNum !== null)
+      ? Math.abs(qBandNum - targetBandNum) * 5
+      : 0;
+
+    // 4. Numeric Difficulty (1-10 scale)
+    let qDiff = 5;
+    if (typeof q.difficulty === 'number') {
+      qDiff = q.difficulty;
+    } else if (typeof (q as any).difficulty === 'string') {
+      const parsedBand = parseDifficultyBand((q as any).difficulty);
+      if (parsedBand) {
+        qDiff = (DIFFICULTY_BAND_NUM[parsedBand] || 3) * 2;
       }
-
-      // Weight difference in CEFR more heavily than difference in relative difficulty
-      const cefrDistance = Math.abs(qCEFRNum - targetCEFRNum) * 10;
-      const diffDistance = Math.abs(qDiff - targetDifficulty);
+    } else if (q.meta && typeof q.meta.difficulty === 'number') {
+      qDiff = q.meta.difficulty;
+    }
+    const diffDistance = Math.abs(qDiff - targets.targetDifficulty);
 
     // Total distance score (lower is better)
-    const distanceScore = cefrDistance + diffDistance;
+    const distanceScore = cefrDistance + bloomDistance + bandDistance + diffDistance;
 
     return { question: q, distanceScore };
   });
@@ -136,11 +314,11 @@ function getClosestQuestion(pool: AppQuestion[], targetCEFR: CEFRLevel, targetDi
   // Sort by closest match (lowest score)
   scoredQuestions.sort((a, b) => a.distanceScore - b.distanceScore);
 
-  // Group the best matches (e.g., all with the exact same minimum distance score)
+  // Group the best matches
   const bestScore = scoredQuestions[0].distanceScore;
   const bestMatches = scoredQuestions.filter(sq => sq.distanceScore === bestScore);
 
-  // Return a random question from the exact best matches to add variety
+  // Return a random question from the exact best matches for variety
   const randomIndex = Math.floor(Math.random() * bestMatches.length);
   return bestMatches[randomIndex].question;
 }


### PR DESCRIPTION
Expands the adaptive testing engine to be subject-agnostic. Supports Bloom taxonomy levels (Remember through Create) and difficulty bands (D1-D2 through D9-D10) for STEM and humanities subjects, while maintaining CEFR support for English.

Fixes #1031

---
*PR created automatically by Jules for task [7275093929002919140](https://jules.google.com/task/7275093929002919140) started by @iberi22*