### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF bypass in moderation API

### DIFF
--- a/saberparatodos/.jules/sentinel.md
+++ b/saberparatodos/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** A malicious user could post a comment impersonating any other user or setting arbitrary \`user_id\` and \`user_name\` via the request body in \`src/pages/api/comments.ts\`.
 **Learning:** Bypassing Row Level Security (RLS) by using the admin client (\`createAdminSupabaseClient\`) means we cannot blindly trust user identifiers from the request payload.
 **Prevention:** Always extract the \`Authorization\` token directly from headers, retrieve the user securely via \`supabase.auth.getUser()\`, and use the server-validated user properties for database inserts instead of the client payload.
+## 2024-10-25 - CSRF Bypass via Missing Headers
+**Vulnerability:** The CSRF validation logic in `isValidOrigin` returned `true` when both `origin` and `referer` headers were missing, allowing an attacker to bypass protection.
+**Learning:** Failing open on missing standard security headers enables attackers to bypass CSRF checks by using contexts that deliberately omit them (e.g., `<meta name="referrer" content="no-referrer">`).
+**Prevention:** Always return `false` in CSRF validation if required headers like `origin` or `referer` are absent.

--- a/saberparatodos/src/pages/api/moderate.ts
+++ b/saberparatodos/src/pages/api/moderate.ts
@@ -76,8 +76,8 @@ function getCsrfToken(request: Request): string | null {
 function isValidOrigin(request: Request): boolean {
   const origin = request.headers.get('origin');
   const referer = request.headers.get('referer');
-  // Allow requests with no origin header (e.g., direct curl) or with valid origin/referer
-  if (!origin && !referer) return true;
+  // Fail closed: Do not allow requests with no origin and no referer header to prevent CSRF bypass
+  if (!origin && !referer) return false;
   const allowedOrigins = [
     'http://localhost:4321',
     'https://saberparatodos.com',


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The CSRF validation logic in `isValidOrigin` (`saberparatodos/src/pages/api/moderate.ts`) returned `true` when both `origin` and `referer` headers were missing, allowing an attacker to bypass protection.
🎯 **Impact:** An attacker could craft a malicious page to perform unauthorized moderation actions (approving or rejecting comments) on behalf of an authenticated moderator by deliberately omitting referrers (e.g., using `<meta name="referrer" content="no-referrer">`).
🔧 **Fix:** Changed the logic in `isValidOrigin` to return `false` (fail closed) when both `origin` and `referer` headers are absent.
✅ **Verification:** Run `pnpm lint` and `PUBLIC_COUNTRY=CO pnpm test:unit` in the `saberparatodos` directory to ensure no regressions. The change was validated to ensure security context is not bypassed by empty header conditions.

---
*PR created automatically by Jules for task [892698832405562965](https://jules.google.com/task/892698832405562965) started by @iberi22*