### PR TITLE
🧹 Refactor Institution Nodes & Remove Legacy Stripe/Pro Tiers

### DIFF
--- a/saberparatodos/src/components/dashboard/DashboardMain.svelte
+++ b/saberparatodos/src/components/dashboard/DashboardMain.svelte
@@ -37,7 +37,7 @@
   async function handleCreateOrg() {
     try {
       creating = true;
-      await institutionalService.createOrganization(newOrgName, newOrgSlug, '');
+      await institutionalService.createOrganization(newOrgName, newOrgSlug);
       showCreateModal = false;
       // Refresh
       organizations = await institutionalService.getUserOrganizations();
@@ -98,9 +98,6 @@
                 </div>
               </div>
               <div class="flex items-center gap-3 shrink-0">
-                 <span class="px-2 py-1 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 text-xs rounded-full font-medium capitalize">
-                    {org.plan_tier}
-                 </span>
                  <span class="text-zinc-400 text-sm" aria-hidden="true">{selectedOrgId === org.id ? '▲' : '▼'}</span>
               </div>
             </button>

--- a/saberparatodos/src/lib/database.types.ts
+++ b/saberparatodos/src/lib/database.types.ts
@@ -356,9 +356,7 @@ export interface Database {
           id: string
           name: string
           slug: string
-          billing_email: string | null
           owner_user_id: string | null
-          plan_tier: 'free' | 'pro' | 'enterprise'
           is_active: boolean
           created_at: string
         }
@@ -366,9 +364,7 @@ export interface Database {
           id?: string
           name: string
           slug: string
-          billing_email?: string | null
           owner_user_id?: string | null
-          plan_tier?: 'free' | 'pro' | 'enterprise'
           is_active?: boolean
           created_at?: string
         }
@@ -376,9 +372,7 @@ export interface Database {
           id?: string
           name?: string
           slug?: string
-          billing_email?: string | null
           owner_user_id?: string | null
-          plan_tier?: 'free' | 'pro' | 'enterprise'
           is_active?: boolean
           created_at?: string
         }

--- a/saberparatodos/src/lib/institutional-service.ts
+++ b/saberparatodos/src/lib/institutional-service.ts
@@ -4,8 +4,6 @@ export interface Organization {
   id: string;
   name: string;
   slug: string;
-  plan_tier: 'free' | 'pro' | 'enterprise';
-  billing_email?: string;
   is_active: boolean;
   created_at: string;
 }
@@ -21,7 +19,7 @@ export const institutionalService = {
   /**
    * Create a new organization
    */
-  async createOrganization(name: string, slug: string, billingEmail: string) {
+  async createOrganization(name: string, slug: string) {
     const { data: userData } = await supabase.auth.getUser();
     const ownerUserId = userData?.user?.id;
 
@@ -30,7 +28,6 @@ export const institutionalService = {
       .insert({
         name,
         slug,
-        billing_email: billingEmail,
         owner_user_id: ownerUserId
       } as any)
       .select()
@@ -62,7 +59,7 @@ export const institutionalService = {
       .select(`
         role,
         organization:organizations (
-          id, name, slug, plan_tier, is_active
+          id, name, slug, is_active
         )
       `)
       .eq('user_id', user.id) as any;

--- a/saberparatodos/src/pages/api/developers/keys.ts
+++ b/saberparatodos/src/pages/api/developers/keys.ts
@@ -42,7 +42,6 @@ async function ensureDeveloperOrganization(session: Awaited<ReturnType<typeof re
     .insert({
       name: orgName,
       slug: orgSlug,
-      billing_email: email,
       owner_user_id: session.user.id,
     })
     .select('id')


### PR DESCRIPTION
Refactored institutional organization services and components to remove legacy plan_tier and billing_email fields as part of Wave 2.01 WorldExams v2 free open-source model migration. Visual flag stripe CSS and SWAL node identity logic remain intact.

Fixes #1022

---
*PR created automatically by Jules for task [6818198998052342539](https://jules.google.com/task/6818198998052342539) started by @iberi22*