### PR TITLE
🎨 Palette: Add aria-labels to header icon buttons in App.svelte

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 ## 2024-11-20 - [Add explicit type="button" to action buttons]
 **Learning:** Svelte buttons without an explicit `type` attribute inside potentially reactive contexts can sometimes be misinterpreted by assistive technologies or unexpectedly trigger form submissions if wrapped later. Adding `type="button"` ensures consistent, predictable behavior.
 **Action:** Always explicitly declare `type="button"` for interactive `<button>` elements that are not intended to submit forms.
+## 2026-08-30 - Add aria-labels and type to icon-only buttons
+**Learning:** Icon-only buttons frequently rely solely on `title` attributes for tooltips, which are insufficient for screen readers. They also often lack `type="button"`, causing unexpected behavior in forms.
+**Action:** Always add explicit `aria-label` attributes and `type="button"` to icon-only buttons to ensure they are accessible and predictable across devices and contexts.

--- a/saberparatodos/src/components/App.svelte
+++ b/saberparatodos/src/components/App.svelte
@@ -993,9 +993,11 @@
         <div class="flex items-center gap-2">
           <!-- Profile Icon - Opens OfflineProfile modal -->
           <button
+            type="button"
             onclick={() => showOfflineProfile = true}
             class="p-2 text-white/40 hover:text-indigo-400 transition-colors"
             title="Mi Perfil Offline"
+            aria-label="Mi Perfil Offline"
           >
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
@@ -1003,9 +1005,11 @@
           </button>
           <!-- Local Reports Icon - Opens LocalReportsView modal -->
           <button
+            type="button"
             onclick={() => showLocalReports = true}
             class="p-2 text-white/40 hover:text-emerald-500 transition-colors"
             title="Ver Historial Local"
+            aria-label="Ver Historial Local"
           >
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />


### PR DESCRIPTION
💡 What: Added `aria-label` and `type="button"` attributes to icon-only buttons in the application header.
🎯 Why: Icon-only buttons often rely on `title` attributes alone, which aren't fully read by screen readers. Adding `aria-label` makes the UI fully accessible to all users. Adding `type="button"` prevents unpredictable form submissions in the future.
📸 Before/After: Visuals are unchanged. Underlying HTML now includes screen reader text.
♿ Accessibility: Improves accessibility for the Profile and Local Reports icon buttons in `App.svelte` by adding descriptive text for assistive tech.

---
*PR created automatically by Jules for task [5337760961838313190](https://jules.google.com/task/5337760961838313190) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved screen-reader support for the Offline Profile and Local Reports header buttons with descriptive labels.
  - Prevented these buttons from triggering unintended form submissions.
- **Documentation**
  - Added guidance on accessible labeling and button behavior for icon-only controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->