### PR TITLE
⚡ Bolt: [performance improvement] Reduce array allocations in LocalReportsView

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -15,3 +15,6 @@
 ## 2024-11-23 - Optimize Svelte Template and Derived Array Chains
 **Learning:** In Svelte 5, using chained array methods (like `.slice(0, 10).reverse().map(...)`) inside `$derived` declarations or executing operations like `.slice(0, 6).map(...)` directly inside the HTML template block triggers unnecessary allocations and intermediate arrays during every reactive re-render cycle. This creates significant garbage collection pressure on the main thread and can lead to frame drops when data frequently updates.
 **Action:** Replace inline template array operations and `$derived` chains with precomputed variables evaluated via a single-pass `for` loop inside `$derived.by()`. This removes O(3N) multi-pass array allocations down to O(N) operations and ensures templates are referencing simple variables rather than executing array logic.
+## 2024-05-18 - Avoid Chained Array Methods in Reactive Blocks
+**Learning:** Chaining methods like `.slice().reverse().slice()` within reactive blocks (like `$derived.by` in Svelte) causes unnecessary intermediate array allocations and multiple iteration passes, which can cause frame drops.
+**Action:** Replace chained array manipulations with single-pass loops or mathematical indexing (e.g., iterating backwards from the array end) to extract data efficiently without mutation or allocations.

--- a/saberparatodos/src/components/LocalReportsView.svelte
+++ b/saberparatodos/src/components/LocalReportsView.svelte
@@ -466,11 +466,13 @@
     if (compStats.length > 0) {
       const sorted = [...compStats].sort((a, b) => b.weightedScore - a.weightedScore);
       strengths = sorted.slice(0, 3);
-      weaknesses = sorted.slice().reverse().slice(0, 3); // Reverse of desc sort = asc sort
+      // ⚡ Bolt Optimization: Use slice(-3).reverse() to extract weaknesses without allocating a full O(N) intermediate array clone
+      weaknesses = sorted.slice(-3).reverse(); // Reverse of desc sort = asc sort
     } else if (subjStats.length > 0) {
       const sorted = [...subjStats].sort((a, b) => b.weightedScore - a.weightedScore);
       strengths = sorted.slice(0, 3);
-      weaknesses = sorted.slice().reverse().slice(0, 3);
+      // ⚡ Bolt Optimization: Use slice(-3).reverse() to extract weaknesses without allocating a full O(N) intermediate array clone
+      weaknesses = sorted.slice(-3).reverse();
     }
 
     return {


### PR DESCRIPTION
💡 What: Replaced the chained array manipulation `sorted.slice().reverse().slice(0, 3)` with `sorted.slice(-3).reverse()` in `LocalReportsView.svelte`.

🎯 Why: The original code was creating a full O(N) clone of the `sorted` array using `.slice()`, then reversing the entire cloned array in-place, and finally slicing the first 3 elements. This happened inside a Svelte `$derived.by()` reactive block, meaning these unnecessary allocations and iterations were executed on every relevant state change. 

📊 Impact: Significantly reduces memory allocations and O(N) iterations during reactive updates. By slicing the last 3 elements first, we only reverse a 3-element array, keeping the operation strictly O(1) in terms of allocations and scaling regardless of the dataset size.

🔬 Measurement: Check the Chrome DevTools Performance tab while opening and interacting with the `LocalReportsView` modal. The main thread blocking time and memory GC pauses will be reduced when processing large student history datasets.

---
*PR created automatically by Jules for task [2996916928248717046](https://jules.google.com/task/2996916928248717046) started by @iberi22*