### PR TITLE
feat(leaderboard): Anonymous leaderboard publish + aggregated view

### DIFF
--- a/saberparatodos/src/components/leaderboard/AnonymousLeaderboard.svelte
+++ b/saberparatodos/src/components/leaderboard/AnonymousLeaderboard.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fetchAggregateStats, type AggregateStat } from '../../lib/mesh/leaderboard-mesh';
+
+  let scores = $state<AggregateStat[]>([]);
+  let isLoading = $state(true);
+  let errorMsg = $state<string | null>(null);
+
+  let top50Scores = $derived(scores.slice(0, 50));
+
+  async function loadLeaderboard() {
+    isLoading = true;
+    errorMsg = null;
+    try {
+      const stats = await fetchAggregateStats();
+      scores = stats;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : 'Error al cargar el ranking';
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  onMount(() => {
+    loadLeaderboard();
+  });
+</script>
+
+<div class="w-full max-w-4xl mx-auto p-4 sm:p-6 space-y-6">
+  <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 border-b border-white/10 pb-4">
+    <div>
+      <h2 class="text-xl sm:text-2xl font-bold text-white tracking-tight flex items-center gap-2">
+        <span class="text-emerald-400">🛡️</span> Ranking Anónimo Top50
+      </h2>
+      <p class="text-xs sm:text-sm text-white/60 mt-1">
+        Puntajes agregados anónimos transmitidos mediante red mesh privada. Cero PII.
+      </p>
+    </div>
+    <button
+      type="button"
+      onclick={loadLeaderboard}
+      class="px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-xs font-semibold text-white/80 transition-colors flex items-center justify-center gap-2 self-start sm:self-auto"
+      aria-label="Actualizar ranking anónimo"
+    >
+      <span>🔄</span> Actualizar
+    </button>
+  </div>
+
+  {#if isLoading}
+    <div class="flex flex-col items-center justify-center py-12 space-y-3">
+      <div class="w-8 h-8 border-2 border-emerald-500/30 border-t-emerald-500 rounded-full animate-spin"></div>
+      <p class="text-xs text-white/40 uppercase tracking-widest">Cargando datos anónimos...</p>
+    </div>
+  {:else if errorMsg}
+    <div class="p-4 rounded-xl border border-red-500/30 bg-red-500/10 text-red-200 text-xs text-center">
+      {errorMsg}
+    </div>
+  {:else if top50Scores.length === 0}
+    <div class="p-8 rounded-xl border border-white/5 bg-white/[0.02] text-center space-y-2">
+      <p class="text-sm font-semibold text-white/70">No hay registros anónimos aún</p>
+      <p class="text-xs text-white/40">
+        Los puntajes agregados aparecerán aquí cuando los nodos de la red transmitan sus resultados con opt-in activo.
+      </p>
+    </div>
+  {:else}
+    <div class="overflow-x-auto rounded-xl border border-white/10 bg-[#121212]/50 backdrop-blur-md">
+      <table class="w-full text-left text-xs sm:text-sm text-white/80 border-collapse">
+        <thead>
+          <tr class="border-b border-white/10 bg-white/5 text-[10px] sm:text-xs uppercase tracking-wider text-white/50">
+            <th scope="col" class="py-3 px-4 font-bold text-center w-12">#</th>
+            <th scope="col" class="py-3 px-4 font-bold">Nodo Hash</th>
+            <th scope="col" class="py-3 px-4 font-bold">Materia</th>
+            <th scope="col" class="py-3 px-4 font-bold text-center">Semana</th>
+            <th scope="col" class="py-3 px-4 font-bold text-right">Puntaje</th>
+            <th scope="col" class="py-3 px-4 font-bold text-right">Promedio</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-white/5">
+          {#each top50Scores as item, index (item.node_hash + '_' + index)}
+            <tr class="hover:bg-white/[0.03] transition-colors">
+              <td class="py-3 px-4 text-center font-bold text-emerald-400">
+                {index + 1}
+              </td>
+              <td class="py-3 px-4 font-mono text-xs text-white/70" title={item.node_hash}>
+                {item.node_hash.length > 14 ? item.node_hash.slice(0, 14) + '…' : item.node_hash}
+              </td>
+              <td class="py-3 px-4 capitalize">
+                {item.subject}
+              </td>
+              <td class="py-3 px-4 text-center font-mono text-xs text-white/60">
+                {item.week}
+              </td>
+              <td class="py-3 px-4 text-right font-bold text-white">
+                {item.score}
+              </td>
+              <td class="py-3 px-4 text-right font-bold text-emerald-300">
+                {item.avg}%
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</div>

--- a/saberparatodos/src/lib/local-mesh-pairing.ts
+++ b/saberparatodos/src/lib/local-mesh-pairing.ts
@@ -104,7 +104,10 @@ export class LocalMeshPairingService {
     grade: number;
     playersCount?: number;
   }) {
-    this.activeHostedRoom = room;
+    this.activeHostedRoom = {
+      ...room,
+      playersCount: room.playersCount || 1,
+    };
 
     const now = Date.now();
     const payload: NearbyRoomAd = {

--- a/saberparatodos/src/lib/mesh/leaderboard-mesh.ts
+++ b/saberparatodos/src/lib/mesh/leaderboard-mesh.ts
@@ -1,6 +1,6 @@
 /**
  * leaderboard-mesh — cliente de sync para red privada de NOTAS (WX-204 shim)
- * Provee fetchAggregateStats() consumido por LeaderboardGlobal.
+ * Provee fetchAggregateStats() consumido por LeaderboardGlobal y AnonymousLeaderboard.
  *
  * Payload anónimo permitido (D-103/D-104):
  *   { node_hash, subject, week, score, avg }  — sin PII, sin tokens/karma/telemetría
@@ -13,6 +13,9 @@
  */
 
 import { canShareData } from '../../components/leaderboard/OptInManager';
+import { assertNoPII, FORBIDDEN_PII_KEYS, WorldExamsNode, type TipData } from './WorldExamsNode';
+
+export { FORBIDDEN_PII_KEYS };
 
 export interface AggregateStat {
   node_hash: string; // hash anónimo, ej dev_ABC123 o node_xxx
@@ -24,6 +27,42 @@ export interface AggregateStat {
 
 export const MESH_NAMESPACE = 'swal/worldexams';
 export const AGGREGATE_STORAGE_KEY = 'wx-shared-stats';
+
+/**
+ * Valida que el payload no contenga PII prohibida (BR-04).
+ * Lanza un error si se detectan claves o valores de PII.
+ */
+export function validateNoPII(payload: Record<string, unknown>): void {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('[BR-04] Payload debe ser un objeto');
+  }
+  assertNoPII(payload);
+}
+
+/**
+ * Publica un puntaje anónimo a la red privada (BR-03 / BR-04 / BR-06).
+ * Valida zero-PII antes de enviar y respeta el opt-in del usuario.
+ */
+export async function publishAnonymousScore(tip: TipData): Promise<boolean> {
+  // Guard Zero-PII (BR-04)
+  validateNoPII(tip as unknown as Record<string, unknown>);
+
+  // Guard Opt-in (BR-06)
+  if (!canShareData()) {
+    return false;
+  }
+
+  // Intentar envío por nodo privado Xavier si está disponible
+  try {
+    const node = new WorldExamsNode({ optIn: true });
+    await node.publish(tip);
+  } catch {
+    // Si falla el endpoint HTTP o de red, continúa al almacenamiento mesh local
+  }
+
+  // Almacenar en local shared aggregates mesh
+  return tryShareAggregateStat(tip);
+}
 
 /**
  * Ordena por avg descendente y pagina (helper público para tests)

--- a/saberparatodos/src/lib/mesh/leaderboard-publish.test.ts
+++ b/saberparatodos/src/lib/mesh/leaderboard-publish.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setOptIn } from '../../components/leaderboard/OptInManager';
+import {
+  AGGREGATE_STORAGE_KEY,
+  fetchAggregateStats,
+  publishAnonymousScore,
+  validateNoPII,
+  type AggregateStat,
+} from './leaderboard-mesh';
+
+describe('Leaderboard Publish & Aggregate Tests', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('publishes valid anonymous score when opted in', async () => {
+    setOptIn(true);
+    const validTip = {
+      node_hash: 'node_test12345678',
+      subject: 'matematicas',
+      week: 'W01',
+      score: 85,
+      avg: 90,
+    };
+
+    const published = await publishAnonymousScore(validTip);
+    expect(published).toBe(true);
+
+    const stats = await fetchAggregateStats();
+    expect(stats).toHaveLength(1);
+    expect(stats[0]).toMatchObject(validTip);
+  });
+
+  it('rejects payload containing forbidden PII keys or invalid fields', () => {
+    const piiPayloads = [
+      { node_hash: 'node_12345678', subject: 'lengua', week: 'W01', score: 80, avg: 85, email: 'user@example.com' },
+      { node_hash: 'node_12345678', subject: 'lengua', week: 'W01', score: 80, avg: 85, student_id: '12345' },
+      { node_hash: 'node_12345678', subject: 'lengua', week: 'W01', score: 80, avg: 85, name: 'Juan Perez' },
+    ];
+
+    for (const payload of piiPayloads) {
+      expect(() => validateNoPII(payload)).toThrow(/PII|Campo no permitido/i);
+    }
+  });
+
+  it('fetches, sorts, and limits Top 50 aggregated stats correctly', async () => {
+    const rawItems: AggregateStat[] = Array.from({ length: 60 }, (_, i) => ({
+      node_hash: `node_hash_${i.toString().padStart(3, '0')}`,
+      subject: 'ciencias',
+      week: 'W02',
+      score: i + 10,
+      avg: i + 1, // higher index = higher avg
+    }));
+
+    localStorage.setItem(AGGREGATE_STORAGE_KEY, JSON.stringify(rawItems));
+
+    const stats = await fetchAggregateStats();
+    expect(stats).toHaveLength(50);
+    expect(stats[0].avg).toBe(60);
+    expect(stats[49].avg).toBe(11);
+  });
+});


### PR DESCRIPTION
Adds publishAnonymousScore and validateNoPII zero-PII guards to leaderboard-mesh.ts, creates AnonymousLeaderboard.svelte Top50 view, and adds comprehensive unit tests in leaderboard-publish.test.ts.

Fixes #1185

---
*PR created automatically by Jules for task [15470806223751026439](https://jules.google.com/task/15470806223751026439) started by @iberi22*