### PR TITLE
feat(pdf): add unit tests for PDF chunker, embeddings, and IndexedDB storage

### DIFF
--- a/saberparatodos/src/lib/ai/pdf/__tests__/chunker.test.ts
+++ b/saberparatodos/src/lib/ai/pdf/__tests__/chunker.test.ts
@@ -3,9 +3,12 @@ import { chunkText, chunkPages, estimateTokens } from '../chunker';
 import type { ExtractedPage } from '../extractor';
 
 describe('chunker — semantic chunking 512 tokens / overlap 50', () => {
-  it('estimateTokens aproxima tokens (words*1.3 vs chars/4)', () => {
+  it('estimateTokens aproxima tokens (1 token ≈ 4 chars / words*1.3)', () => {
     expect(estimateTokens('')).toBe(0);
     expect(estimateTokens('hola mundo')).toBeGreaterThan(0);
+    // 1 token ≈ 4 chars: 100 chars ≈ 25 tokens
+    const text100 = 'a'.repeat(100);
+    expect(estimateTokens(text100)).toBe(25);
     // 512 tokens ≈ 2048 chars
     const long = 'a '.repeat(1000);
     expect(estimateTokens(long)).toBeGreaterThan(400);
@@ -19,14 +22,14 @@ describe('chunker — semantic chunking 512 tokens / overlap 50', () => {
     expect(chunks[0].embedding).toBeUndefined();
   });
 
-  it('chunkText: 512 tokens respeta tamaño y overlap 50', () => {
+  it('chunkText: 512 tokens respeta tamaño y overlap 50 respetando párrafos y oraciones', () => {
     // Generar texto largo (~2000 tokens ≈ 8000 chars)
     const sentence = 'La fotosíntesis es el proceso mediante el cual las plantas convierten luz solar en energía química. ';
     const long = sentence.repeat(200); // ~ 200 * ~14 tokens ≈ 2800 tokens
     const chunks = chunkText(long, { chunkSize: 512, overlap: 50, docId: 'test' });
     expect(chunks.length).toBeGreaterThan(1);
     for (const c of chunks) {
-      // Permitir margen porque cortamos en oración: hasta 600 tokens
+      // Permitir margen porque cortamos en oración: hasta 650 tokens
       expect(c.tokenCount).toBeLessThanOrEqual(650);
       expect(c.tokenCount).toBeGreaterThan(0);
     }
@@ -86,9 +89,7 @@ describe('chunker — semantic chunking 512 tokens / overlap 50', () => {
       'Primera oración. Segunda oración. Tercera oración. '.repeat(100) +
       'Última oración final.';
     const chunks = chunkText(text, { chunkSize: 50, overlap: 5 });
-    // Cada chunk debería terminar cerca de un punto o espacio, no a mitad de palabra larga
     for (const c of chunks.slice(0, -1)) {
-      // El texto no debe terminar en mitad de una palabra sin espacio (heurística simple)
       expect(c.text.length).toBeGreaterThan(10);
     }
   });

--- a/saberparatodos/src/lib/ai/pdf/studio-chunk.test.ts
+++ b/saberparatodos/src/lib/ai/pdf/studio-chunk.test.ts
@@ -1,0 +1,90 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { chunkText, type Chunk } from './chunker';
+import { createEmbedder, EMBEDDING_DIMS } from './embedder';
+import { savePDFDoc, getPDFDoc, clearAllPDFDocs, type PDFDoc } from './storage';
+
+/**
+ * Helper to embed a list of chunks using local embedder.
+ * Attaches a 384-dimensional embedding Float32Array to each chunk.
+ */
+export async function embedChunks(chunks: Chunk[]): Promise<Chunk[]> {
+  const embedder = await createEmbedder({ forceMock: true });
+  const texts = chunks.map((c) => c.text);
+  const embeddings = await embedder.embedBatch(texts);
+  return chunks.map((c, i) => ({
+    ...c,
+    embedding: embeddings[i],
+  }));
+}
+
+/**
+ * Helper to persist chunks as a PDFDoc record in IndexedDB.
+ */
+export async function saveChunks(
+  hash: string,
+  chunks: Chunk[],
+  fileName = 'test.pdf'
+): Promise<PDFDoc> {
+  const doc: PDFDoc = {
+    id: hash,
+    hash,
+    fileName,
+    fileSize: 1024,
+    numPages: 1,
+    chunks,
+    metadata: { title: 'Test PDF', numPages: 1 },
+    createdAt: Date.now(),
+    modelId: 'Xenova/all-MiniLM-L6-v2',
+  };
+  await savePDFDoc(doc);
+  return doc;
+}
+
+/**
+ * Helper to load chunks and document metadata from IndexedDB for a given hash.
+ */
+export async function loadChunks(hash: string): Promise<PDFDoc | null> {
+  return getPDFDoc(hash);
+}
+
+describe('studio-chunk — PDF Studio chunk embedding & storage persistence', () => {
+  beforeEach(async () => {
+    await clearAllPDFDocs();
+  });
+
+  it('embedChunks returns 384 dim vectors for each chunk', async () => {
+    const text = 'Saber Para Todos es una plataforma educativa offline-first para estudiantes.';
+    const rawChunks = chunkText(text, { docId: 'doc-embed-test' });
+    expect(rawChunks.length).toBeGreaterThan(0);
+
+    const embedded = await embedChunks(rawChunks);
+    expect(embedded).toHaveLength(rawChunks.length);
+
+    for (const chunk of embedded) {
+      expect(chunk.embedding).toBeDefined();
+      expect(chunk.embedding).toBeInstanceOf(Float32Array);
+      expect(chunk.embedding?.length).toBe(EMBEDDING_DIMS); // 384 dims
+    }
+  });
+
+  it('saveChunks and loadChunks round-trip correctly with IndexedDB', async () => {
+    const text = 'Texto de prueba para verificar persistencia en IndexedDB con fake-indexeddb.';
+    const rawChunks = chunkText(text, { docId: 'doc-store-test' });
+    const chunksWithEmbeddings = await embedChunks(rawChunks);
+    const testHash = 'a1b2c3d4e5f6';
+
+    const savedDoc = await saveChunks(testHash, chunksWithEmbeddings, 'manual-studio.pdf');
+    expect(savedDoc.hash).toBe(testHash);
+    expect(savedDoc.chunks).toHaveLength(chunksWithEmbeddings.length);
+
+    const loadedDoc = await loadChunks(testHash);
+    expect(loadedDoc).not.toBeNull();
+    expect(loadedDoc?.hash).toBe(testHash);
+    expect(loadedDoc?.fileName).toBe('manual-studio.pdf');
+    expect(loadedDoc?.chunks).toHaveLength(chunksWithEmbeddings.length);
+    expect(loadedDoc?.chunks[0].text).toBe(rawChunks[0].text);
+    expect(loadedDoc?.chunks[0].embedding).toBeDefined();
+    expect(loadedDoc?.chunks[0].embedding?.length).toBe(384);
+  });
+});


### PR DESCRIPTION
Adds unit tests covering estimateTokens, chunkText 512/50 overlap paragraph splitting, embedChunks 384-dim vector generation, and saveChunks/loadChunks IndexedDB round-trip persistence.

Fixes #1205

---
*PR created automatically by Jules for task [5789681509352076404](https://jules.google.com/task/5789681509352076404) started by @iberi22*