### PR TITLE
🎨 Palette: Fix a11y on icon-only voting buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-11-20 - Forms without properly associated labels
 **Learning:** For a form to be accessible and to have correctly clickable labels for inputs, the `for` attribute in the `<label>` tag must map accurately to the `id` of the matching `<input>` field. When a form input has no visual label by design (e.g., a simple email input modal), add a `<label class="sr-only" for="input-id">` to inform screen reader users of the input's purpose.
 **Action:** Ensure all form inputs have associated labels, either visible or `sr-only`, connected using `for`/`id` mapping.
+## 2026-08-24 - [Add aria labels and aria-pressed states to voting buttons]
+**Learning:** Svelte seamlessly binds boolean values to aria-pressed attributes, making toggle buttons highly accessible with minimal code.
+**Action:** Always add aria-pressed along with aria-label on icon-only toggle buttons to properly announce state to screen readers.

--- a/saberparatodos/src/components/QuestionFeedback.svelte
+++ b/saberparatodos/src/components/QuestionFeedback.svelte
@@ -127,6 +127,8 @@
           : 'text-white/30 hover:text-emerald-400 hover:bg-white/5'
       }`}
       title="Buena pregunta"
+      aria-label="Buena pregunta"
+      aria-pressed={userVote === 'up'}
     >
       <svg class="w-5 h-5" fill={userVote === 'up' ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5" />
@@ -140,6 +142,8 @@
           : 'text-white/30 hover:text-red-400 hover:bg-white/5'
       }`}
       title="Pregunta mejorable"
+      aria-label="Pregunta mejorable"
+      aria-pressed={userVote === 'down'}
     >
       <svg class="w-5 h-5" fill={userVote === 'down' ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14H5.236a2 2 0 01-1.789-2.894l3.5-7A2 2 0 018.736 3h4.018a2 2 0 01.485.06l3.76.94m-7 10v5a2 2 0 002 2h.096c.5 0 .905-.405.905-.904 0-.715.211-1.413.608-2.008L17 13V4m-7 10h2m5-10h2a2 2 0 012 2v6a2 2 0 01-2 2h-2.5" />


### PR DESCRIPTION
💡 What: Added `aria-label` and `aria-pressed` attributes to the upvote and downvote icon buttons in the QuestionFeedback component.
🎯 Why: The buttons were icon-only with only a title tooltip. Adding ARIA labels provides clear context, and `aria-pressed` properly communicates their toggled state to screen readers.
📸 Before/After: Visuals are unchanged. Screen readers will now announce "Buena pregunta, pressed" (or similar depending on language/device).
♿ Accessibility: Directly improves WCAG compliance for icon-only toggle buttons.

---
*PR created automatically by Jules for task [2687154548553539365](https://jules.google.com/task/2687154548553539365) started by @iberi22*