### PR TITLE
📸 Rework Camera Face Detection Anti-Cheat

### DIFF
--- a/saberparatodos/package.json
+++ b/saberparatodos/package.json
@@ -69,6 +69,7 @@
     "@astrojs/sitemap": "^3.6.0",
     "@astrojs/svelte": "^9.0.0",
     "@cloudflare/workers-types": "^4.20240529.0",
+    "@mediapipe/face_detection": "^0.4.1646425229",
     "@mlc-ai/web-llm": "^0.2.84",
     "@remotion/cli": "^4.0.481",
     "@remotion/core": "^1.0.0-y.46",

--- a/saberparatodos/src/lib/anti-cheat/face-detection.ts
+++ b/saberparatodos/src/lib/anti-cheat/face-detection.ts
@@ -1,0 +1,472 @@
+/**
+ * Camera Face Detection Anti-Cheat Service
+ * Uses MediaPipe WASM Face Detection (@mediapipe/face_detection) to analyze camera frames locally.
+ *
+ * Privacy & Resource Guarantees:
+ * - Video processing occurs strictly locally in browser memory using MediaPipe WebAssembly.
+ * - Raw video streams and canvas frame data are NEVER recorded, saved, or transmitted outside the device.
+ * - Face detection runs periodically (default every 5000ms = 5s) instead of continuously to save battery and CPU.
+ * - Reference face landmarks are stored locally in IndexedDB / local memory for matching during exam sessions.
+ * - Users can disable camera monitoring at any time.
+ */
+
+import { FaceDetection, type Detection, type Results } from '@mediapipe/face_detection';
+
+export interface FaceLandmark {
+  x: number;
+  y: number;
+  z?: number;
+}
+
+export interface FaceEvent {
+  timestamp: number;
+  type:
+    | 'face_detected'
+    | 'no_face'
+    | 'multiple_faces'
+    | 'face_mismatch'
+    | 'permission_denied'
+    | 'error'
+    | 'disabled';
+  faceCount: number;
+  confidence: number;
+  details?: string;
+}
+
+export interface FaceAnalysisResult {
+  timestamp: number;
+  faceCount: number;
+  confidence: number;
+  landmarksCount?: number;
+  isMatch?: boolean;
+}
+
+export interface FaceDetectorConfig {
+  sessionId?: string;
+  sampleIntervalMs?: number; // Interval between video frame analyses (default: 5000ms = 5s)
+  minConfidence?: number; // Minimum confidence threshold for face detection (default: 0.5)
+  mismatchThreshold?: number; // Maximum feature distance variance before flagging mismatch (default: 0.25)
+  enabled?: boolean; // User control setting (default: true)
+  referenceLandmarks?: FaceLandmark[]; // Baseline face landmarks for matching
+  onEvent?: (event: FaceEvent) => void;
+  onFaceDetected?: (event: FaceEvent) => void;
+  onNoFace?: (event: FaceEvent) => void;
+  onMultipleFaces?: (event: FaceEvent) => void;
+  onFaceMismatch?: (event: FaceEvent) => void;
+}
+
+export interface FaceDetector {
+  start: () => Promise<boolean>;
+  stop: () => void;
+  enable: () => void;
+  disable: () => void;
+  isEnabled: () => boolean;
+  isMonitoring: () => boolean;
+  getEvents: () => FaceEvent[];
+  getViolationCount: () => number;
+  getLatestAnalysis: () => FaceAnalysisResult | null;
+  setReferenceFace: (landmarks: FaceLandmark[]) => void;
+  getReferenceFace: () => FaceLandmark[] | null;
+  destroy: () => void;
+}
+
+const DEFAULT_SAMPLE_INTERVAL_MS = 5000;
+const DEFAULT_MIN_CONFIDENCE = 0.5;
+const DEFAULT_MISMATCH_THRESHOLD = 0.25;
+const IDB_STORE_KEY = 'worldexams_face_reference';
+
+/**
+ * Saves reference face landmarks to local IndexedDB/localStorage for offline matching.
+ */
+function saveReferenceToLocal(sessionId: string, landmarks: FaceLandmark[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(`${IDB_STORE_KEY}_${sessionId}`, JSON.stringify(landmarks));
+  } catch {
+    // Ignore storage write errors
+  }
+}
+
+/**
+ * Retrieves reference face landmarks from local IndexedDB/localStorage.
+ */
+function getReferenceFromLocal(sessionId: string): FaceLandmark[] | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(`${IDB_STORE_KEY}_${sessionId}`);
+    return raw ? (JSON.parse(raw) as FaceLandmark[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Calculates normalized distance vector variance between candidate face landmarks and reference baseline.
+ */
+function compareFaceLandmarks(
+  candidate: FaceLandmark[],
+  reference: FaceLandmark[],
+  mismatchThreshold: number
+): { isMatch: boolean; distanceVariance: number } {
+  if (!candidate || !reference || candidate.length === 0 || reference.length === 0) {
+    return { isMatch: true, distanceVariance: 0 };
+  }
+
+  const count = Math.min(candidate.length, reference.length);
+  let totalDelta = 0;
+
+  for (let i = 0; i < count; i++) {
+    const dx = candidate[i].x - reference[i].x;
+    const dy = candidate[i].y - reference[i].y;
+    totalDelta += Math.sqrt(dx * dx + dy * dy);
+  }
+
+  const avgDelta = totalDelta / count;
+  const isMatch = avgDelta <= mismatchThreshold;
+  return { isMatch, distanceVariance: avgDelta };
+}
+
+/**
+ * Creates a FaceDetector instance for camera face detection anti-cheat.
+ */
+export function createFaceDetector(config: FaceDetectorConfig = {}): FaceDetector {
+  const sessionId = config.sessionId || 'default-session';
+  const sampleIntervalMs = config.sampleIntervalMs ?? DEFAULT_SAMPLE_INTERVAL_MS;
+  const minConfidence = config.minConfidence ?? DEFAULT_MIN_CONFIDENCE;
+  const mismatchThreshold = config.mismatchThreshold ?? DEFAULT_MISMATCH_THRESHOLD;
+
+  let enabled = config.enabled ?? true;
+  let isMonitoring = false;
+  let analysisIntervalId: ReturnType<typeof setInterval> | null = null;
+
+  let mediaStream: MediaStream | null = null;
+  let videoElement: HTMLVideoElement | null = null;
+  let faceDetectionInstance: FaceDetection | null = null;
+
+  let referenceLandmarks: FaceLandmark[] | null =
+    config.referenceLandmarks || getReferenceFromLocal(sessionId);
+
+  const events: FaceEvent[] = [];
+  let latestAnalysis: FaceAnalysisResult | null = null;
+
+  const addEvent = (event: FaceEvent) => {
+    events.push(event);
+    if (config.onEvent) {
+      config.onEvent(event);
+    }
+    if (event.type === 'face_detected' && config.onFaceDetected) {
+      config.onFaceDetected(event);
+    }
+    if (event.type === 'no_face' && config.onNoFace) {
+      config.onNoFace(event);
+    }
+    if (event.type === 'multiple_faces' && config.onMultipleFaces) {
+      config.onMultipleFaces(event);
+    }
+    if (event.type === 'face_mismatch' && config.onFaceMismatch) {
+      config.onFaceMismatch(event);
+    }
+  };
+
+  /**
+   * Processes MediaPipe face detection results.
+   */
+  const handleResults = (results: Results) => {
+    if (!isMonitoring || !enabled) return;
+
+    const timestamp = Date.now();
+    const detections: Detection[] = results.detections || [];
+    const faceCount = detections.length;
+
+    let maxConfidence = 0;
+    for (const d of detections) {
+      const score = Array.isArray((d as any).score) ? (d as any).score[0] : (d as any).score || 0;
+      if (score > maxConfidence) {
+        maxConfidence = score;
+      }
+    }
+
+    if (faceCount === 0) {
+      latestAnalysis = {
+        timestamp,
+        faceCount: 0,
+        confidence: 0,
+        landmarksCount: 0,
+        isMatch: false,
+      };
+      addEvent({
+        timestamp,
+        type: 'no_face',
+        faceCount: 0,
+        confidence: 0,
+        details: 'No human face detected in camera frame',
+      });
+      return;
+    }
+
+    if (faceCount > 1) {
+      latestAnalysis = {
+        timestamp,
+        faceCount,
+        confidence: maxConfidence,
+        landmarksCount: 0,
+        isMatch: false,
+      };
+      addEvent({
+        timestamp,
+        type: 'multiple_faces',
+        faceCount,
+        confidence: maxConfidence,
+        details: `Multiple faces detected in frame (${faceCount} faces)`,
+      });
+      return;
+    }
+
+    // Exactly 1 face detected
+    const primaryDetection = detections[0];
+    const candidateLandmarks: FaceLandmark[] = (primaryDetection.landmarks || []).map((lm: any) => ({
+      x: lm.x,
+      y: lm.y,
+      z: lm.z,
+    }));
+
+    // Check face mismatch against baseline reference if established
+    if (referenceLandmarks && referenceLandmarks.length > 0) {
+      const matchResult = compareFaceLandmarks(
+        candidateLandmarks,
+        referenceLandmarks,
+        mismatchThreshold
+      );
+
+      latestAnalysis = {
+        timestamp,
+        faceCount: 1,
+        confidence: maxConfidence,
+        landmarksCount: candidateLandmarks.length,
+        isMatch: matchResult.isMatch,
+      };
+
+      if (!matchResult.isMatch) {
+        addEvent({
+          timestamp,
+          type: 'face_mismatch',
+          faceCount: 1,
+          confidence: maxConfidence,
+          details: `Face landmark mismatch detected (variance: ${matchResult.distanceVariance.toFixed(3)})`,
+        });
+        return;
+      }
+    } else {
+      // Set first detected face as baseline reference if none existed
+      referenceLandmarks = candidateLandmarks;
+      saveReferenceToLocal(sessionId, candidateLandmarks);
+      latestAnalysis = {
+        timestamp,
+        faceCount: 1,
+        confidence: maxConfidence,
+        landmarksCount: candidateLandmarks.length,
+        isMatch: true,
+      };
+    }
+
+    addEvent({
+      timestamp,
+      type: 'face_detected',
+      faceCount: 1,
+      confidence: maxConfidence,
+      details: 'Primary user face verified',
+    });
+  };
+
+  /**
+   * Captures current frame from video element and passes it to MediaPipe WASM face detection.
+   * Runs every `sampleIntervalMs` (default 5000ms = 5s) to preserve battery & CPU.
+   */
+  const analyzeFrame = async () => {
+    if (!faceDetectionInstance || !videoElement || !isMonitoring || !enabled) return;
+    if (videoElement.readyState < 2) return; // HAVE_CURRENT_DATA or higher
+
+    try {
+      await faceDetectionInstance.send({ image: videoElement });
+    } catch (err: any) {
+      console.warn(`[FaceDetector:${sessionId}] Frame analysis error:`, err?.message);
+    }
+  };
+
+  /**
+   * Cleanup camera stream and DOM elements.
+   */
+  const cleanupResources = () => {
+    if (analysisIntervalId) {
+      clearInterval(analysisIntervalId);
+      analysisIntervalId = null;
+    }
+
+    if (mediaStream) {
+      mediaStream.getTracks().forEach((track) => {
+        try {
+          track.stop();
+        } catch {
+          // Ignore track stop errors
+        }
+      });
+      mediaStream = null;
+    }
+
+    if (videoElement) {
+      try {
+        videoElement.srcObject = null;
+        if (videoElement.parentNode) {
+          videoElement.parentNode.removeChild(videoElement);
+        }
+      } catch {
+        // Ignore video remove errors
+      }
+      videoElement = null;
+    }
+
+    if (faceDetectionInstance) {
+      try {
+        faceDetectionInstance.close();
+      } catch {
+        // Ignore close errors
+      }
+      faceDetectionInstance = null;
+    }
+
+    isMonitoring = false;
+  };
+
+  return {
+    start: async () => {
+      if (isMonitoring) return true;
+      if (!enabled) {
+        addEvent({
+          timestamp: Date.now(),
+          type: 'disabled',
+          faceCount: 0,
+          confidence: 0,
+          details: 'Camera monitoring is disabled by user',
+        });
+        return false;
+      }
+
+      if (typeof window === 'undefined' || !navigator?.mediaDevices?.getUserMedia) {
+        addEvent({
+          timestamp: Date.now(),
+          type: 'error',
+          faceCount: 0,
+          confidence: 0,
+          details: 'MediaDevices / getUserMedia not supported in environment',
+        });
+        return false;
+      }
+
+      try {
+        mediaStream = await navigator.mediaDevices.getUserMedia({
+          video: {
+            width: { ideal: 640 },
+            height: { ideal: 480 },
+            facingMode: 'user',
+          },
+        });
+
+        // Create off-screen video element for MediaPipe frame capturing
+        videoElement = document.createElement('video');
+        videoElement.autoplay = true;
+        videoElement.muted = true;
+        videoElement.playsInline = true;
+        videoElement.style.display = 'none';
+        videoElement.srcObject = mediaStream;
+        document.body.appendChild(videoElement);
+
+        await videoElement.play().catch(() => {});
+
+        // Initialize MediaPipe Face Detection
+        faceDetectionInstance = new FaceDetection({
+          locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/face_detection/${file}`,
+        });
+
+        faceDetectionInstance.setOptions({
+          model: 'short',
+          minDetectionConfidence: minConfidence,
+        });
+
+        faceDetectionInstance.onResults(handleResults);
+        await faceDetectionInstance.initialize();
+
+        isMonitoring = true;
+
+        // Periodic frame analysis every 5 seconds (5000ms)
+        analysisIntervalId = setInterval(analyzeFrame, sampleIntervalMs);
+
+        console.log(`[FaceDetector:${sessionId}] Camera face detection initialized`);
+        return true;
+      } catch (err: any) {
+        cleanupResources();
+        const isPermissionError =
+          err?.name === 'NotAllowedError' || err?.name === 'PermissionDeniedError';
+        const eventType = isPermissionError ? 'permission_denied' : 'error';
+
+        addEvent({
+          timestamp: Date.now(),
+          type: eventType,
+          faceCount: 0,
+          confidence: 0,
+          details: err?.message || 'Failed to acquire camera access',
+        });
+
+        return false;
+      }
+    },
+
+    stop: () => {
+      cleanupResources();
+      console.log(`[FaceDetector:${sessionId}] Face monitoring stopped`);
+    },
+
+    enable: () => {
+      enabled = true;
+    },
+
+    disable: () => {
+      enabled = false;
+      cleanupResources();
+      addEvent({
+        timestamp: Date.now(),
+        type: 'disabled',
+        faceCount: 0,
+        confidence: 0,
+        details: 'Camera monitoring disabled by user',
+      });
+    },
+
+    isEnabled: () => enabled,
+
+    isMonitoring: () => isMonitoring,
+
+    getEvents: () => [...events],
+
+    getViolationCount: () => {
+      return events.filter(
+        (e) => e.type === 'no_face' || e.type === 'multiple_faces' || e.type === 'face_mismatch'
+      ).length;
+    },
+
+    getLatestAnalysis: () => (latestAnalysis ? { ...latestAnalysis } : null),
+
+    setReferenceFace: (landmarks: FaceLandmark[]) => {
+      referenceLandmarks = landmarks;
+      saveReferenceToLocal(sessionId, landmarks);
+    },
+
+    getReferenceFace: () => (referenceLandmarks ? [...referenceLandmarks] : null),
+
+    destroy: () => {
+      cleanupResources();
+      events.length = 0;
+      latestAnalysis = null;
+      console.log(`[FaceDetector:${sessionId}] Destroyed`);
+    },
+  };
+}

--- a/saberparatodos/src/modules/exam-room/types.ts
+++ b/saberparatodos/src/modules/exam-room/types.ts
@@ -82,7 +82,10 @@ export interface SuspiciousEvent {
     | 'long_inactivity'
     | 'fullscreen_exit'
     | 'orientation_change'
-    | 'resize_suspicious';
+    | 'resize_suspicious'
+    | 'no_face'
+    | 'multiple_faces'
+    | 'face_mismatch';
   timestamp: Date;
   duration?: number; // ms
 }

--- a/saberparatodos/tests/unit/faceDetection.unit.test.ts
+++ b/saberparatodos/tests/unit/faceDetection.unit.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createFaceDetector } from '../../src/lib/anti-cheat/face-detection';
+
+const { MockFaceDetection, getMockOnResultsCallback, resetMockOnResultsCallback } = vi.hoisted(() => {
+  let cb: ((results: any) => void) | null = null;
+  class MockFaceDetection {
+    initialize = vi.fn().mockResolvedValue(undefined);
+    setOptions = vi.fn();
+    onResults = vi.fn((listener: (results: any) => void) => {
+      cb = listener;
+    });
+    send = vi.fn().mockImplementation(async () => {
+      if (cb) {
+        cb({ detections: [] });
+      }
+    });
+    close = vi.fn().mockResolvedValue(undefined);
+  }
+  return {
+    MockFaceDetection,
+    getMockOnResultsCallback: () => cb,
+    resetMockOnResultsCallback: () => {
+      cb = null;
+    },
+  };
+});
+
+vi.mock('@mediapipe/face_detection', () => {
+  return {
+    FaceDetection: MockFaceDetection,
+  };
+});
+
+describe('FaceDetector Anti-Cheat Service', () => {
+  let mockTrack: { stop: ReturnType<typeof vi.fn> };
+  let mockMediaStream: { getTracks: () => any[] };
+  let mockVideoElement: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetMockOnResultsCallback();
+
+    mockTrack = { stop: vi.fn() };
+    mockMediaStream = { getTracks: () => [mockTrack] };
+
+    mockVideoElement = {
+      autoplay: false,
+      muted: false,
+      playsInline: false,
+      style: {},
+      srcObject: null,
+      readyState: 4, // HAVE_ENOUGH_DATA
+      play: vi.fn().mockResolvedValue(undefined),
+      parentNode: {
+        removeChild: vi.fn(),
+      },
+    };
+
+    (globalThis as any).window = globalThis;
+
+    Object.defineProperty(document, 'body', {
+      writable: true,
+      value: {
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+    });
+
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'video') {
+        return mockVideoElement as any;
+      }
+      return origCreateElement(tagName);
+    });
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      writable: true,
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue(mockMediaStream),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should initialize with default options', () => {
+    const detector = createFaceDetector({ sessionId: 'test-init' });
+    expect(detector.isEnabled()).toBe(true);
+    expect(detector.isMonitoring()).toBe(false);
+    expect(detector.getEvents()).toEqual([]);
+    expect(detector.getViolationCount()).toBe(0);
+    expect(detector.getLatestAnalysis()).toBeNull();
+  });
+
+  it('should request camera permissions and start monitoring', async () => {
+    const detector = createFaceDetector({ sessionId: 'test-start', sampleIntervalMs: 5000 });
+    const started = await detector.start();
+
+    expect(started).toBe(true);
+    expect(detector.isMonitoring()).toBe(true);
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+      video: {
+        width: { ideal: 640 },
+        height: { ideal: 480 },
+        facingMode: 'user',
+      },
+    });
+
+    detector.stop();
+    expect(detector.isMonitoring()).toBe(false);
+    expect(mockTrack.stop).toHaveBeenCalled();
+  });
+
+  it('should handle camera permission denial gracefully', async () => {
+    const permissionError = new Error('Camera access denied');
+    permissionError.name = 'NotAllowedError';
+    (navigator.mediaDevices.getUserMedia as any).mockRejectedValueOnce(permissionError);
+
+    const detector = createFaceDetector({ sessionId: 'test-denied' });
+    const started = await detector.start();
+
+    expect(started).toBe(false);
+    expect(detector.isMonitoring()).toBe(false);
+
+    const events = detector.getEvents();
+    expect(events.length).toBe(1);
+    expect(events[0].type).toBe('permission_denied');
+    expect(events[0].faceCount).toBe(0);
+  });
+
+  it('should detect no_face when no human face is found in frame', async () => {
+    const onNoFace = vi.fn();
+    const detector = createFaceDetector({
+      sessionId: 'test-no-face',
+      sampleIntervalMs: 5000,
+      onNoFace,
+    });
+
+    await detector.start();
+
+    // Fast-forward 5s to trigger frame analysis
+    vi.advanceTimersByTime(5000);
+
+    expect(onNoFace).toHaveBeenCalled();
+    const events = detector.getEvents();
+    expect(events.length).toBe(1);
+    expect(events[0].type).toBe('no_face');
+    expect(events[0].faceCount).toBe(0);
+    expect(detector.getViolationCount()).toBe(1);
+
+    detector.stop();
+  });
+
+  it('should detect multiple_faces when more than 1 face is present', async () => {
+    const onMultipleFaces = vi.fn();
+    const detector = createFaceDetector({
+      sessionId: 'test-multi-faces',
+      sampleIntervalMs: 5000,
+      onMultipleFaces,
+    });
+
+    await detector.start();
+
+    // Simulate multiple face detections callback from MediaPipe
+    const callback = getMockOnResultsCallback();
+    if (callback) {
+      callback({
+        detections: [
+          { score: [0.95], landmarks: [{ x: 0.2, y: 0.3 }] },
+          { score: [0.88], landmarks: [{ x: 0.7, y: 0.4 }] },
+        ],
+      });
+    }
+
+    expect(onMultipleFaces).toHaveBeenCalled();
+    const events = detector.getEvents();
+    expect(events.length).toBe(1);
+    expect(events[0].type).toBe('multiple_faces');
+    expect(events[0].faceCount).toBe(2);
+    expect(detector.getViolationCount()).toBe(1);
+
+    detector.stop();
+  });
+
+  it('should detect face_mismatch when candidate landmarks differ from reference face', async () => {
+    const onFaceMismatch = vi.fn();
+    const referenceLandmarks = [
+      { x: 0.1, y: 0.1 },
+      { x: 0.2, y: 0.2 },
+    ];
+
+    const detector = createFaceDetector({
+      sessionId: 'test-mismatch',
+      sampleIntervalMs: 5000,
+      referenceLandmarks,
+      mismatchThreshold: 0.2,
+      onFaceMismatch,
+    });
+
+    await detector.start();
+
+    // Simulate candidate landmarks with large position variance relative to reference
+    const callback = getMockOnResultsCallback();
+    if (callback) {
+      callback({
+        detections: [
+          {
+            score: [0.92],
+            landmarks: [
+              { x: 0.8, y: 0.8 },
+              { x: 0.9, y: 0.9 },
+            ],
+          },
+        ],
+      });
+    }
+
+    expect(onFaceMismatch).toHaveBeenCalled();
+    const events = detector.getEvents();
+    expect(events.length).toBe(1);
+    expect(events[0].type).toBe('face_mismatch');
+    expect(events[0].faceCount).toBe(1);
+    expect(detector.getViolationCount()).toBe(1);
+
+    detector.stop();
+  });
+
+  it('should allow setting and getting reference face landmarks', () => {
+    const detector = createFaceDetector({ sessionId: 'test-ref' });
+    expect(detector.getReferenceFace()).toBeNull();
+
+    const landmarks = [
+      { x: 0.3, y: 0.4, z: 0.1 },
+      { x: 0.5, y: 0.6, z: 0.2 },
+    ];
+    detector.setReferenceFace(landmarks);
+
+    expect(detector.getReferenceFace()).toEqual(landmarks);
+  });
+
+  it('should allow user to disable and enable monitoring', async () => {
+    const detector = createFaceDetector({ sessionId: 'test-toggle' });
+    await detector.start();
+    expect(detector.isMonitoring()).toBe(true);
+
+    detector.disable();
+    expect(detector.isEnabled()).toBe(false);
+    expect(detector.isMonitoring()).toBe(false);
+
+    const events = detector.getEvents();
+    expect(events.some((e) => e.type === 'disabled')).toBe(true);
+
+    const restarted = await detector.start();
+    expect(restarted).toBe(false);
+
+    detector.enable();
+    expect(detector.isEnabled()).toBe(true);
+  });
+
+  it('should clean up completely on destroy', async () => {
+    const detector = createFaceDetector({ sessionId: 'test-destroy' });
+    await detector.start();
+
+    detector.destroy();
+    expect(detector.isMonitoring()).toBe(false);
+    expect(detector.getEvents()).toEqual([]);
+    expect(detector.getLatestAnalysis()).toBeNull();
+  });
+});


### PR DESCRIPTION
Rework camera face detection anti-cheat service using MediaPipe WASM (@mediapipe/face_detection). Performs local 5-second periodic frame analysis to detect no_face, multiple_faces, and face_mismatch while ensuring video data never leaves the local device.

Fixes #1026

---
*PR created automatically by Jules for task [14938892215039681500](https://jules.google.com/task/14938892215039681500) started by @iberi22*