### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability via RateLimit Map memory leak

### DIFF
--- a/saberparatodos/src/pages/api/explanations.ts
+++ b/saberparatodos/src/pages/api/explanations.ts
@@ -44,9 +44,21 @@ export function sanitizeContent(input: string): string {
 // ---------------------------------------------------------------------------
 export const rateLimitMap = new Map<string, { lastAt: number }>();
 export const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const CLEANUP_PROBABILITY = 0.05;
+
+export function cleanupRateLimitMap(now: number) {
+  for (const [key, value] of rateLimitMap.entries()) {
+    if (value.lastAt + RATE_LIMIT_WINDOW_MS < now) {
+      rateLimitMap.delete(key);
+    }
+  }
+}
 
 export function checkRateLimit(nodeHash: string): boolean {
   const now = Date.now();
+  if (Math.random() < CLEANUP_PROBABILITY) {
+    cleanupRateLimitMap(now);
+  }
   const entry = rateLimitMap.get(nodeHash);
   if (!entry) {
     rateLimitMap.set(nodeHash, { lastAt: now });

--- a/saberparatodos/src/pages/api/replies.ts
+++ b/saberparatodos/src/pages/api/replies.ts
@@ -6,7 +6,7 @@ import {
   getServerRuntimeEnv,
   type RuntimeLocals,
 } from '../../lib/server-runtime';
-import { sanitizeContent, rateLimitMap, RATE_LIMIT_WINDOW_MS } from './explanations';
+import { sanitizeContent, rateLimitMap, RATE_LIMIT_WINDOW_MS, cleanupRateLimitMap } from './explanations';
 
 // WX-302 capa 3: hilos por explicación (reply / citar / ampliar)
 // Usa community_replies si existe; fallback in-memory para tests sin supabase
@@ -47,8 +47,13 @@ function jsonResponse(data: unknown, status = 200) {
   });
 }
 
+const CLEANUP_PROBABILITY = 0.05;
+
 function checkReplyRateLimit(nodeHash: string): boolean {
   const now = Date.now();
+  if (Math.random() < CLEANUP_PROBABILITY) {
+    cleanupRateLimitMap(now);
+  }
   const key = `reply:${nodeHash}`;
   const entry = rateLimitMap.get(key);
   if (!entry) {


### PR DESCRIPTION
In `saberparatodos/src/pages/api/explanations.ts` and `saberparatodos/src/pages/api/replies.ts`, an in-memory `Map` was being used for rate limiting without any mechanism to prune expired entries. Over time, an attacker could continuously hit the API with unique hashes, causing the Map to grow infinitely and leading to memory exhaustion (DoS).

This commit resolves the issue by:
1. Exporting a `cleanupRateLimitMap` function from `explanations.ts` that removes expired records.
2. Applying a lightweight probabilistic garbage collection mechanism (cleaning up 5% of the time, `Math.random() < 0.05`) in both the explanations and replies API handlers.

---
*PR created automatically by Jules for task [5650193318560789542](https://jules.google.com/task/5650193318560789542) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit management by automatically removing expired entries.
  * Helps prevent stale rate-limit data from accumulating over time.
  * Existing rate-limit behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->