### PR TITLE
🎨 Palette: Add explicit type="button" to selector buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 ## 2026-08-24 - [Add aria labels and aria-pressed states to voting buttons]
 **Learning:** Svelte seamlessly binds boolean values to aria-pressed attributes, making toggle buttons highly accessible with minimal code.
 **Action:** Always add aria-pressed along with aria-label on icon-only toggle buttons to properly announce state to screen readers.
+## 2024-11-20 - [Add explicit type="button" to action buttons]
+**Learning:** Svelte buttons without an explicit `type` attribute inside potentially reactive contexts can sometimes be misinterpreted by assistive technologies or unexpectedly trigger form submissions if wrapped later. Adding `type="button"` ensures consistent, predictable behavior.
+**Action:** Always explicitly declare `type="button"` for interactive `<button>` elements that are not intended to submit forms.

--- a/saberparatodos/src/components/GradeSelector.svelte
+++ b/saberparatodos/src/components/GradeSelector.svelte
@@ -76,6 +76,7 @@
 
   {#if extraGrades.length > 0 && !showAllGrades}
     <button
+      type="button"
       onclick={() => (showAllGrades = true)}
       class="px-6 py-2 mt-4 text-emerald-400 hover:text-emerald-300 transition-colors uppercase text-sm tracking-widest font-semibold"
     >
@@ -84,6 +85,7 @@
   {/if}
 
   <button
+    type="button"
     onclick={onBack}
     class="px-6 py-2 border border-white/20 hover:bg-white/10 transition-colors uppercase text-xs tracking-widest opacity-60 hover:opacity-100"
   >

--- a/saberparatodos/src/components/SubjectSelector.svelte
+++ b/saberparatodos/src/components/SubjectSelector.svelte
@@ -115,6 +115,7 @@
 
   <div class="flex gap-4">
     <button
+      type="button"
       onclick={onBack}
       class="px-6 py-2 border border-white/20 hover:bg-white/10 transition-colors uppercase text-xs tracking-widest opacity-60 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded"
     >
@@ -122,6 +123,7 @@
     </button>
 
     <button
+      type="button"
       onclick={() => onSelect('CHANGE_GRADE')}
       class="px-6 py-2 border border-emerald-500/20 hover:bg-emerald-500/10 text-emerald-500/80 hover:text-emerald-500 transition-colors uppercase text-xs tracking-widest focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded"
     >


### PR DESCRIPTION
💡 What: Added explicit `type="button"` attributes to interactive buttons in `SubjectSelector.svelte` and `GradeSelector.svelte` that are used strictly for navigation and view swapping.
🎯 Why: Prevents these buttons from ever unexpectedly acting as form submission triggers and improves semantic predictability for assistive technologies.
♿ Accessibility: Ensures that screen readers reliably announce these purely as actionable buttons.

---
*PR created automatically by Jules for task [4581903597924039645](https://jules.google.com/task/4581903597924039645) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved button behavior by explicitly identifying non-submit buttons, helping prevent unintended form submissions.
  * Updated navigation and selection controls across grade and subject selection screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->