### PR TITLE
feat(api): add GET /v1/grades/:country/:grade/bundle endpoint

### DIFF
--- a/apps/worldexams-api/src/index.ts
+++ b/apps/worldexams-api/src/index.ts
@@ -411,8 +411,48 @@ export default {
           health: "/health",
           free_questions: "/v1/questions",
           premium_questions: "/v1/premium/questions",
+          grade_bundle: "/v1/grades/:country/:grade/bundle",
         },
       }, 200, {}, request)
+    }
+
+    const gradeBundleMatch = url.pathname.match(/^\/v1\/grades\/([^\/]+)\/([^\/]+)\/bundle$/i)
+    if (gradeBundleMatch) {
+      const country = gradeBundleMatch[1].toLowerCase()
+      const grade = gradeBundleMatch[2].toLowerCase()
+      const assetPath = `/v1/grades/${country}-grado-${grade}-full.json`
+      const assetUrl = new URL(assetPath, url.origin)
+      const assetResponse = await env.ASSETS.fetch(
+        new Request(assetUrl.toString(), {
+          method: "GET",
+          headers: request.headers,
+        })
+      )
+
+      if (assetResponse.ok) {
+        const headers = new Headers(assetResponse.headers)
+        headers.set("Content-Type", "application/json")
+        headers.set("Cache-Control", "public, max-age=86400, s-maxage=604800")
+        Object.entries(corsHeadersFor(request)).forEach(([key, value]) =>
+          headers.set(key, value)
+        )
+        return new Response(assetResponse.body, {
+          status: 200,
+          headers,
+        })
+      }
+
+      return json(
+        {
+          error: "GRADE_BUNDLE_NOT_FOUND",
+          message: `Grade bundle for country '${country}' and grade '${grade}' was not found.`,
+          country,
+          grade,
+        },
+        404,
+        {},
+        request
+      )
     }
 
     if (url.pathname === "/health") {

--- a/apps/worldexams-api/tests/grade-bundles.test.ts
+++ b/apps/worldexams-api/tests/grade-bundles.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest"
+import worker from "../src/index"
+import type { Env } from "../src/index"
+
+describe("GET /v1/grades/:country/:grade/bundle worker handler", () => {
+  const mockEnv = (assetsMap: Record<string, Response>): Env => ({
+    SUPABASE_URL: "https://mock.supabase.co",
+    SUPABASE_ANON_KEY: "mock-key",
+    ASSETS: {
+      fetch: vi.fn(async (request: Request | string) => {
+        const urlStr = typeof request === "string" ? request : request.url
+        const url = new URL(urlStr)
+        const response = assetsMap[url.pathname]
+        if (response) {
+          return response.clone()
+        }
+        return new Response("Not Found", { status: 404 })
+      }),
+    } as unknown as Fetcher,
+  })
+
+  it("returns 200 OK with grade bundle payload and cache-control headers when asset exists", async () => {
+    const bundleData = {
+      grade: "11",
+      country: "co",
+      subjects: ["matematicas", "lectura_critica"],
+      questions_count: 120,
+    }
+
+    const env = mockEnv({
+      "/v1/grades/co-grado-11-full.json": new Response(JSON.stringify(bundleData), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    })
+
+    const req = new Request("http://localhost/v1/grades/co/11/bundle", {
+      method: "GET",
+      headers: { Origin: "https://saberparatodos.space" },
+    })
+
+    const res = await worker.fetch(req, env)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toBe("application/json")
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=86400, s-maxage=604800")
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://saberparatodos.space")
+
+    const data = await res.json()
+    expect(data).toEqual(bundleData)
+  })
+
+  it("returns 404 with error body when requested grade pack does not exist", async () => {
+    const env = mockEnv({})
+
+    const req = new Request("http://localhost/v1/grades/co/99/bundle", {
+      method: "GET",
+    })
+
+    const res = await worker.fetch(req, env)
+
+    expect(res.status).toBe(404)
+    expect(res.headers.get("Content-Type")).toBe("application/json")
+
+    const data = (await res.json()) as any
+    expect(data.error).toBe("GRADE_BUNDLE_NOT_FOUND")
+    expect(data.country).toBe("co")
+    expect(data.grade).toBe("99")
+  })
+
+  it("does not grant cross-origin access for untrusted Origin headers", async () => {
+    const bundleData = { grade: "11", country: "co" }
+    const env = mockEnv({
+      "/v1/grades/co-grado-11-full.json": new Response(JSON.stringify(bundleData), {
+        status: 200,
+      }),
+    })
+
+    const req = new Request("http://localhost/v1/grades/co/11/bundle", {
+      method: "GET",
+      headers: { Origin: "https://untrusted-site.com" },
+    })
+
+    const res = await worker.fetch(req, env)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    include: ['src/**/*.{test,spec}.{js,ts,jsx,tsx}', 'saberparatodos/src/**/*.{test,spec}.{js,ts,jsx,tsx}'],
+    include: ['src/**/*.{test,spec}.{js,ts,jsx,tsx}', 'saberparatodos/src/**/*.{test,spec}.{js,ts,jsx,tsx}', 'apps/**/*.{test,spec}.{js,ts,jsx,tsx}'],
     exclude: ['node_modules', 'dist', '.astro', 'tests/e2e/**'],
   },
 });


### PR DESCRIPTION
Extends API gateway apps/worldexams-api/src/index.ts with the GET /v1/grades/:country/:grade/bundle route to serve offline grade bundles from static assets with CDN cache-control headers, CORS allowlist matching, and 404 fallback JSON payload. Adds unit/integration test coverage in apps/worldexams-api/tests/grade-bundles.test.ts.

Fixes #1066

---
*PR created automatically by Jules for task [953048582394023135](https://jules.google.com/task/953048582394023135) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint for retrieving country- and grade-specific exam bundles.
  * Responses include long-lived caching and trusted cross-origin access support.
  * Added clear 404 responses when a requested bundle is unavailable.
  * Listed the new endpoint in the API metadata.

* **Tests**
  * Added coverage for successful retrievals, missing bundles, caching, and origin validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->