### PR TITLE
feat(ci-cd): add coverage thresholds and security history rewrite docs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,7 @@
 # Workflows disabled (GitCore 3.8 / SWAL private era)
 
-Active definitions live in `../workflows.disabled/`.
-GitHub will not run them while they are outside `workflows/`.
-Re-enable only with an exception in `.gitcore/ARCHITECTURE.md`.
+Note: Workflows disabled intentional GitCore private era, enable on public.
+Active definitions live in `../workflows-disabled/`.
+GitHub Actions workflows are intentionally disabled during the GitCore private era and will be re-enabled upon transitioning to public.
+GitHub will not run them while they are outside `workflows/` or disabled.
+Re-enable only with an exception in `.gitcore/ARCHITECTURE.md` or upon public transition.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -99,6 +99,26 @@ Actualmente **no** contamos con un programa formal de recompensas por bugs. Como
 
 ---
 
+## 🧹 History Rewrite (221)
+
+Para remediar y depurar completamente tokens, llaves o secrets expuestos en commits antiguos dentro del historial de Git (referenciado en el issue #221), se sigue el procedimiento estandarizado con `git-filter-repo`.
+
+### Script y Ejecución en Seco (`scripts/security-221-history-rewrite.sh`)
+
+1. **Modo Dry-Run (Verificación sin modificación):**
+   Antes de reescribir el historial o aplicar cambios irreversibles en las ramas, se debe ejecutar el script `scripts/security-221-history-rewrite.sh` en modo `--dry-run` para auditar la presencia de patrones o archivos sensibles:
+   ```bash
+   bash scripts/security-221-history-rewrite.sh --dry-run
+   ```
+
+2. **Reescritura de Historial con `git-filter-repo`:**
+   Tras validar los hallazgos en modo dry-run, el proceso elimina de forma permanente cualquier string de credenciales o archivo sensible del árbol de commits.
+
+3. **Nota de Coordinación con BELA:**
+   > ⚠️ **IMPORTANTE:** Ninguna reescritura de historial real (`force-push`) se debe ejecutar directamente en `main` sin la coordinación y aprobación explícita previa con BELA (@iberi22). Todo test de reescritura en ramas o entornos locales debe ser estrictamente dry-run.
+
+---
+
 ## 🔍 Alcance de Seguridad
 
 ### Incluido

--- a/saberparatodos/vitest.config.ts
+++ b/saberparatodos/vitest.config.ts
@@ -28,6 +28,10 @@ export default defineConfig(({ mode }) => {
         reporter: ['text', 'json', 'html'],
         include: ['src/lib/**/*.ts', 'src/utils/**/*.ts', 'src/modules/**/*.ts', 'src/modules/**/*.svelte.ts'],
         exclude: ['src/env.d.ts', 'src/**/*.d.ts'],
+        thresholds: {
+          lines: 46,
+          branches: 40,
+        },
       },
     },
   };


### PR DESCRIPTION
This PR hardens CI/CD and security configuration by setting honest Vitest coverage thresholds (lines: 46%, branches: 40%) in `saberparatodos/vitest.config.ts`, documenting history rewrite procedures and BELA coordination in `docs/SECURITY.md`, and documenting workflow readiness in `.github/workflows/README.md`.

Fixes #1188

---
*PR created automatically by Jules for task [14744923333869839447](https://jules.google.com/task/14744923333869839447) started by @iberi22*