### PR TITLE
feat(vault): Encrypted Progress & Notes Storage via Vault Bridge

### DIFF
--- a/saberparatodos/src/lib/vault/encrypted-vault-sync.ts
+++ b/saberparatodos/src/lib/vault/encrypted-vault-sync.ts
@@ -1,0 +1,237 @@
+/**
+ * Encrypted Vault Sync Module — Student Progress & Notes Storage via Vault Bridge
+ * Handles Zero-PII serialization, AES-256-GCM encryption, decryption, and chunk preparation for mesh sync / vault export.
+ */
+
+import {
+  deriveKeyFromPhrase,
+  encryptData,
+  decryptData,
+  isEncryptedPayload,
+  isWebCryptoAvailable,
+  type EncryptedPayload
+} from '../encryption';
+
+export interface StudentNote {
+  noteId: string;
+  questionId?: string;
+  subject: string;
+  topic?: string;
+  noteText: string;
+  tags?: string[];
+  updatedAt: number;
+}
+
+export interface SubjectCompetency {
+  subject: string;
+  score: number;
+  level: string;
+  masteredTopics: string[];
+  weakTopics: string[];
+  updatedAt: number;
+}
+
+export interface ErrorLogEntry {
+  errorId: string;
+  questionId: string;
+  subject: string;
+  errorCategory: string;
+  userAns: string;
+  correctAns: string;
+  timestamp: number;
+}
+
+export interface PedagogicalProgress {
+  overallProgressPct: number;
+  studyTimeMinutes: number;
+  streakDays: number;
+  lastActiveTimestamp: number;
+}
+
+export interface StudentVaultData {
+  metadata: {
+    schemaVersion: number;
+    exportTimestamp: number;
+    country?: string;
+  };
+  notes: StudentNote[];
+  competencies: SubjectCompetency[];
+  errorLogs: ErrorLogEntry[];
+  pedagogicalProgress: PedagogicalProgress;
+}
+
+export interface EncryptedSyncChunk {
+  __encrypted: true;
+  version: number;
+  node_hash: string;
+  ciphertext: string;
+  iv: string;
+  salt: string;
+  timestamp: number;
+  [key: string]: any;
+}
+
+const PII_KEY_PATTERNS = [
+  'email',
+  'name',
+  'full_name',
+  'first_name',
+  'last_name',
+  'user_name',
+  'username',
+  'phone',
+  'telephone',
+  'address',
+  'password',
+  'token',
+  'secret',
+  'ssn',
+  'dni',
+  'cedula',
+  'pii'
+];
+
+const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
+
+/**
+ * Validates that no unencrypted PII (Personally Identifiable Information) field or pattern
+ * exists outside ciphertext in an EncryptedSyncChunk metadata payload.
+ * Throws a [BR-04] error if PII is detected.
+ */
+export function assertNoPIIOutsideCiphertext(chunk: Record<string, any>): void {
+  const allowedStandardKeys = new Set([
+    '__encrypted',
+    'version',
+    'node_hash',
+    'ciphertext',
+    'iv',
+    'salt',
+    'timestamp'
+  ]);
+
+  for (const [key, value] of Object.entries(chunk)) {
+    const lowerKey = key.toLowerCase();
+
+    // Check key names for PII terms (ignore allowed encrypted keys)
+    if (!allowedStandardKeys.has(key) && PII_KEY_PATTERNS.some(p => lowerKey.includes(p))) {
+      throw new Error(`[BR-04] Unencrypted PII field '${key}' attached outside ciphertext`);
+    }
+
+    // Check string values for email patterns outside ciphertext
+    if (typeof value === 'string' && key !== 'ciphertext') {
+      if (EMAIL_REGEX.test(value)) {
+        throw new Error(`[BR-04] Unencrypted PII email pattern detected in key '${key}' outside ciphertext`);
+      }
+    }
+
+    // Recursively check nested objects outside ciphertext
+    if (typeof value === 'object' && value !== null && key !== 'ciphertext') {
+      assertNoPIIOutsideCiphertext(value);
+    }
+  }
+}
+
+/**
+ * Serializes StudentVaultData into a clean JSON string
+ */
+export function serializeVaultData(data: StudentVaultData): string {
+  return JSON.stringify(data);
+}
+
+/**
+ * Deserializes a JSON string back into StudentVaultData
+ */
+export function deserializeVaultData(jsonStr: string): StudentVaultData {
+  const parsed = JSON.parse(jsonStr);
+  if (!parsed || typeof parsed !== 'object' || !parsed.metadata) {
+    throw new Error('Invalid vault data format');
+  }
+  return parsed as StudentVaultData;
+}
+
+/**
+ * Prepares and encrypts student vault data into a sync chunk for mesh broadcast or local vault export.
+ * Strictly guarantees zero PII outside ciphertext.
+ */
+export async function createEncryptedSyncChunk(
+  data: StudentVaultData,
+  vaultKeyOrPhrase: CryptoKey | string,
+  nodeHash: string,
+  extraUnencryptedMetadata?: Record<string, any>
+): Promise<EncryptedSyncChunk> {
+  let key: CryptoKey;
+  if (typeof vaultKeyOrPhrase === 'string') {
+    key = await deriveKeyFromPhrase(vaultKeyOrPhrase);
+  } else {
+    key = vaultKeyOrPhrase;
+  }
+
+  const jsonPayload = serializeVaultData(data);
+  const encryptedPayload: EncryptedPayload = await encryptData(JSON.parse(jsonPayload), key);
+
+  if (!encryptedPayload || !encryptedPayload.__encrypted) {
+    throw new Error('Failed to encrypt student vault data');
+  }
+
+  const chunk: EncryptedSyncChunk = {
+    __encrypted: true,
+    version: 1,
+    node_hash: nodeHash,
+    ciphertext: encryptedPayload.ciphertext,
+    iv: encryptedPayload.iv,
+    salt: encryptedPayload.salt,
+    timestamp: Date.now(),
+    ...extraUnencryptedMetadata
+  };
+
+  // Perform strict [BR-04] Zero-PII check
+  assertNoPIIOutsideCiphertext(chunk);
+
+  return chunk;
+}
+
+/**
+ * Decrypts and deserializes an EncryptedSyncChunk back into StudentVaultData
+ * when authorized by the student's Vault key.
+ */
+export async function decryptSyncChunk(
+  chunk: EncryptedSyncChunk,
+  vaultKeyOrPhrase: CryptoKey | string
+): Promise<StudentVaultData> {
+  if (!chunk || !chunk.__encrypted || !chunk.ciphertext) {
+    throw new Error('Invalid encrypted sync chunk');
+  }
+
+  // Ensure chunk has no unencrypted PII attached outside ciphertext
+  assertNoPIIOutsideCiphertext(chunk);
+
+  const payload: EncryptedPayload = {
+    __encrypted: true,
+    version: chunk.version || 1,
+    ciphertext: chunk.ciphertext,
+    iv: chunk.iv,
+    salt: chunk.salt
+  };
+
+  let key: CryptoKey | null = null;
+  if (typeof vaultKeyOrPhrase === 'string') {
+    const saltBytes = chunk.salt ? new Uint8Array(Buffer.from(chunk.salt, 'base64')) : undefined;
+    key = await deriveKeyFromPhrase(vaultKeyOrPhrase, saltBytes);
+  } else {
+    key = vaultKeyOrPhrase;
+  }
+
+  const decryptedResult = await decryptData(payload, key);
+
+  if (isEncryptedPayload(decryptedResult)) {
+    throw new Error('Failed to decrypt vault sync chunk: Invalid key or corrupted payload');
+  }
+
+  if (typeof decryptedResult === 'string') {
+    return deserializeVaultData(decryptedResult);
+  } else if (typeof decryptedResult === 'object' && decryptedResult !== null && 'metadata' in decryptedResult) {
+    return decryptedResult as StudentVaultData;
+  }
+
+  throw new Error('Decryption resulted in invalid data payload');
+}

--- a/saberparatodos/tests/unit/encrypted-vault-sync.test.ts
+++ b/saberparatodos/tests/unit/encrypted-vault-sync.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  serializeVaultData,
+  deserializeVaultData,
+  createEncryptedSyncChunk,
+  decryptSyncChunk,
+  assertNoPIIOutsideCiphertext,
+  type StudentVaultData,
+  type EncryptedSyncChunk
+} from '../../src/lib/vault/encrypted-vault-sync';
+import { deriveKeyFromPhrase } from '../../src/lib/encryption';
+
+describe('Encrypted Vault Sync Module (feat-encrypted-vault-sync)', () => {
+  const sampleVaultData: StudentVaultData = {
+    metadata: {
+      schemaVersion: 1,
+      exportTimestamp: 1700000000000,
+      country: 'CO'
+    },
+    notes: [
+      {
+        noteId: 'note-001',
+        questionId: 'q-math-101',
+        subject: 'matematicas',
+        topic: 'algebra',
+        noteText: 'Revisar la regla de la cadena para funciones compuestas.',
+        tags: ['importante', 'repaso'],
+        updatedAt: 1700000010000
+      }
+    ],
+    competencies: [
+      {
+        subject: 'matematicas',
+        score: 85,
+        level: 'Avanzado',
+        masteredTopics: ['algebra', 'geometria'],
+        weakTopics: ['trigonometria'],
+        updatedAt: 1700000020000
+      }
+    ],
+    errorLogs: [
+      {
+        errorId: 'err-55',
+        questionId: 'q-math-102',
+        subject: 'matematicas',
+        errorCategory: 'calculo_erroneo',
+        userAns: 'B',
+        correctAns: 'D',
+        timestamp: 1700000030000
+      }
+    ],
+    pedagogicalProgress: {
+      overallProgressPct: 78.5,
+      studyTimeMinutes: 340,
+      streakDays: 5,
+      lastActiveTimestamp: 1700000040000
+    }
+  };
+
+  const passPhrase = 'aguila jaguar condor oriente selva andes sol luna estrella fuego viento mar';
+  const nodeHash = 'a1b2c3d4e5f678901234567890abcdef12345678';
+
+  beforeEach(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+  });
+
+  it('should serialize and deserialize StudentVaultData with 100% data integrity', () => {
+    const jsonStr = serializeVaultData(sampleVaultData);
+    expect(typeof jsonStr).toBe('string');
+    const deserialized = deserializeVaultData(jsonStr);
+    expect(deserialized).toEqual(sampleVaultData);
+  });
+
+  it('should encrypt -> serialize -> deserialize -> decrypt roundtrip preserving 100% data integrity', async () => {
+    const chunk: EncryptedSyncChunk = await createEncryptedSyncChunk(
+      sampleVaultData,
+      passPhrase,
+      nodeHash
+    );
+
+    expect(chunk.__encrypted).toBe(true);
+    expect(chunk.version).toBe(1);
+    expect(chunk.node_hash).toBe(nodeHash);
+    expect(typeof chunk.ciphertext).toBe('string');
+    expect(typeof chunk.iv).toBe('string');
+    expect(typeof chunk.salt).toBe('string');
+
+    // Transmit chunk as JSON string over network / mesh relay
+    const chunkString = JSON.stringify(chunk);
+    const parsedChunk: EncryptedSyncChunk = JSON.parse(chunkString);
+
+    const decryptedData = await decryptSyncChunk(parsedChunk, passPhrase);
+    expect(decryptedData).toEqual(sampleVaultData);
+  });
+
+  it('should support decrypting with pre-derived SubtleCrypto CryptoKey', async () => {
+    const key = await deriveKeyFromPhrase(passPhrase);
+    const chunk = await createEncryptedSyncChunk(sampleVaultData, key, nodeHash);
+    const decryptedData = await decryptSyncChunk(chunk, key);
+    expect(decryptedData).toEqual(sampleVaultData);
+  });
+
+  it('should throw [BR-04] error if unencrypted PII field is attached outside ciphertext', async () => {
+    // Test key name containing PII (e.g., user_email)
+    await expect(
+      createEncryptedSyncChunk(sampleVaultData, passPhrase, nodeHash, {
+        user_email: 'estudiante@ejemplo.com'
+      })
+    ).rejects.toThrow('[BR-04]');
+
+    // Test name field attached outside ciphertext
+    await expect(
+      createEncryptedSyncChunk(sampleVaultData, passPhrase, nodeHash, {
+        full_name: 'Juan Perez'
+      })
+    ).rejects.toThrow('[BR-04]');
+
+    // Test token field attached outside ciphertext
+    await expect(
+      createEncryptedSyncChunk(sampleVaultData, passPhrase, nodeHash, {
+        auth_token: 'secret-token-123'
+      })
+    ).rejects.toThrow('[BR-04]');
+
+    // Direct check using assertNoPIIOutsideCiphertext
+    const invalidChunk = {
+      __encrypted: true,
+      version: 1,
+      node_hash: nodeHash,
+      ciphertext: 'valid_ciphertext_string',
+      iv: 'iv_string',
+      salt: 'salt_string',
+      timestamp: Date.now(),
+      student_email: 'user@domain.com'
+    };
+
+    expect(() => assertNoPIIOutsideCiphertext(invalidChunk)).toThrow('[BR-04]');
+  });
+
+  it('should throw [BR-04] error if email pattern string value is attached outside ciphertext', () => {
+    const invalidChunkWithEmailValue = {
+      __encrypted: true,
+      version: 1,
+      node_hash: nodeHash,
+      ciphertext: 'valid_ciphertext_string',
+      iv: 'iv_string',
+      salt: 'salt_string',
+      timestamp: Date.now(),
+      custom_meta: 'contact me at test@school.edu'
+    };
+
+    expect(() => assertNoPIIOutsideCiphertext(invalidChunkWithEmailValue)).toThrow('[BR-04]');
+  });
+
+  it('should allow clean unencrypted metadata like subject or grade outside ciphertext', async () => {
+    const chunk = await createEncryptedSyncChunk(sampleVaultData, passPhrase, nodeHash, {
+      subject: 'matematicas',
+      grade_level: 11
+    });
+
+    expect(chunk.subject).toBe('matematicas');
+    expect(chunk.grade_level).toBe(11);
+    expect(() => assertNoPIIOutsideCiphertext(chunk)).not.toThrow();
+  });
+
+  it('should throw when decrypting with wrong key or tampered passphrase', async () => {
+    const chunk = await createEncryptedSyncChunk(sampleVaultData, passPhrase, nodeHash);
+    const wrongPhrase = 'diferente frase secreta para desencriptacion fallida prueba1234';
+
+    await expect(decryptSyncChunk(chunk, wrongPhrase)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Implemented saberparatodos/src/lib/vault/encrypted-vault-sync.ts and unit tests saberparatodos/tests/unit/encrypted-vault-sync.test.ts for encrypted progress & notes storage via Vault Bridge. Features Zero-PII assertions [BR-04], AES-256-GCM encryption/decryption, and payload serialization/deserialization.

Fixes #1070

---
*PR created automatically by Jules for task [4715358376543033647](https://jules.google.com/task/4715358376543033647) started by @iberi22*