### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP spoofing vulnerability in rate limiting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -59,3 +59,8 @@
 **Vulnerability:** A hardcoded production `API_KEY` (sk-wMepzFhQrFxfq0RsKIM7fp3gPWftUL18E71lAq6rrqRDoFXLsHOI2HGxWINiaUmi) was exposed directly in multiple python script source files (`fix_empty_bundle.py`, `regenerate_bad_bundles.py`, `direct-generate-gateway.py`, `regen_mexico.py`).
 **Learning:** Hardcoding API keys directly into scripts instead of fetching them securely from environment variables leaves the application vulnerable to credential theft and exploitation. Even auxiliary or generation scripts can leak critical access tokens if pushed to remote repositories.
 **Prevention:** Always retrieve secrets securely via environment variables (e.g., `os.environ.get("OPENCODE_API_KEY")`). Any newly created scripts that handle external APIs must use environment variables or encrypted secrets managers, and never embed literal strings starting with standard secret prefixes (e.g., `sk-`).
+
+## 2026-08-18 - [Fix IP spoofing in Edge Functions]
+**Vulnerability:** IP extraction in Supabase Edge Functions (`get-questions`, `get-questions-bulk`) and the Cloudflare API Gateway proxy trusted `x-forwarded-for` as a fallback when identifying client IP, making it vulnerable to spoofing.
+**Learning:** Never trust `x-forwarded-for` as a fallback when identifying client IP in Edge/Serverless environments unless the proxy topology is strictly validated.
+**Prevention:** Strictly rely on `cf-connecting-ip` (or the respective trusted provider header) and avoid sending or reading `x-forwarded-for`. Use a safe fallback like `'unknown'` when the trusted header is absent.

--- a/apps/worldexams-api/src/index.ts
+++ b/apps/worldexams-api/src/index.ts
@@ -370,7 +370,7 @@ function getProxyHeaders(request: Request, env: Env, includeApiKey = false, useA
   }
   if (includeApiKey && apiKey) headers.set("x-api-key", apiKey)
   if (userAgent) headers.set("user-agent", userAgent)
-  if (ipAddress) headers.set("x-forwarded-for", ipAddress)
+  if (ipAddress) headers.set("cf-connecting-ip", ipAddress)
   return headers
 }
 

--- a/supabase/functions/get-questions-bulk/index.ts
+++ b/supabase/functions/get-questions-bulk/index.ts
@@ -80,9 +80,7 @@ serve(async (req: Request) => {
 
     // Rate limiting for guests
     if (isGuest) {
-      const clientIP = req.headers.get('cf-connecting-ip') ||
-                       req.headers.get('x-forwarded-for')?.split(',')[0] ||
-                       'unknown';
+      const clientIP = req.headers.get('cf-connecting-ip') || 'unknown';
 
       const { data: rateLimitData } = await supabase
         .from('api_rate_limits')

--- a/supabase/functions/get-questions/index.ts
+++ b/supabase/functions/get-questions/index.ts
@@ -90,9 +90,7 @@ serve(async (req: Request) => {
 
     // 3. Rate Limiting for Guests
     if (isGuest) {
-      const clientIP = req.headers.get('cf-connecting-ip') ||
-                       req.headers.get('x-forwarded-for')?.split(',')[0] ||
-                       'unknown';
+      const clientIP = req.headers.get('cf-connecting-ip') || 'unknown';
 
       // Check rate limit (100 requests per hour)
       const { data: rateLimitData, error: rateLimitError } = await supabase

--- a/supabase/migrations/20251218_create_rate_limiting.sql
+++ b/supabase/migrations/20251218_create_rate_limiting.sql
@@ -35,6 +35,6 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION cleanup_old_rate_limits() TO authenticated;
 
 COMMENT ON TABLE api_rate_limits IS 'Rate limiting for guest API requests (100 requests/hour per IP)';
-COMMENT ON COLUMN api_rate_limits.ip_address IS 'Client IP address (from x-forwarded-for or cf-connecting-ip)';
+COMMENT ON COLUMN api_rate_limits.ip_address IS 'Client IP address (from cf-connecting-ip)';
 COMMENT ON COLUMN api_rate_limits.request_count IS 'Number of requests in current hour window';
 COMMENT ON COLUMN api_rate_limits.last_reset IS 'Start of current hour window';


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Supabase Edge Functions (`get-questions`, `get-questions-bulk`), as well as the Cloudflare API proxy gateway in `apps/worldexams-api`, were extracting the client IP using a fallback to the `x-forwarded-for` header if `cf-connecting-ip` was missing or as a fallback choice. This is dangerous because an attacker can easily spoof the `x-forwarded-for` header to bypass IP-based rate limits.
🎯 **Impact:** If exploited, attackers can bypass the API rate limit (100 requests/hour for guests) and launch a Denial-of-Service or scrape data unchecked.
🔧 **Fix:** Removed the `x-forwarded-for` header extraction completely from the proxy and Edge Functions. The system now strictly relies on the trusted `cf-connecting-ip` injected by Cloudflare and correctly defaults to a safe fallback (`'unknown'`) if no trusted header is present, protecting the rate limit mechanism. Updated the SQL comment documenting the IP source as well.
✅ **Verification:** Unit tests and linter verify functionality is intact. The vulnerability is structurally mitigated as `x-forwarded-for` is no longer parsed as an IP source in the impacted files.

---
*PR created automatically by Jules for task [8054273998507191600](https://jules.google.com/task/8054273998507191600) started by @iberi22*