### PR TITLE
feat(pdf): local embedder stub & IndexedDB storage

### DIFF
--- a/saberparatodos/src/lib/ai/pdf/__tests__/embedder.test.ts
+++ b/saberparatodos/src/lib/ai/pdf/__tests__/embedder.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  mockEmbedding,
+  createEmbedder,
+  generateEmbedding,
+  embedChunks,
+  EMBEDDING_DIMS,
+  DEFAULT_EMBEDDING_MODEL,
+  __resetPipelineForTests,
+} from '../embedder';
+import type { Chunk } from '../chunker';
+
+describe('embedder — MiniLM 384 dim local embedder stub', () => {
+  beforeEach(() => {
+    __resetPipelineForTests();
+  });
+
+  it('mockEmbedding genera un Float32Array de 384 dimensiones normalizado L2', () => {
+    const text = 'Texto de prueba para embedding';
+    const vec = mockEmbedding(text);
+    expect(vec).toBeInstanceOf(Float32Array);
+    expect(vec.length).toBe(384);
+    expect(vec.length).toBe(EMBEDDING_DIMS);
+
+    // L2 norm sum(vec[i]^2) ≈ 1
+    let sumSq = 0;
+    for (let i = 0; i < vec.length; i++) {
+      sumSq += vec[i] * vec[i];
+    }
+    expect(sumSq).toBeCloseTo(1, 2);
+  });
+
+  it('mockEmbedding es determinístico para el mismo texto', () => {
+    const text = 'El mismo texto da el mismo vector';
+    const vec1 = mockEmbedding(text);
+    const vec2 = mockEmbedding(text);
+    expect(Array.from(vec1)).toEqual(Array.from(vec2));
+  });
+
+  it('createEmbedder con forceMock devuelve un Embedder local de 384 dims', async () => {
+    const embedder = await createEmbedder({ forceMock: true });
+    expect(embedder.modelId).toBe(DEFAULT_EMBEDDING_MODEL);
+    expect(embedder.dims).toBe(384);
+
+    const vec = await embedder.embed('Prueba embed');
+    expect(vec).toBeInstanceOf(Float32Array);
+    expect(vec.length).toBe(384);
+
+    const batch = await embedder.embedBatch(['Texto A', 'Texto B']);
+    expect(batch).toHaveLength(2);
+    expect(batch[0].length).toBe(384);
+    expect(batch[1].length).toBe(384);
+  });
+
+  it('generateEmbedding genera un vector de 384 dimensiones', async () => {
+    const vec = await generateEmbedding('Un solo texto', { forceMock: true });
+    expect(vec).toBeInstanceOf(Float32Array);
+    expect(vec.length).toBe(384);
+  });
+
+  it('embedChunks asigna embeddings Float32Array(384) a una lista de chunks', async () => {
+    const chunks: Chunk[] = [
+      {
+        id: 'chunk-0001',
+        text: 'Primer chunk de información sobre ciencias.',
+        page: 1,
+        offset: 0,
+        tokenCount: 8,
+      },
+      {
+        id: 'chunk-0002',
+        text: 'Segundo chunk sobre matemáticas y álgebra.',
+        page: 1,
+        offset: 50,
+        tokenCount: 7,
+      },
+    ];
+
+    const embedded = await embedChunks(chunks, { forceMock: true });
+    expect(embedded).toHaveLength(2);
+    for (const c of embedded) {
+      expect(c.embedding).toBeDefined();
+      expect(c.embedding).toBeInstanceOf(Float32Array);
+      expect(c.embedding!.length).toBe(384);
+    }
+  });
+
+  it('embedChunks con arreglo vacío devuelve []', async () => {
+    const embedded = await embedChunks([]);
+    expect(embedded).toEqual([]);
+  });
+});

--- a/saberparatodos/src/lib/ai/pdf/__tests__/storage.test.ts
+++ b/saberparatodos/src/lib/ai/pdf/__tests__/storage.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  saveChunks,
+  loadChunks,
+  getChunksKey,
+  savePDFDoc,
+  getPDFDoc,
+  listPDFDocs,
+  deletePDFDoc,
+  clearAllPDFDocs,
+  hashBuffer,
+  type PDFDoc,
+} from '../storage';
+import type { Chunk } from '../chunker';
+
+describe('storage — IndexedDB / idb 100% local PDF storage', () => {
+  beforeEach(async () => {
+    await clearAllPDFDocs();
+  });
+
+  it('getChunksKey genera la clave con prefijo pdf-chunks-', () => {
+    const hash = 'abc12345';
+    expect(getChunksKey(hash)).toBe('pdf-chunks-abc12345');
+  });
+
+  it('saveChunks y loadChunks guardan y recuperan chunks por hash', async () => {
+    const hash = 'hash-test-chunks-1';
+    const chunks: Chunk[] = [
+      {
+        id: 'chunk-1',
+        text: 'Contenido del chunk 1',
+        page: 1,
+        offset: 0,
+        tokenCount: 5,
+        embedding: new Float32Array(384),
+      },
+      {
+        id: 'chunk-2',
+        text: 'Contenido del chunk 2',
+        page: 2,
+        offset: 25,
+        tokenCount: 5,
+      },
+    ];
+
+    await saveChunks(hash, chunks);
+    const loaded = await loadChunks(hash);
+
+    expect(loaded).toHaveLength(2);
+    expect(loaded[0].id).toBe('chunk-1');
+    expect(loaded[0].text).toBe('Contenido del chunk 1');
+    expect(loaded[1].id).toBe('chunk-2');
+  });
+
+  it('loadChunks con hash inexistente retorna []', async () => {
+    const loaded = await loadChunks('hash-inexistente');
+    expect(loaded).toEqual([]);
+  });
+
+  it('hashBuffer genera un hash consistente', async () => {
+    const encoder = new TextEncoder();
+    const buffer = encoder.encode('Hola mundo PDF').buffer;
+    const h1 = await hashBuffer(buffer);
+    const h2 = await hashBuffer(buffer);
+    expect(typeof h1).toBe('string');
+    expect(h1.length).toBeGreaterThan(0);
+    expect(h1).toBe(h2);
+  });
+
+  it('savePDFDoc y getPDFDoc guardan y obtienen un PDFDoc completo', async () => {
+    const hash = 'pdf-doc-hash-100';
+    const doc: PDFDoc = {
+      id: hash,
+      hash,
+      fileName: 'ejemplo.pdf',
+      fileSize: 1024,
+      numPages: 3,
+      chunks: [
+        {
+          id: 'chunk-1',
+          text: 'Texto página 1',
+          page: 1,
+          offset: 0,
+          tokenCount: 3,
+        },
+      ],
+      metadata: {
+        numPages: 3,
+        info: { Title: 'Documento Ejemplo' },
+      },
+      createdAt: Date.now(),
+    };
+
+    await savePDFDoc(doc);
+    const loaded = await getPDFDoc(hash);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded?.hash).toBe(hash);
+    expect(loaded?.fileName).toBe('ejemplo.pdf');
+    expect(loaded?.chunks).toHaveLength(1);
+  });
+
+  it('listPDFDocs no incluye las entradas internas de chunks (pdf-chunks-)', async () => {
+    const docHash = 'pdf-doc-hash-200';
+    const doc: PDFDoc = {
+      id: docHash,
+      hash: docHash,
+      fileName: 'documento2.pdf',
+      fileSize: 2048,
+      numPages: 5,
+      chunks: [],
+      metadata: { numPages: 5, info: {} },
+      createdAt: Date.now(),
+    };
+
+    await savePDFDoc(doc);
+    await saveChunks(docHash, [{ id: 'c1', text: 'Chunk t', page: 1, offset: 0, tokenCount: 2 }]);
+
+    const docs = await listPDFDocs();
+    expect(docs.some((d) => d.hash === docHash)).toBe(true);
+    expect(docs.some((d) => d.hash.startsWith('pdf-chunks-'))).toBe(false);
+  });
+
+  it('deletePDFDoc elimina el documento', async () => {
+    const docHash = 'pdf-doc-to-delete';
+    const doc: PDFDoc = {
+      id: docHash,
+      hash: docHash,
+      fileName: 'borrar.pdf',
+      fileSize: 500,
+      numPages: 1,
+      chunks: [],
+      metadata: { numPages: 1, info: {} },
+      createdAt: Date.now(),
+    };
+
+    await savePDFDoc(doc);
+    await deletePDFDoc(docHash);
+
+    const loaded = await getPDFDoc(docHash);
+    expect(loaded).toBeNull();
+  });
+});

--- a/saberparatodos/src/lib/ai/pdf/embedder.ts
+++ b/saberparatodos/src/lib/ai/pdf/embedder.ts
@@ -5,6 +5,8 @@
  * Nunca envía texto a servidor. Fallback determinístico si el modelo no está disponible (tests / sin WebGPU).
  */
 
+import type { Chunk } from './chunker';
+
 export const DEFAULT_EMBEDDING_MODEL = 'Xenova/all-MiniLM-L6-v2';
 export const EMBEDDING_DIMS = 384;
 
@@ -171,6 +173,35 @@ export async function generateEmbedding(
   const vec = await embedder.embed(text);
   await embedder.dispose();
   return vec;
+}
+
+/**
+ * Asigna embeddings a un arreglo de chunks (384 dimensiones).
+ * Devuelve un nuevo arreglo de chunks con su propiedad `embedding: Float32Array(384)` poblada.
+ * Operación 100% local, sin consumo de red.
+ */
+export async function embedChunks(
+  chunks: Chunk[],
+  options: EmbedderOptions = {}
+): Promise<Chunk[]> {
+  if (!chunks || chunks.length === 0) return [];
+
+  try {
+    const embedder = await createEmbedder(options);
+    const texts = chunks.map((c) => c.text);
+    const vectors = await embedder.embedBatch(texts);
+    await embedder.dispose();
+
+    return chunks.map((c, idx) => ({
+      ...c,
+      embedding: vectors[idx] ?? mockEmbedding(c.text, EMBEDDING_DIMS),
+    }));
+  } catch {
+    return chunks.map((c) => ({
+      ...c,
+      embedding: mockEmbedding(c.text, EMBEDDING_DIMS),
+    }));
+  }
 }
 
 /** Para tests: resetea singleton */

--- a/saberparatodos/src/lib/ai/pdf/storage.ts
+++ b/saberparatodos/src/lib/ai/pdf/storage.ts
@@ -214,25 +214,100 @@ export async function getPDFDoc(hash: string): Promise<PDFDoc | null> {
 }
 
 export async function listPDFDocs(): Promise<PDFDoc[]> {
+  const isDoc = (d: any): d is PDFDoc => Boolean(d && d.fileName && d.hash && !String(d.hash).startsWith('pdf-chunks-'));
   if (!isIndexedDBAvailable()) {
     const agg = memoryFallback.get(AGGREGATE_DB);
     if (!agg) return [];
-    return Array.from(agg.values()) as PDFDoc[];
+    return (Array.from(agg.values()) as any[]).filter(isDoc);
   }
   const idb = await getIdb();
   if (!idb) {
     const agg = memoryFallback.get(AGGREGATE_DB);
-    return agg ? (Array.from(agg.values()) as PDFDoc[]) : [];
+    return agg ? (Array.from(agg.values()) as any[]).filter(isDoc) : [];
   }
   try {
     const db = await idb.openDB(AGGREGATE_DB, AGGREGATE_VERSION);
-    const docs = (await db.getAll(AGGREGATE_STORE)) as PDFDoc[];
+    const docs = (await db.getAll(AGGREGATE_STORE)) as any[];
     db.close();
-    return docs;
+    return docs.filter(isDoc);
   } catch {
     const agg = memoryFallback.get(AGGREGATE_DB);
-    return agg ? (Array.from(agg.values()) as PDFDoc[]) : [];
+    return agg ? (Array.from(agg.values()) as any[]).filter(isDoc) : [];
   }
+}
+
+// ---------- Operaciones de Chunks (key: pdf-chunks-{hash}) ----------
+
+export function getChunksKey(hash: string): string {
+  return `pdf-chunks-${hash}`;
+}
+
+/**
+ * Guarda los chunks asociados a un PDF por su hash en IndexedDB (idb).
+ * Usa la clave `pdf-chunks-{hash}` para persistencia local.
+ */
+export async function saveChunks(hash: string, chunks: Chunk[]): Promise<void> {
+  const key = getChunksKey(hash);
+  if (!isIndexedDBAvailable()) {
+    const m = memoryFallback.get(AGGREGATE_DB) ?? new Map<string, unknown>();
+    m.set(key, chunks);
+    memoryFallback.set(AGGREGATE_DB, m);
+    return;
+  }
+  const idb = await getIdb();
+  if (!idb) {
+    const m = memoryFallback.get(AGGREGATE_DB) ?? new Map<string, unknown>();
+    m.set(key, chunks);
+    memoryFallback.set(AGGREGATE_DB, m);
+    return;
+  }
+  try {
+    const db = await idb.openDB(AGGREGATE_DB, AGGREGATE_VERSION, {
+      upgrade(db: any) {
+        if (!db.objectStoreNames.contains(AGGREGATE_STORE)) {
+          db.createObjectStore(AGGREGATE_STORE, { keyPath: 'hash' });
+        }
+      },
+    });
+    await db.put(AGGREGATE_STORE, { hash: key, chunks, docHash: hash, updatedAt: Date.now() });
+    db.close();
+  } catch {
+    const m = memoryFallback.get(AGGREGATE_DB) ?? new Map<string, unknown>();
+    m.set(key, chunks);
+    memoryFallback.set(AGGREGATE_DB, m);
+  }
+}
+
+/**
+ * Carga los chunks guardados para un hash de PDF usando IndexedDB (idb).
+ */
+export async function loadChunks(hash: string): Promise<Chunk[]> {
+  const key = getChunksKey(hash);
+  if (!isIndexedDBAvailable()) {
+    const m = memoryFallback.get(AGGREGATE_DB);
+    return (m?.get(key) as Chunk[]) ?? [];
+  }
+  const idb = await getIdb();
+  if (!idb) {
+    const m = memoryFallback.get(AGGREGATE_DB);
+    return (m?.get(key) as Chunk[]) ?? [];
+  }
+  try {
+    const db = await idb.openDB(AGGREGATE_DB, AGGREGATE_VERSION, {
+      upgrade(db: any) {
+        if (!db.objectStoreNames.contains(AGGREGATE_STORE)) {
+          db.createObjectStore(AGGREGATE_STORE, { keyPath: 'hash' });
+        }
+      },
+    });
+    const record = await db.get(AGGREGATE_STORE, key);
+    db.close();
+    if (record && Array.isArray(record.chunks)) {
+      return record.chunks;
+    }
+  } catch {}
+  const m = memoryFallback.get(AGGREGATE_DB);
+  return (m?.get(key) as Chunk[]) ?? [];
 }
 
 export async function deletePDFDoc(hash: string): Promise<void> {


### PR DESCRIPTION
Enhanced saberparatodos local PDF embedder and storage modules:
- saberparatodos/src/lib/ai/pdf/embedder.ts: Exported embedChunks(chunks) returning 384-dimensional Float32Array embeddings 100% locally.
- saberparatodos/src/lib/ai/pdf/storage.ts: Exported saveChunks and loadChunks via idb IndexedDB using pdf-chunks-{hash} key prefix with in-memory fallback.
- Added comprehensive unit tests in embedder.test.ts and storage.test.ts.

Fixes #1204

---
*PR created automatically by Jules for task [10190002335071665160](https://jules.google.com/task/10190002335071665160) started by @iberi22*