### PR TITLE
🎨 Palette: Improve accessibility of Search close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 ## 2026-08-24 - [Add aria labels and aria-pressed states to voting buttons]
 **Learning:** Svelte seamlessly binds boolean values to aria-pressed attributes, making toggle buttons highly accessible with minimal code.
 **Action:** Always add aria-pressed along with aria-label on icon-only toggle buttons to properly announce state to screen readers.
+
+## 2024-12-06 - [Missing type=button on Search Modals]
+**Learning:** When creating a custom modal close button (like the ESC button), omitting `type="button"` can cause accidental form submissions or unexpected behaviors if the modal is ever placed inside a form. Additionally, adding `aria-label` makes the close button accessible to screen readers.
+**Action:** Always include `type="button"` and `aria-label` on custom icon-only close buttons.

--- a/saberparatodos/src/components/Search.svelte
+++ b/saberparatodos/src/components/Search.svelte
@@ -79,7 +79,7 @@
             class="flex-1 bg-transparent border-none outline-none text-[#F5F5DC] placeholder-white/20"
             autocomplete="off"
           />
-          <button on:click={toggleSearch} class="text-xs uppercase tracking-widest text-white/40 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded px-1">
+          <button type="button" aria-label="Cerrar búsqueda" on:click={toggleSearch} class="text-xs uppercase tracking-widest text-white/40 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded px-1">
             ESC
           </button>
         </div>


### PR DESCRIPTION
💡 What: Added `type="button"` and `aria-label="Cerrar búsqueda"` to the ESC close button in `Search.svelte`.
🎯 Why: To ensure keyboard users and screen readers can properly interact with and identify the close button, and prevent accidental form submissions if the search component is nested in a form.
📸 Before/After: Visuals remained identical. Screen readers now announce the button correctly as "Cerrar búsqueda" and it correctly operates as a button.
♿ Accessibility: Improved keyboard and screen reader accessibility for the search modal's close control.

---
*PR created automatically by Jules for task [3273585737356659054](https://jules.google.com/task/3273585737356659054) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved the search modal’s close button with a descriptive accessible label.
* **Bug Fixes**
  * Prevented the close button from unintentionally submitting forms when used inside a form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->