### PR TITLE
feat(ai): tutor session persistence and history

### DIFF
--- a/saberparatodos/src/components/ai/TutorHistory.svelte
+++ b/saberparatodos/src/components/ai/TutorHistory.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    getAllTutorSessions,
+    deleteTutorSession,
+    clearTutorHistory,
+    type TutorSessionRecord,
+  } from '../../lib/ai/tutor-history';
+
+  interface Props {
+    onSelectSession?: (session: TutorSessionRecord) => void;
+  }
+
+  let { onSelectSession = undefined }: Props = $props();
+
+  let sessions = $state<TutorSessionRecord[]>([]);
+  let loading = $state(true);
+  let expandedSessionId = $state<string | null>(null);
+  let searchFilter = $state('');
+
+  let filteredSessions = $derived.by(() => {
+    if (!searchFilter.trim()) return sessions;
+    const term = searchFilter.toLowerCase();
+    return sessions.filter((s) => {
+      const subject = (s.context.subject || '').toLowerCase();
+      const qText = (s.context.questionText || '').toLowerCase();
+      const turnMatch = s.history.some(
+        (t) => t.userText.toLowerCase().includes(term) || t.assistantText.toLowerCase().includes(term)
+      );
+      return subject.includes(term) || qText.includes(term) || turnMatch;
+    });
+  });
+
+  async function loadHistory() {
+    loading = true;
+    try {
+      sessions = await getAllTutorSessions();
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    void loadHistory();
+  });
+
+  async function handleDeleteSession(id: string, e: Event) {
+    e.stopPropagation();
+    await deleteTutorSession(id);
+    sessions = sessions.filter((s) => s.sessionId !== id);
+    if (expandedSessionId === id) expandedSessionId = null;
+  }
+
+  async function handleClearAll() {
+    if (typeof window !== 'undefined' && !window.confirm('¿Borrar todo el historial de tutoría?')) return;
+    await clearTutorHistory();
+    sessions = [];
+    expandedSessionId = null;
+  }
+
+  function toggleExpand(id: string) {
+    expandedSessionId = expandedSessionId === id ? null : id;
+  }
+
+  function formatDate(timestamp: number): string {
+    return new Date(timestamp).toLocaleString('es-ES', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+</script>
+
+<div class="w-full max-w-2xl rounded-2xl border border-white/10 bg-slate-900/90 p-4 shadow-xl text-white space-y-4">
+  <div class="flex items-center justify-between border-b border-white/10 pb-3">
+    <div>
+      <h2 class="text-base font-bold text-white flex items-center gap-2">
+        <span>📜</span> Historial de Tutoría IA
+      </h2>
+      <p class="text-xs text-slate-400">Sesiones previas guardadas en local (IndexedDB)</p>
+    </div>
+    {#if sessions.length > 0}
+      <button
+        type="button"
+        onclick={handleClearAll}
+        class="text-xs text-rose-400 hover:text-rose-300 font-medium px-2.5 py-1 rounded-lg border border-rose-500/20 bg-rose-500/10 hover:bg-rose-500/20 transition"
+      >
+        Limpiar historial
+      </button>
+    {/if}
+  </div>
+
+  <div class="flex items-center gap-2">
+    <input
+      type="text"
+      placeholder="Buscar por materia, pregunta o interacción..."
+      bind:value={searchFilter}
+      class="w-full rounded-xl border border-white/10 bg-slate-950/80 px-3 py-2 text-xs text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-violet-500"
+    />
+  </div>
+
+  {#if loading}
+    <div class="py-8 text-center text-xs text-slate-400">Cargando historial de sesiones...</div>
+  {:else if filteredSessions.length === 0}
+    <div class="py-8 text-center text-xs text-slate-400">
+      {#if searchFilter.trim()}
+        No se encontraron sesiones que coincidan con la búsqueda.
+      {:else}
+        No hay sesiones de tutoría guardadas todavía.
+      {/if}
+    </div>
+  {:else}
+    <div class="space-y-3 max-h-96 overflow-y-auto pr-1">
+      {#each filteredSessions as s (s.sessionId)}
+        <div
+          class="rounded-xl border border-white/10 bg-white/5 p-3 transition hover:border-violet-500/30"
+        >
+          <div class="flex items-start justify-between gap-2">
+            <button
+              type="button"
+              onclick={() => toggleExpand(s.sessionId)}
+              class="flex-1 text-left space-y-1"
+            >
+              <div class="flex items-center gap-2 flex-wrap">
+                {#if s.context.subject}
+                  <span class="rounded bg-violet-500/20 px-2 py-0.5 text-[10px] font-bold text-violet-300 border border-violet-500/30">
+                    {s.context.subject}
+                  </span>
+                {/if}
+                {#if s.context.grade}
+                  <span class="rounded bg-sky-500/20 px-2 py-0.5 text-[10px] font-bold text-sky-300 border border-sky-500/30">
+                    Grado {s.context.grade}
+                  </span>
+                {/if}
+                <span class="text-[11px] text-slate-400 ml-auto font-mono">
+                  {formatDate(s.updatedAt)}
+                </span>
+              </div>
+
+              {#if s.context.questionText}
+                <p class="text-xs text-slate-200 line-clamp-1 font-medium mt-1">
+                  Pregunta: {s.context.questionText}
+                </p>
+              {/if}
+
+              <div class="text-[11px] text-slate-400 flex items-center gap-3 mt-1">
+                <span>💬 {s.history.length} {s.history.length === 1 ? 'interacción' : 'interacciones'}</span>
+                {#if s.syncedToXavier}
+                  <span class="text-emerald-400 font-semibold">✓ Xavier</span>
+                {/if}
+              </div>
+            </button>
+
+            <div class="flex items-center gap-1">
+              {#if onSelectSession}
+                <button
+                  type="button"
+                  onclick={() => onSelectSession(s)}
+                  class="rounded-lg bg-violet-600/30 hover:bg-violet-600/50 border border-violet-500/30 px-2 py-1 text-[11px] font-medium text-violet-200 transition"
+                  title="Continuar sesión"
+                >
+                  Cargar
+                </button>
+              {/if}
+              <button
+                type="button"
+                onclick={(e) => handleDeleteSession(s.sessionId, e)}
+                class="rounded-lg p-1 text-slate-400 hover:text-rose-400 hover:bg-rose-500/10 transition text-xs"
+                title="Eliminar sesión"
+              >
+                🗑️
+              </button>
+            </div>
+          </div>
+
+          {#if expandedSessionId === s.sessionId}
+            <div class="mt-3 border-t border-white/10 pt-3 space-y-2 text-xs">
+              <p class="text-[11px] font-bold text-slate-400 uppercase tracking-wider">Detalle del diálogo:</p>
+              {#each s.history as turn, i}
+                <div class="rounded-lg bg-slate-950/60 p-2.5 space-y-1">
+                  <div class="text-sky-300 font-medium text-[11px]">Estudiante: {turn.userText}</div>
+                  <div class="text-slate-200 text-[11px]">Tutor: {turn.assistantText}</div>
+                  <div class="text-[9px] text-slate-500 text-right">{formatDate(turn.at)}</div>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/saberparatodos/src/lib/ai/tutor-history.test.ts
+++ b/saberparatodos/src/lib/ai/tutor-history.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  saveTutorSession,
+  getTutorSession,
+  getAllTutorSessions,
+  deleteTutorSession,
+  clearTutorHistory,
+  syncSessionToXavier,
+  type TutorSessionRecord,
+} from './tutor-history';
+import { TutorSession } from './tutor-session';
+
+// Mock IndexedDB
+class IDBRequestMock {
+  public result: any = null;
+  public error: any = null;
+  public onsuccess: any = null;
+  public onerror: any = null;
+
+  succeed(val: any) {
+    this.result = val;
+    if (this.onsuccess) this.onsuccess({ target: this });
+  }
+
+  fail(err: any) {
+    this.error = err;
+    if (this.onerror) this.onerror({ target: this });
+  }
+}
+
+class IDBTransactionMock {
+  public oncomplete: any = null;
+  public onerror: any = null;
+
+  constructor(private store: IDBObjectStoreMock) {}
+
+  objectStore() {
+    return this.store;
+  }
+}
+
+class IDBIndexMock {
+  constructor(private dataMap: Map<string, any>) {}
+
+  getAll() {
+    const req = new IDBRequestMock();
+    setTimeout(() => {
+      req.succeed(Array.from(this.dataMap.values()));
+    }, 0);
+    return req;
+  }
+}
+
+class IDBObjectStoreMock {
+  constructor(private dataMap: Map<string, any>) {}
+
+  put(record: any) {
+    this.dataMap.set(record.sessionId, record);
+    const req = new IDBRequestMock();
+    setTimeout(() => req.succeed(record.sessionId), 0);
+    return req;
+  }
+
+  get(key: string) {
+    const req = new IDBRequestMock();
+    setTimeout(() => req.succeed(this.dataMap.get(key) || null), 0);
+    return req;
+  }
+
+  delete(key: string) {
+    this.dataMap.delete(key);
+    const req = new IDBRequestMock();
+    setTimeout(() => req.succeed(undefined), 0);
+    return req;
+  }
+
+  clear() {
+    this.dataMap.clear();
+    const req = new IDBRequestMock();
+    setTimeout(() => req.succeed(undefined), 0);
+    return req;
+  }
+
+  index() {
+    return new IDBIndexMock(this.dataMap);
+  }
+}
+
+class IDBDatabaseMock {
+  public objectStoreNames = {
+    contains: (name: string) => name === 'tutor_sessions',
+  };
+
+  constructor(private dataMap: Map<string, any>) {}
+
+  transaction() {
+    return new IDBTransactionMock(new IDBObjectStoreMock(this.dataMap));
+  }
+}
+
+describe('tutor-history and tutor-session persistence', () => {
+  let dbMap: Map<string, any>;
+
+  beforeEach(() => {
+    dbMap = new Map();
+    const dbMock = new IDBDatabaseMock(dbMap);
+    const mockIndexedDB = {
+      open: vi.fn().mockImplementation(() => {
+        const req = new IDBRequestMock();
+        setTimeout(() => req.succeed(dbMock), 0);
+        return req;
+      }),
+    };
+
+    (globalThis as any).indexedDB = mockIndexedDB;
+    (globalThis as any).window = {
+      indexedDB: mockIndexedDB,
+    };
+  });
+
+  it('persists tutor session turns automatically to IndexedDB history', async () => {
+    const session = new TutorSession({ subject: 'Biología', grade: 11 });
+    await session.respondText('¿Qué es la fotosíntesis?', { speak: false });
+
+    const saved = await getTutorSession(session.sessionId);
+    expect(saved).not.toBeNull();
+    expect(saved?.sessionId).toBe(session.sessionId);
+    expect(saved?.context.subject).toBe('Biología');
+    expect(saved?.history.length).toBe(1);
+    expect(saved?.history[0].userText).toBe('¿Qué es la fotosíntesis?');
+  });
+
+  it('retrieves all tutor sessions ordered newest first', async () => {
+    const session1: TutorSessionRecord = {
+      sessionId: 's1',
+      context: { subject: 'Física' },
+      history: [{ userText: 'u1', assistantText: 'a1', at: 1000 }],
+      createdAt: 1000,
+      updatedAt: 1000,
+    };
+    const session2: TutorSessionRecord = {
+      sessionId: 's2',
+      context: { subject: 'Química' },
+      history: [{ userText: 'u2', assistantText: 'a2', at: 2000 }],
+      createdAt: 2000,
+      updatedAt: 2000,
+    };
+
+    await saveTutorSession(session1);
+    await saveTutorSession(session2);
+
+    const all = await getAllTutorSessions();
+    expect(all.length).toBe(2);
+    expect(all[0].sessionId).toBe('s2');
+    expect(all[1].sessionId).toBe('s1');
+  });
+
+  it('deletes individual tutor sessions', async () => {
+    const record: TutorSessionRecord = {
+      sessionId: 'del-id',
+      context: { subject: 'Historia' },
+      history: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    await saveTutorSession(record);
+    expect(await getTutorSession('del-id')).not.toBeNull();
+
+    await deleteTutorSession('del-id');
+    expect(await getTutorSession('del-id')).toBeNull();
+  });
+
+  it('clears all tutor history', async () => {
+    await saveTutorSession({
+      sessionId: 's1',
+      context: {},
+      history: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await saveTutorSession({
+      sessionId: 's2',
+      context: {},
+      history: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    expect((await getAllTutorSessions()).length).toBe(2);
+    await clearTutorHistory();
+    expect((await getAllTutorSessions()).length).toBe(0);
+  });
+
+  it('handles optional Xavier sync graceful fallback', async () => {
+    const record: TutorSessionRecord = {
+      sessionId: 'xavier-test',
+      context: { subject: 'Matemáticas' },
+      history: [{ userText: 'hola', assistantText: 'hola', at: Date.now() }],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const synced = await syncSessionToXavier(record);
+    // Unconfigured PUBLIC_XAVIER_URL returns false gracefully
+    expect(synced).toBe(false);
+  });
+});

--- a/saberparatodos/src/lib/ai/tutor-history.ts
+++ b/saberparatodos/src/lib/ai/tutor-history.ts
@@ -1,0 +1,201 @@
+/**
+ * Tutor session history management using IndexedDB storage.
+ * Handles persisting past tutoring conversations locally and optional Xavier sync.
+ */
+
+import type { TutorContext, TutorTurn } from './tutor-session';
+import { isXavierConfigured, xavierSave } from '../xavier-client';
+
+export interface TutorSessionRecord {
+  sessionId: string;
+  context: TutorContext;
+  history: TutorTurn[];
+  createdAt: number;
+  updatedAt: number;
+  syncedToXavier?: boolean;
+}
+
+const DB_NAME = 'worldexams_db';
+const DB_VERSION = 6;
+const STORE_TUTOR_SESSIONS = 'tutor_sessions';
+
+/**
+ * Opens IndexedDB database for tutor session history.
+ */
+function openTutorDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined' || !window.indexedDB) {
+      reject(new Error('IndexedDB not supported in this environment'));
+      return;
+    }
+
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = (event) => {
+      console.error('IndexedDB error in tutor-history:', event);
+      reject(new Error('Failed to open IndexedDB database'));
+    };
+
+    request.onsuccess = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      resolve(db);
+    };
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_TUTOR_SESSIONS)) {
+        const store = db.createObjectStore(STORE_TUTOR_SESSIONS, { keyPath: 'sessionId' });
+        store.createIndex('createdAt', 'createdAt', { unique: false });
+        store.createIndex('updatedAt', 'updatedAt', { unique: false });
+      }
+    };
+  });
+}
+
+/**
+ * Clean session record to ensure it is structuredClone-compatible (stripping non-clonable audio buffers if needed).
+ */
+function sanitizeSessionRecord(record: TutorSessionRecord): TutorSessionRecord {
+  const cleanHistory = record.history.map((turn) => {
+    const { audioWav, ...rest } = turn;
+    return rest;
+  });
+  return {
+    ...record,
+    history: cleanHistory,
+  };
+}
+
+/**
+ * Persists a tutor session record to IndexedDB local storage.
+ */
+export async function saveTutorSession(session: TutorSessionRecord): Promise<void> {
+  try {
+    const db = await openTutorDB();
+    const cleanRecord = sanitizeSessionRecord(session);
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([STORE_TUTOR_SESSIONS], 'readwrite');
+      const store = tx.objectStore(STORE_TUTOR_SESSIONS);
+      const request = store.put(cleanRecord);
+
+      request.onsuccess = () => {
+        resolve();
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch (err) {
+    console.warn('Failed to save tutor session to IndexedDB:', err);
+  }
+}
+
+/**
+ * Retrieves a single tutor session by sessionId from IndexedDB storage.
+ */
+export async function getTutorSession(sessionId: string): Promise<TutorSessionRecord | null> {
+  try {
+    const db = await openTutorDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([STORE_TUTOR_SESSIONS], 'readonly');
+      const store = tx.objectStore(STORE_TUTOR_SESSIONS);
+      const request = store.get(sessionId);
+
+      request.onsuccess = () => {
+        resolve(request.result || null);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch (err) {
+    console.warn('Failed to get tutor session from IndexedDB:', err);
+    return null;
+  }
+}
+
+/**
+ * Gets all saved tutor sessions from IndexedDB history, newest first.
+ */
+export async function getAllTutorSessions(): Promise<TutorSessionRecord[]> {
+  try {
+    const db = await openTutorDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([STORE_TUTOR_SESSIONS], 'readonly');
+      const store = tx.objectStore(STORE_TUTOR_SESSIONS);
+      const index = store.index('updatedAt');
+      const request = index.getAll();
+
+      request.onsuccess = () => {
+        const records = (request.result as TutorSessionRecord[]) || [];
+        resolve(records.reverse());
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch (err) {
+    console.warn('Failed to fetch tutor sessions from IndexedDB:', err);
+    return [];
+  }
+}
+
+/**
+ * Deletes a tutor session by sessionId from IndexedDB.
+ */
+export async function deleteTutorSession(sessionId: string): Promise<void> {
+  try {
+    const db = await openTutorDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([STORE_TUTOR_SESSIONS], 'readwrite');
+      const store = tx.objectStore(STORE_TUTOR_SESSIONS);
+      const request = store.delete(sessionId);
+
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  } catch (err) {
+    console.warn('Failed to delete tutor session from IndexedDB:', err);
+  }
+}
+
+/**
+ * Clears all tutor sessions from IndexedDB history.
+ */
+export async function clearTutorHistory(): Promise<void> {
+  try {
+    const db = await openTutorDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction([STORE_TUTOR_SESSIONS], 'readwrite');
+      const store = tx.objectStore(STORE_TUTOR_SESSIONS);
+      const request = store.clear();
+
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  } catch (err) {
+    console.warn('Failed to clear tutor history in IndexedDB:', err);
+  }
+}
+
+/**
+ * Optionally syncs tutor session summary/data to Xavier memory storage if configured.
+ */
+export async function syncSessionToXavier(session: TutorSessionRecord): Promise<boolean> {
+  if (!isXavierConfigured()) return false;
+  try {
+    const summaryText = `Tutor session ${session.sessionId} (${session.context.subject || 'general'}): ${session.history.length} turns.`;
+    const ok = await xavierSave(summaryText, {
+      kind: 'tutor-session',
+      sessionId: session.sessionId,
+      subject: session.context.subject,
+      grade: session.context.grade,
+      turnsCount: session.history.length,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+    });
+    if (ok) {
+      session.syncedToXavier = true;
+      await saveTutorSession(session);
+    }
+    return ok;
+  } catch (err) {
+    console.warn('Xavier sync failed for tutor session:', err);
+    return false;
+  }
+}

--- a/saberparatodos/src/lib/ai/tutor-session.ts
+++ b/saberparatodos/src/lib/ai/tutor-session.ts
@@ -6,6 +6,7 @@
 import { getAiCore } from './ai-core-client';
 import { generateNanoTutorResponse } from './chrome-nano-provider';
 import { recordMejoraInterna } from '../mejora-interna-telemetry';
+import { saveTutorSession, syncSessionToXavier, type TutorSessionRecord } from './tutor-history';
 
 export interface TutorContext {
   questionText?: string;
@@ -25,19 +26,46 @@ export interface TutorTurn {
 }
 
 export class TutorSession {
-  private readonly history: TutorTurn[] = [];
+  public readonly sessionId: string;
+  public readonly createdAt: number;
+  private updatedAt: number;
+  private history: TutorTurn[] = [];
   private context: TutorContext;
 
-  constructor(context: TutorContext = {}) {
+  constructor(context: TutorContext = {}, sessionId?: string, existingHistory?: TutorTurn[], createdAt?: number) {
     this.context = context;
+    this.sessionId = sessionId || (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `session-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`);
+    this.createdAt = createdAt || Date.now();
+    this.updatedAt = Date.now();
+    if (existingHistory && Array.isArray(existingHistory)) {
+      this.history = [...existingHistory];
+    }
   }
 
   updateContext(partial: TutorContext): void {
     this.context = { ...this.context, ...partial };
+    this.updatedAt = Date.now();
+    this.persist();
   }
 
   getHistory(): readonly TutorTurn[] {
     return this.history;
+  }
+
+  getContext(): TutorContext {
+    return this.context;
+  }
+
+  private persist(): void {
+    const record: TutorSessionRecord = {
+      sessionId: this.sessionId,
+      context: this.context,
+      history: this.history,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+    saveTutorSession(record).catch(() => {});
+    syncSessionToXavier(record).catch(() => {});
   }
 
   private buildSystemPrompt(): string {
@@ -93,6 +121,9 @@ export class TutorSession {
       at: Date.now(),
     };
     this.history.push(turn);
+    this.updatedAt = Date.now();
+    this.persist();
+
     recordMejoraInterna('ai.tutor.turn', {
       hasAudio: Boolean(audioWav),
       userChars: userText.length,
@@ -118,6 +149,11 @@ export class TutorSession {
   }
 }
 
-export function createTutorSession(context?: TutorContext): TutorSession {
-  return new TutorSession(context);
+export function createTutorSession(
+  context?: TutorContext,
+  sessionId?: string,
+  existingHistory?: TutorTurn[],
+  createdAt?: number
+): TutorSession {
+  return new TutorSession(context, sessionId, existingHistory, createdAt);
 }


### PR DESCRIPTION
Adds local IndexedDB persistence for AI tutor sessions in `saberparatodos/src/lib/ai/tutor-session.ts` and `saberparatodos/src/lib/ai/tutor-history.ts`, optional Xavier sync, and `saberparatodos/src/components/ai/TutorHistory.svelte` component.

Fixes #1034

---
*PR created automatically by Jules for task [9203964270561612699](https://jules.google.com/task/9203964270561612699) started by @iberi22*