### PR TITLE
Teacher Toolkit Refinement: Exportador Markdown, Clave Pedagógica y Lanzamiento Rápido

### DIFF
--- a/saberparatodos/src/components/docentes/TeacherToolkit.svelte
+++ b/saberparatodos/src/components/docentes/TeacherToolkit.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { fade, fly } from 'svelte/transition';
   import MathRenderer from '../MathRenderer.svelte';
+  import { getAuthorityGuidelines } from '../../config/authority-guidelines';
 
   let { runtimeCountry } = $props();
 
@@ -9,6 +10,7 @@
   let selectedSubject = $state(runtimeCountry?.subjects?.[0]?.name || 'Matemáticas');
   let selectedGrade = $state(11);
   let workshopQuestionCount = $state(10);
+  let includeAnswerKey = $state(true);
   let isGeneratingWorkshop = $state(false);
   let workshopReady = $state(false);
 
@@ -51,9 +53,147 @@
     }, 600);
   }
 
+  function getSampleQuestions() {
+    return Array.from({ length: workshopQuestionCount }, (_, i) => ({
+      num: i + 1,
+      question: `Enunciado pedagógico de práctica #${i + 1} para ${selectedSubject} (Grado ${selectedGrade}°). ¿Cuál de las siguientes alternativas representa la solución analítica correcta?`,
+      options: [
+        'A) Opción A — Planteamiento analítico estándar.',
+        'B) Opción B — Alternativa con distractor de interpretación.',
+        'C) Opción C — Respuesta correcta validada por estándar curricular.',
+        'D) Opción D — Distractor procedural frecuente.'
+      ],
+      correct: 'C',
+      justification: 'La Opción C aplica rigurosamente las competencias evaluadas por el estándar curricular nacional. El distractor B surge de omitir el análisis dimensional.'
+    }));
+  }
+
+  function downloadFile(content: string, filename: string, type: string) {
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  function exportMarkdown() {
+    const questions = getSampleQuestions();
+    let md = `# TALLER EVALUATIVO - ${selectedSubject.toUpperCase()}\n`;
+    md += `**País:** ${runtimeCountry?.name || 'Oficial'} | **Grado:** ${selectedGrade}° | **Fecha:** ____/____/2026\n`;
+    md += `**Estudiante:** ________________________________________ | **Calificación:** ________ / ${workshopQuestionCount}\n\n`;
+    md += `---\n\n`;
+    md += `### Instrucciones:\n`;
+    md += `Lee detenidamente cada pregunta y selecciona la alternativa correcta. Fundamenta tus respuestas cuando sea requerido.\n\n`;
+    md += `---\n\n`;
+
+    questions.forEach((q) => {
+      md += `### Pregunta ${q.num}\n${q.question}\n\n`;
+      q.options.forEach((opt) => {
+        md += `- [ ] ${opt}\n`;
+      });
+      md += `\n`;
+    });
+
+    if (includeAnswerKey) {
+      md += `---\n\n## 🔑 CLAVE DE RESPUESTAS Y JUSTIFICACIÓN PEDAGÓGICA\n\n`;
+      questions.forEach((q) => {
+        md += `**${q.num}. Respuesta Correcta: (${q.correct})**\n`;
+        md += `*Justificación:* ${q.justification}\n\n`;
+      });
+    }
+
+    const filename = `Taller_${selectedSubject.replace(/\s+/g, '_')}_Grado${selectedGrade}.md`;
+    downloadFile(md, filename, 'text/markdown;charset=utf-8');
+  }
+
+  function exportHTML() {
+    const questions = getSampleQuestions();
+    let html = `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Taller de ${selectedSubject} - Grado ${selectedGrade}°</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; padding: 2rem; color: #111; max-w: 800px; margin: auto; }
+    h1 { color: #d97706; border-bottom: 2px solid #e5e7eb; padding-bottom: 0.5rem; }
+    .meta { background: #f3f4f6; padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; font-size: 0.9rem; }
+    .question-card { background: #fff; border: 1px solid #e5e7eb; padding: 1rem; margin-bottom: 1rem; border-radius: 8px; }
+    .options { list-style: none; padding-left: 0; }
+    .options li { margin: 0.4rem 0; padding: 0.4rem 0.8rem; background: #f9fafb; border-radius: 4px; }
+    .answer-key { margin-top: 2rem; padding: 1rem; background: #fef3c7; border: 1px solid #fde68a; border-radius: 8px; }
+  </style>
+</head>
+<body>
+  <h1>Taller de Evaluacion: ${selectedSubject}</h1>
+  <div class="meta">
+    <p><strong>País:</strong> ${runtimeCountry?.name || 'Oficial'} | <strong>Grado:</strong> ${selectedGrade}° | <strong>Fecha:</strong> ____/____/2026</p>
+    <p><strong>Estudiante:</strong> ________________________________________ | <strong>Puntaje:</strong> ________ / ${workshopQuestionCount}</p>
+  </div>
+  <div>`;
+
+    questions.forEach((q) => {
+      html += `
+    <div class="question-card">
+      <h3>Pregunta ${q.num}</h3>
+      <p>${q.question}</p>
+      <ul class="options">
+        ${q.options.map(opt => `<li>${opt}</li>`).join('')}
+      </ul>
+    </div>`;
+    });
+
+    if (includeAnswerKey) {
+      html += `
+  <div class="answer-key">
+    <h2>🔑 Clave de Respuestas & Justificación Pedagógica</h2>
+    ${questions.map(q => `
+      <div style="margin-bottom: 1rem;">
+        <strong>Pregunta ${q.num}: (${q.correct})</strong>
+        <p style="margin: 0.2rem 0; font-style: italic;">${q.justification}</p>
+      </div>
+    `).join('')}
+  </div>`;
+    }
+
+    html += `
+  </div>
+</body>
+</html>`;
+
+    const filename = `Taller_${selectedSubject.replace(/\s+/g, '_')}_Grado${selectedGrade}.html`;
+    downloadFile(html, filename, 'text/html;charset=utf-8');
+  }
+
   function printWorkshop() {
     window.print();
   }
+
+  function normalizeSubjectKey(name: string): string {
+    return String(name || '')
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]/g, '');
+  }
+
+  const activeGuidelines = $derived(getAuthorityGuidelines(runtimeCountry?.code || 'CO'));
+  const currentCompetencyData = $derived.by(() => {
+    const norm = normalizeSubjectKey(selectedSubject);
+    const keys = Object.keys(activeGuidelines.competencias || {});
+    const matchedKey = keys.find(k => norm.includes(k) || k.includes(norm)) || keys[0];
+    if (matchedKey && activeGuidelines.competencias[matchedKey]) {
+      return activeGuidelines.competencias[matchedKey];
+    }
+    return {
+      competencias: ['Comunicación y representación', 'Razonamiento lógico', 'Resolución de problemas'],
+      componentes: ['Conceptual', 'Procedimental', 'Aplicación contextual'],
+      color: '#f59e0b'
+    };
+  });
 </script>
 
 <div class="space-y-8">
@@ -109,14 +249,22 @@
             </p>
           </div>
 
-          <div class="pt-6 mt-4 border-t border-white/5">
+          <div class="pt-6 mt-4 border-t border-white/5 flex flex-wrap items-center gap-2">
             {#if pillar.href}
               <a
                 href={pillar.href}
-                class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 hover:bg-amber-500 hover:text-black text-amber-300 text-xs font-bold uppercase tracking-wider border border-white/10 transition-all"
+                class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 text-white text-xs font-bold uppercase tracking-wider border border-white/10 transition-all"
               >
                 {pillar.actionLabel} →
               </a>
+              {#if pillar.href === '/sala-examenes'}
+                <a
+                  href={`/sala-examenes?quickLaunch=10&subject=${encodeURIComponent(selectedSubject)}&grade=${selectedGrade}`}
+                  class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-400 text-black text-xs font-bold uppercase tracking-wider shadow-md shadow-amber-500/20 active:scale-95 transition-all"
+                >
+                  ⚡ Lanzar Quiz Rápido (10 Preguntas)
+                </a>
+              {/if}
             {:else if pillar.tabTarget}
               <button
                 type="button"
@@ -186,6 +334,56 @@
         </div>
       </div>
 
+      <!-- Subject & Competency Deep-Dive Box -->
+      <div class="p-5 bg-black/40 border border-amber-500/30 rounded-xl space-y-3">
+        <div class="flex items-center justify-between border-b border-white/10 pb-2">
+          <div class="flex items-center gap-2">
+            <span class="text-base">🎯</span>
+            <h4 class="text-xs font-bold uppercase tracking-wider text-amber-300">
+              Competencias Evaluadas en {selectedSubject} ({activeGuidelines.authorityName})
+            </h4>
+          </div>
+          <span class="text-[10px] font-mono text-white/50">{activeGuidelines.badgeLabel}</span>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-xs">
+          <div>
+            <span class="block text-[10px] font-bold uppercase text-white/40 mb-1">Competencias Oficiales</span>
+            <ul class="space-y-1">
+              {#each currentCompetencyData.competencias as comp}
+                <li class="flex items-center gap-1.5 text-white/90">
+                  <span class="text-amber-400 font-bold">•</span>
+                  <span>{comp}</span>
+                </li>
+              {/each}
+            </ul>
+          </div>
+          <div>
+            <span class="block text-[10px] font-bold uppercase text-white/40 mb-1">Componentes Curriculares</span>
+            <div class="flex flex-wrap gap-1.5">
+              {#each currentCompetencyData.componentes as comp}
+                <span class="px-2 py-0.5 rounded bg-amber-500/10 text-amber-200 border border-amber-500/20 text-[11px]">
+                  {comp}
+                </span>
+              {/each}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Options: Answer Key Toggle -->
+      <div class="p-4 bg-white/5 border border-white/10 rounded-xl flex items-center justify-between">
+        <label class="flex items-center gap-3 cursor-pointer text-xs font-semibold text-white/90">
+          <input
+            type="checkbox"
+            bind:checked={includeAnswerKey}
+            class="w-4 h-4 rounded border-white/20 bg-black/40 text-amber-500 focus:ring-amber-500/40 focus:ring-offset-0"
+          />
+          <span>Incluir hoja de respuestas y justificación pedagógica</span>
+        </label>
+        <span class="text-[10px] text-amber-400/80 font-mono">Recomendado para docentes</span>
+      </div>
+
       <div class="flex justify-end gap-3 pt-2">
         <button
           type="button"
@@ -204,13 +402,35 @@
               <span class="text-[10px] uppercase tracking-widest text-amber-400 font-bold">Documento Listo</span>
               <h4 class="text-lg font-bold text-white">Taller de {selectedSubject} — Grado {selectedGrade}° ({workshopQuestionCount} preguntas)</h4>
             </div>
-            <button
-              type="button"
-              onclick={printWorkshop}
-              class="px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-white text-xs font-bold uppercase tracking-wider flex items-center gap-2 border border-white/10"
-            >
-              🖨️ Imprimir / Guardar PDF
-            </button>
+            <div class="flex flex-wrap items-center gap-2">
+              <a
+                href={`/sala-examenes?quickLaunch=${workshopQuestionCount}&subject=${encodeURIComponent(selectedSubject)}&grade=${selectedGrade}`}
+                class="px-3 py-1.5 rounded-lg bg-amber-500 hover:bg-amber-400 text-black text-xs font-bold uppercase tracking-wider shadow-md shadow-amber-500/20 transition-all flex items-center gap-1.5"
+              >
+                ⚡ Lanzar en Sala P2P
+              </a>
+              <button
+                type="button"
+                onclick={exportMarkdown}
+                class="px-3 py-1.5 rounded-lg bg-amber-500/20 hover:bg-amber-500 hover:text-black text-amber-300 text-xs font-bold uppercase tracking-wider border border-amber-500/30 transition-all flex items-center gap-1.5"
+              >
+                📥 Exportar .md
+              </button>
+              <button
+                type="button"
+                onclick={exportHTML}
+                class="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/20 text-white text-xs font-bold uppercase tracking-wider border border-white/10 transition-all flex items-center gap-1.5"
+              >
+                🌐 Exportar HTML
+              </button>
+              <button
+                type="button"
+                onclick={printWorkshop}
+                class="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/20 text-white text-xs font-bold uppercase tracking-wider flex items-center gap-1.5 border border-white/10 transition-all"
+              >
+                🖨️ Imprimir PDF
+              </button>
+            </div>
           </div>
 
           <div class="text-xs text-white/70 space-y-2">

--- a/saberparatodos/src/modules/exam-room/components/RoomApp.svelte
+++ b/saberparatodos/src/modules/exam-room/components/RoomApp.svelte
@@ -28,7 +28,49 @@
     return 'edge-mesh';
   }
 
-  // Detectar backend + ?join=CODE (ruta /sala-examenes)
+  let hasAutoLaunched = $state(false);
+
+  async function autoQuickLaunch(count: number, subject: string, grade: number) {
+    if (hasAutoLaunched) return;
+    hasAutoLaunched = true;
+
+    hostName = hostName || 'Docente (Quick Launch)';
+    roomName = roomName || `Quiz Rápido de ${subject} - ${grade}°`;
+    selectedGrade = grade;
+    selectedSubject = subject;
+
+    try {
+      const roomId = await roomState.createRoom(
+        hostName,
+        roomName,
+        selectedGrade,
+        selectedSubject,
+        {
+          connectionMode: preferredConnectionMode(),
+          maxPlayers: 100,
+          timePerQuestion: 60,
+          totalQuestions: count,
+          mode: 'standard'
+        }
+      );
+
+      localMeshPairing.announceRoom({
+        code: roomId || roomState.config?.id || 'ROOM',
+        name: roomName,
+        hostName: hostName,
+        subject: selectedSubject,
+        grade: selectedGrade,
+      });
+
+      roomCode = roomId || roomState.config?.id || 'ROOM';
+      view = 'lobby';
+    } catch (error) {
+      console.error('Error during quick-launch creation:', error);
+      view = 'home';
+    }
+  }
+
+  // Detectar backend + ?join=CODE / ?quickLaunch=10 (ruta /sala-examenes)
   $effect(() => {
     detectBackendMode().then((mode) => {
       backendMode = mode === 'rust' ? 'rust' : 'edge-mesh';
@@ -36,10 +78,18 @@
     });
 
     if (typeof window !== 'undefined') {
-      const join = new URLSearchParams(window.location.search).get('join');
+      const params = new URLSearchParams(window.location.search);
+      const join = params.get('join');
+      const quickLaunch = params.get('quickLaunch');
+
       if (join) {
         roomCode = join;
         view = 'join';
+      } else if (quickLaunch && !hasAutoLaunched) {
+        const count = parseInt(quickLaunch, 10) || 10;
+        const subj = params.get('subject') || 'Matemáticas';
+        const grd = parseInt(params.get('grade') || '11', 10) || 11;
+        autoQuickLaunch(count, subj, grd);
       }
     }
   });


### PR DESCRIPTION
Refines the Teacher Toolkit experience in /docentes and /sala-examenes:
1. Interactive Workshop Exporter: Allows downloading generated workshops as Markdown (.md) or standalone HTML documents in addition to window.print(). Includes a toggle for including/excluding answer keys and pedagogical justifications.
2. Subject & Competency Deep-Dive: Displays official evaluation competencies (e.g. Comunicación, Razonamiento, Resolución de Problemas) and components based on runtimeCountry and selected subject via getAuthorityGuidelines.
3. P2P Room Quick-Launch: Adds 1-click quick launch buttons from TeacherToolkit.svelte into /sala-examenes, with URL parameter detection in RoomApp.svelte for automatic room creation and lobby initialization.

Fixes #1158

---
*PR created automatically by Jules for task [8429496834142775886](https://jules.google.com/task/8429496834142775886) started by @iberi22*