### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 ## 2024-11-20 - [Add explicit type="button" to action buttons]
 **Learning:** Svelte buttons without an explicit `type` attribute inside potentially reactive contexts can sometimes be misinterpreted by assistive technologies or unexpectedly trigger form submissions if wrapped later. Adding `type="button"` ensures consistent, predictable behavior.
 **Action:** Always explicitly declare `type="button"` for interactive `<button>` elements that are not intended to submit forms.
+## 2024-05-18 - Icon-only Buttons (Emoji vs SVG)
+**Learning:** Emoji-based icon-only buttons (like `🔄` or `📋`) often get overlooked for accessibility because they lack the complex SVG markup that typically triggers accessibility warnings, but they are just as opaque to screen readers if they lack an `aria-label`.
+**Action:** Always check both SVG and emoji icon-only buttons for `aria-label` attributes to ensure consistent screen reader support.

--- a/saberparatodos/src/components/ExamConfigModal.svelte
+++ b/saberparatodos/src/components/ExamConfigModal.svelte
@@ -1425,6 +1425,7 @@
             <button
               onclick={handleResetMemory}
               class="text-[10px] uppercase tracking-widest px-2 py-1 rounded border transition-all duration-200 {showResetConfirm ? 'bg-red-500/20 border-red-500 text-red-400' : 'border-white/20 text-white/40 hover:text-white/60 hover:border-white/40'}"
+              aria-label={showResetConfirm ? 'Confirmar reinicio de configuración' : 'Reiniciar configuración'}
             >
               {showResetConfirm ? '¿Confirmar?' : '🔄 Reiniciar'}
             </button>
@@ -1609,6 +1610,7 @@
                     <button
                       onclick={copyShareUrl}
                       class="px-4 py-2 rounded text-xs font-bold uppercase {copied ? 'bg-emerald-500' : 'bg-white/10 hover:bg-white/20'}"
+                      aria-label="Copiar enlace"
                     >
                       {copied ? '✓' : '📋'}
                     </button>

--- a/saberparatodos/src/components/ai/TutorPanel.svelte
+++ b/saberparatodos/src/components/ai/TutorPanel.svelte
@@ -139,6 +139,7 @@
           class={`px-2 py-1 rounded-lg border text-xs font-bold ${listening ? 'bg-red-500/30 border-red-400/40 text-red-100' : 'bg-sky-500/20 border-sky-400/30 text-sky-100'}`}
           disabled={busy}
           onclick={toggleMic}
+          aria-label={listening ? 'Detener grabación' : 'Iniciar grabación'}
         >{listening ? '■' : '🎤'}</button>
       </div>
     </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to emoji-based icon-only buttons in `ExamConfigModal.svelte` and `TutorPanel.svelte`.
🎯 **Why:** To improve accessibility for screen reader users, who otherwise cannot decipher the purpose of buttons that only contain emojis like `📋`, `🔄`, and `🎤`.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now correctly announce actions like "Copiar enlace", "Reiniciar configuración", "Confirmar reinicio de configuración", "Iniciar grabación" and "Detener grabación".

---
*PR created automatically by Jules for task [14234054241852452635](https://jules.google.com/task/14234054241852452635) started by @iberi22*