### PR TITLE
feat(ai): bump pdfjs-dist 5.7 to 6.2 with legacy fallback guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
       "integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ci-info": "^4.4.0",
         "dset": "^3.1.4",
@@ -124,6 +125,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -140,6 +142,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -149,6 +152,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.2.tgz",
       "integrity": "sha512-rn7bsh2n2/Wm/blS7QO6+aKstNfEOygX35cACGQJP8tM2uLRfeNTTEawrUR6NpVr27mOMGnl6CSWQ0CNb8iGZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler-rs": "^0.3.1",
         "@astrojs/internal-helpers": "0.10.1",
@@ -265,6 +269,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
       "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=22"
       },
@@ -279,6 +284,7 @@
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -325,13 +331,15 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "apps/landing-worldexams/node_modules/neotraverse": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
       "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -386,6 +394,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
@@ -395,6 +404,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -529,6 +539,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.1.tgz",
       "integrity": "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
@@ -556,6 +567,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -572,6 +584,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -588,6 +601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -604,6 +618,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -620,6 +635,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -636,6 +652,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -649,6 +666,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^1.1.6"
       },
@@ -662,6 +680,7 @@
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -686,6 +705,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -702,6 +722,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -711,6 +732,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.1.tgz",
       "integrity": "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler-binding": "0.3.1"
       },
@@ -839,6 +861,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz",
       "integrity": "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/internal-helpers": "0.10.1",
         "@astrojs/prism": "4.0.2",
@@ -852,6 +875,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
       "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prismjs": "^1.30.0"
       },
@@ -1233,7 +1257,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@bruits/satteri-darwin-x64": {
       "version": "0.9.5",
@@ -1246,7 +1271,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@bruits/satteri-linux-arm64-gnu": {
       "version": "0.9.5",
@@ -1259,7 +1285,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@bruits/satteri-linux-arm64-musl": {
       "version": "0.9.5",
@@ -1272,7 +1299,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@bruits/satteri-linux-x64-gnu": {
       "version": "0.9.5",
@@ -1285,7 +1313,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@bruits/satteri-linux-x64-musl": {
       "version": "0.9.5",
@@ -1298,7 +1327,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@bruits/satteri-wasm32-wasi": {
       "version": "0.9.5",
@@ -1309,6 +1339,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
@@ -1324,6 +1355,7 @@
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -1347,7 +1379,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@bruits/satteri-win32-x64-msvc": {
       "version": "0.9.5",
@@ -1360,11 +1393,13 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontkitten": "^1.0.0"
       },
@@ -1375,6 +1410,7 @@
     "node_modules/@clack/core": {
       "version": "1.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sisteransi": "^1.0.5"
       }
@@ -1382,6 +1418,7 @@
     "node_modules/@clack/prompts": {
       "version": "1.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@clack/core": "1.1.0",
         "sisteransi": "^1.0.5"
@@ -3317,9 +3354,9 @@
       }
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
-      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.8.tgz",
+      "integrity": "sha512-/SaLcvlqGWdm0HSCWMgHu7cjJiQXfP8/mOY+6dUyV9flQz7sPBBZ+ed2zYtoukojPmxOaL7bm+d/G4GeWWoN7g==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -3333,23 +3370,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-x64": "0.1.100",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+        "@napi-rs/canvas-android-arm64": "1.0.8",
+        "@napi-rs/canvas-darwin-arm64": "1.0.8",
+        "@napi-rs/canvas-darwin-x64": "1.0.8",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.8",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.8",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.8",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.8",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.8",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.8",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.8",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.8"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
-      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.8.tgz",
+      "integrity": "sha512-5+nkh8i3gt6lqS/d2jTZ1xAn6tdgtB4Lf1mW6T0Qm5/rXNwBuV1sAEyLEWan5o9gJPU/GuvHR3rvSeZ+FaGrbw==",
       "cpu": [
         "arm64"
       ],
@@ -3367,9 +3404,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
-      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.8.tgz",
+      "integrity": "sha512-7jQ47gi+fZ7KJmfc/5rNyy1CYw/cu4kZ0KPIYbo9UUgSdW0bKQJpt+WihEor6s4Lyp7+xc3a+3HeyXmAEbbnPg==",
       "cpu": [
         "arm64"
       ],
@@ -3387,9 +3424,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
-      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.8.tgz",
+      "integrity": "sha512-rRjDMZs9pIRKGxgijwezplKc1RnJsqUokrA9h88bbTkqQ+7ePj0ZN4ZnZDy8Vu0tXs7KRlI2tQLaK4mx9QlxHg==",
       "cpu": [
         "x64"
       ],
@@ -3407,9 +3444,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
-      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.8.tgz",
+      "integrity": "sha512-jGcCd+8ra6Q61xKqZeiItujTpp9a9eRLcQ0jW6qYNku+WpupqOPFPY0SrsuSnXFviJwkpKYT9p7QrB4lsf3LNQ==",
       "cpu": [
         "arm"
       ],
@@ -3427,11 +3464,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
-      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.8.tgz",
+      "integrity": "sha512-od6I2Y7kU7i1SwZYG2EKW8rWz6JiedtPpko4WEe1DDsiikrfaotVBCRaUTM5/yeZKaZ92EatoAS+5xG+6uJlYA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3447,11 +3487,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
-      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.8.tgz",
+      "integrity": "sha512-yYkPbJDJiWj6N0gASA3CAvRypZmVpJnxU0DQg3aBhneLDQde9TPLKADsQkobNoJUtTT/lj46aWpzT48PDb3Qcg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3467,11 +3510,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
-      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.8.tgz",
+      "integrity": "sha512-PB00MSKAp4VwK/xwe6duKxRKmH8UH4GIl1pqHSbxng0jnU9Dr7FwaDypDiqwNFZ774N+8G7mJLGuLtg9NTcQsg==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3487,11 +3533,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
-      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.8.tgz",
+      "integrity": "sha512-TWM2XWJoitLiIPCvgJh7SriC+L/T9qkYCVzC66AidsZy0QP1hkKzBzVwshCdcA3q6fIn3yE0ISbq4lMJSy8jFw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3507,11 +3556,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
-      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.8.tgz",
+      "integrity": "sha512-hb20MxKXXb5IB7AAwN8UHz9WRsa2HmdZfjsDCzjElwJoeV1aotVEwFU4FrFQcYQVzsJQLeaCc/2Qdt/0Q72mMg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3527,9 +3579,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
-      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.8.tgz",
+      "integrity": "sha512-WwPN08IXE4SkL+FhJyPz/iFnycMAUkbphFIT4cmKLlvbSU0Zfn1R7BGJ3Hqky1S89QUYc0Q4IOScXb/42Re9wQ==",
       "cpu": [
         "arm64"
       ],
@@ -3547,9 +3599,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
-      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.8.tgz",
+      "integrity": "sha512-XkrVqKb+pxyba7kjy2LJvABFVBTE0DNpEl7MrG4OYUmaWarrXH+t54z/Czj2YxCKtizYTV4mg6phNm3x24qjhQ==",
       "cpu": [
         "x64"
       ],
@@ -3711,7 +3763,8 @@
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@oxc-project/types": {
       "version": "0.147.0",
@@ -4692,6 +4745,7 @@
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
@@ -4711,7 +4765,8 @@
     },
     "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
       "version": "2.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -6287,6 +6342,7 @@
       "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
       "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*"
       }
@@ -7227,6 +7283,7 @@
       "resolved": "https://registry.npmjs.org/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
       "integrity": "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "process-ancestry": "^0.1.0"
       },
@@ -7296,6 +7353,7 @@
     "node_modules/aria-query": {
       "version": "5.3.2",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7743,7 +7801,8 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/boolean": {
       "version": "3.2.0",
@@ -7989,6 +8048,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8137,6 +8197,7 @@
     "node_modules/common-ancestor-path": {
       "version": "2.0.0",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -8188,7 +8249,8 @@
     },
     "node_modules/cookie-es": {
       "version": "1.2.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -8237,6 +8299,7 @@
     "node_modules/crossws": {
       "version": "0.3.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -8286,6 +8349,7 @@
     "node_modules/css-select": {
       "version": "5.2.2",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -8311,6 +8375,7 @@
     "node_modules/css-what": {
       "version": "6.2.2",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       },
@@ -8331,6 +8396,7 @@
     "node_modules/csso": {
       "version": "5.0.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "~2.2.0"
       },
@@ -8342,6 +8408,7 @@
     "node_modules/csso/node_modules/css-tree": {
       "version": "2.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.0.28",
         "source-map-js": "^1.0.1"
@@ -8353,7 +8420,8 @@
     },
     "node_modules/csso/node_modules/mdn-data": {
       "version": "2.0.28",
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -8506,7 +8574,8 @@
     },
     "node_modules/defu": {
       "version": "6.1.7",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -8524,7 +8593,8 @@
     },
     "node_modules/destr": {
       "version": "2.0.5",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -8563,6 +8633,7 @@
     "node_modules/diff": {
       "version": "8.0.3",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -8584,6 +8655,7 @@
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -8596,6 +8668,7 @@
     "node_modules/dom-serializer/node_modules/entities": {
       "version": "4.5.0",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -8611,11 +8684,13 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -8639,6 +8714,7 @@
     "node_modules/domutils": {
       "version": "3.2.2",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -8665,6 +8741,7 @@
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
       "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9953,6 +10030,7 @@
       "resolved": "https://registry.npmjs.org/find-proc/-/find-proc-0.1.0.tgz",
       "integrity": "sha512-OaOpEYv2PiQ7SQ5LIrl+deA1XaWcxEjnpM6VuWXTUvn+teIXxeFTLDmu18/zDQpFmHN4o3oDBX+BT0AGwEhemg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -9995,6 +10073,7 @@
     "node_modules/flattie": {
       "version": "1.1.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10002,6 +10081,7 @@
     "node_modules/fontace": {
       "version": "0.4.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontkitten": "^1.0.2"
       }
@@ -10009,6 +10089,7 @@
     "node_modules/fontkitten": {
       "version": "1.0.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tiny-inflate": "^1.0.3"
       },
@@ -10209,6 +10290,7 @@
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
       "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -10221,7 +10303,8 @@
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -10384,6 +10467,7 @@
     "node_modules/h3": {
       "version": "1.15.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie-es": "^1.2.3",
         "crossws": "^0.3.5",
@@ -10472,6 +10556,7 @@
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.1.0",
@@ -10488,6 +10573,7 @@
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -10520,6 +10606,7 @@
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -10626,6 +10713,7 @@
     "node_modules/hastscript": {
       "version": "9.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -10676,7 +10764,8 @@
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
@@ -10699,7 +10788,8 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -10862,6 +10952,7 @@
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
       }
@@ -10992,6 +11083,7 @@
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
       "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -13250,6 +13342,7 @@
     "node_modules/mrmime": {
       "version": "2.0.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13372,7 +13465,8 @@
     },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
@@ -13398,7 +13492,8 @@
     },
     "node_modules/node-mock-http": {
       "version": "1.0.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
@@ -13426,6 +13521,7 @@
     "node_modules/nth-check": {
       "version": "2.1.1",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -13538,6 +13634,7 @@
     "node_modules/ofetch": {
       "version": "1.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "destr": "^2.0.5",
         "node-fetch-native": "^1.6.7",
@@ -13546,7 +13643,8 @@
     },
     "node_modules/ohash": {
       "version": "2.0.11",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -13726,6 +13824,7 @@
     "node_modules/p-limit": {
       "version": "7.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^1.2.1"
       },
@@ -13775,6 +13874,7 @@
     "node_modules/p-queue": {
       "version": "9.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^7.0.0"
@@ -13789,6 +13889,7 @@
     "node_modules/p-queue/node_modules/p-timeout": {
       "version": "7.0.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -13798,7 +13899,8 @@
     },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pagefind": {
       "version": "1.4.0",
@@ -13842,6 +13944,7 @@
     "node_modules/parse5": {
       "version": "7.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -13946,15 +14049,15 @@
       "license": "0BSD"
     },
     "node_modules/pdfjs-dist": {
-      "version": "5.7.284",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
-      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+      "version": "6.3.289",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.3.289.tgz",
+      "integrity": "sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.13.0 || >=24"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.100"
+        "@napi-rs/canvas": "^1.0.0"
       }
     },
     "node_modules/peerjs": {
@@ -14334,6 +14437,7 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
       "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14343,6 +14447,7 @@
       "resolved": "https://registry.npmjs.org/process-ancestry/-/process-ancestry-0.1.0.tgz",
       "integrity": "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -14473,7 +14578,8 @@
     },
     "node_modules/radix3": {
       "version": "1.1.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/raf": {
       "version": "3.4.1",
@@ -14839,6 +14945,7 @@
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -15158,6 +15265,7 @@
       "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
       "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.5",
         "@types/hast": "^3.0.4",
@@ -15983,6 +16091,7 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
       "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^11.1.0",
         "css-select": "^5.1.0",
@@ -16006,6 +16115,7 @@
     "node_modules/svgo/node_modules/commander": {
       "version": "11.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -16165,7 +16275,8 @@
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -16181,6 +16292,7 @@
     "node_modules/tinyclip": {
       "version": "0.1.12",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^16.14.0 || >= 17.3.0"
       }
@@ -16482,11 +16594,13 @@
     },
     "node_modules/ufo": {
       "version": "1.6.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ultrahtml": {
       "version": "1.6.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -16506,7 +16620,8 @@
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/undici": {
       "version": "7.28.0",
@@ -16548,6 +16663,7 @@
     "node_modules/unifont": {
       "version": "0.7.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.1.0",
         "ofetch": "^1.5.1",
@@ -16681,6 +16797,7 @@
     "node_modules/unstorage": {
       "version": "1.17.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^5.0.0",
@@ -16775,6 +16892,7 @@
     "node_modules/unstorage/node_modules/chokidar": {
       "version": "5.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -16788,6 +16906,7 @@
     "node_modules/unstorage/node_modules/lru-cache": {
       "version": "11.3.5",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -16795,6 +16914,7 @@
     "node_modules/unstorage/node_modules/readdirp": {
       "version": "5.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -16871,6 +16991,7 @@
     "node_modules/vfile-location": {
       "version": "5.0.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile": "^6.0.0"
@@ -17376,6 +17497,7 @@
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -17845,7 +17967,8 @@
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -17958,6 +18081,7 @@
     "node_modules/yocto-queue": {
       "version": "1.2.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -18036,7 +18160,7 @@
         "jspdf": "^4.2.1",
         "katex": "^0.16.40",
         "lightningcss-linux-x64-gnu": "^1.32.0",
-        "pdfjs-dist": "^5.4.149",
+        "pdfjs-dist": "^6.2.108",
         "peerjs": "^1.5.5",
         "remotion": "^4.0.451",
         "svelte": "^5.55.9",
@@ -18092,6 +18216,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.4.0.tgz",
       "integrity": "sha512-x2RjDUuWfwLNtc3mjAdSRInwqh/rqbLar9cm/5FOMbHvmYZB7yfKewzSclAxWjIZsypJDXv1lhaP2WG+P8TK3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
@@ -18119,6 +18244,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18135,6 +18261,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18151,6 +18278,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18167,6 +18295,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18183,6 +18312,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18199,6 +18329,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18212,6 +18343,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^1.2.2"
       },
@@ -18231,6 +18363,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18247,6 +18380,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -18256,6 +18390,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.4.0.tgz",
       "integrity": "sha512-koVikeon1kreEy+/JzLQRy3vzHHQVOjycs4degg4vFufKApZOwMZvSSAEztYNhmcQVfNVsVZZI4cEge3cexAbQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler-binding": "0.4.0"
       },
@@ -18310,6 +18445,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.8.tgz",
       "integrity": "sha512-n8ItpFTCmlDsVR5+rwDmehSf+jFCYLWmZiisZNGuF7xILqYhsVeBfcha4qgS2Seq3fAc9Tm58ZVrvqFQ6RQgRQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/internal-helpers": "0.10.4",
         "@astrojs/prism": "4.0.2",
@@ -18322,6 +18458,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
       "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.4",
         "@types/mdast": "^4.0.4",
@@ -18348,6 +18485,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -18394,6 +18532,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
       "integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ci-info": "^4.4.0",
         "dset": "^3.1.4",
@@ -18425,7 +18564,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "saberparatodos/node_modules/@bruits/satteri-darwin-x64": {
       "version": "0.10.5",
@@ -18438,7 +18578,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "saberparatodos/node_modules/@bruits/satteri-linux-arm64-gnu": {
       "version": "0.10.5",
@@ -18451,7 +18592,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "saberparatodos/node_modules/@bruits/satteri-linux-arm64-musl": {
       "version": "0.10.5",
@@ -18464,7 +18606,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "saberparatodos/node_modules/@bruits/satteri-linux-x64-gnu": {
       "version": "0.10.5",
@@ -18477,7 +18620,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "saberparatodos/node_modules/@bruits/satteri-linux-x64-musl": {
       "version": "0.10.5",
@@ -18490,7 +18634,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "saberparatodos/node_modules/@bruits/satteri-wasm32-wasi": {
       "version": "0.10.5",
@@ -18501,6 +18646,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
@@ -18521,7 +18667,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "saberparatodos/node_modules/@bruits/satteri-win32-x64-msvc": {
       "version": "0.10.5",
@@ -18534,7 +18681,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "saberparatodos/node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.1",
@@ -18548,6 +18696,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18564,6 +18713,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18580,6 +18730,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18602,6 +18753,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18621,6 +18773,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "dependencies": {
         "@img/sharp-wasm32": "0.35.4"
       },
@@ -18643,6 +18796,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18659,6 +18813,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18675,6 +18830,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18691,6 +18847,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18707,6 +18864,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18723,6 +18881,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18739,6 +18898,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18755,6 +18915,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18771,6 +18932,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18787,6 +18949,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -18803,6 +18966,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18825,6 +18989,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18847,6 +19012,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18869,6 +19035,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18891,6 +19058,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18913,6 +19081,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18935,6 +19104,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18957,6 +19127,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -18973,6 +19144,7 @@
       "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.11.3"
       },
@@ -18989,6 +19161,7 @@
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -19002,6 +19175,7 @@
       ],
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@img/sharp-wasm32": "0.35.4"
       },
@@ -19024,6 +19198,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -19043,6 +19218,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.9.0"
       },
@@ -19062,6 +19238,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.9.0"
       },
@@ -19075,6 +19252,7 @@
       "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -19226,6 +19404,7 @@
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
       "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -19243,6 +19422,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.9.tgz",
       "integrity": "sha512-o5nZFo/bieF6rp4x9sQSLhI7GO7Bahpld38Y4LvX27nFoxNiuttjI+Hea81w5ksORLHgdPUlQpU9obPz5QRa8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler-rs": "^0.4.0",
         "@astrojs/internal-helpers": "0.10.4",
@@ -19327,6 +19507,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
       "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.4",
         "@types/mdast": "^4.0.4",
@@ -19353,6 +19534,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -19365,6 +19547,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
       "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -19375,6 +19558,7 @@
       "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
@@ -19450,6 +19634,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
       "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=22"
       },
@@ -19463,6 +19648,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
       "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -19473,6 +19659,7 @@
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -19566,7 +19753,8 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "saberparatodos/node_modules/jspdf": {
       "version": "4.2.1",
@@ -19648,6 +19836,7 @@
       "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
       "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -19696,6 +19885,7 @@
       "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.10.5.tgz",
       "integrity": "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.5",
         "@types/hast": "^3.0.5",
@@ -19783,6 +19973,7 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
       "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=22.19.0"
       }
@@ -19797,6 +19988,7 @@
       "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
       "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.1.0",
         "ohash": "^2.0.11",
@@ -19975,6 +20167,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
@@ -19984,6 +20177,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/saberparatodos/package.json
+++ b/saberparatodos/package.json
@@ -88,7 +88,7 @@
     "jspdf": "^4.2.1",
     "katex": "^0.16.40",
     "lightningcss-linux-x64-gnu": "^1.32.0",
-    "pdfjs-dist": "^5.4.149",
+    "pdfjs-dist": "^6.2.108",
     "peerjs": "^1.5.5",
     "remotion": "^4.0.451",
     "svelte": "^5.55.9",

--- a/saberparatodos/src/lib/ai/pdf-ingest.ts
+++ b/saberparatodos/src/lib/ai/pdf-ingest.ts
@@ -86,8 +86,18 @@ export async function ingestPdfToV52Draft(
     let text = '';
     let pagesCount = 0;
     try {
-      const pdfjs: any = await import('pdfjs-dist').catch(() => null);
-      if (pdfjs) {
+      let pdfjsModule: any = await import('pdfjs-dist').catch(() => null);
+      if (!pdfjsModule) {
+        const pdfLegacy = 'pdfjs-dist/legacy/build/pdf.mjs';
+        pdfjsModule = await import(/* @vite-ignore */ pdfLegacy as string).catch(() => null);
+      }
+      let pdfjs: any = pdfjsModule;
+      if (pdfjsModule && typeof pdfjsModule === 'object' && 'default' in pdfjsModule) {
+        if (pdfjsModule.default?.getDocument) {
+          pdfjs = pdfjsModule.default;
+        }
+      }
+      if (pdfjs && typeof pdfjs.getDocument === 'function') {
         const task = pdfjs.getDocument({ data: pdfBytes, verbosity: 0 });
         const pdf = await task.promise;
         pagesCount = pdf.numPages;

--- a/saberparatodos/src/lib/ai/pdf/extractor.ts
+++ b/saberparatodos/src/lib/ai/pdf/extractor.ts
@@ -36,11 +36,12 @@ export interface ExtractionResult {
 export async function extractTextFromArrayBuffer(buffer: ArrayBuffer): Promise<ExtractionResult> {
   let pdfjsLib: any;
   try {
-    // Intento 1: pdfjs-dist legacy (compat Node/browser) — dynamic para no romper vite si no instalado
+    // Intento 1: pdfjs-dist (v6.2+ / standard) — dynamic import para compatibilidad Vite/Astro
     const pdfName = 'pdfjs-dist';
     pdfjsLib = await import(/* @vite-ignore */ pdfName as string);
   } catch {
     try {
+      // Fallback a legacy build para entornos Node/SSR/jsdom si import principal falla
       const pdfLegacy = 'pdfjs-dist/legacy/build/pdf.mjs';
       pdfjsLib = await import(/* @vite-ignore */ pdfLegacy as string);
     } catch (e) {
@@ -50,7 +51,7 @@ export async function extractTextFromArrayBuffer(buffer: ArrayBuffer): Promise<E
     }
   }
 
-  // Normalizar export (algunas versiones usan default) — evitar acceso a .default si el mock no lo define (vitest)
+  // Normalizar export para pdfjs-dist v5/v6.2 (manejo de Module namespace vs default export)
   let lib: any = pdfjsLib;
   try {
     if (pdfjsLib && typeof pdfjsLib === 'object' && 'default' in pdfjsLib) {
@@ -62,7 +63,7 @@ export async function extractTextFromArrayBuffer(buffer: ArrayBuffer): Promise<E
   } catch {
     lib = pdfjsLib;
   }
-  // Fallback si lib no tiene getDocument pero default sí
+  // Fallback guard si lib no tiene getDocument pero default sí
   if (!lib.getDocument && (pdfjsLib as any)?.default?.getDocument) {
     lib = (pdfjsLib as any).default;
   }


### PR DESCRIPTION
Updates pdfjs-dist to ^6.2.108 in saberparatodos package, enhances dynamic import fallback guards and export normalization in extractor.ts and pdf-ingest.ts, and preserves the File | ArrayBuffer overload signature.

Fixes #1201

---
*PR created automatically by Jules for task [2122723531880890980](https://jules.google.com/task/2122723531880890980) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PDF processing compatibility across modern browsers, Node.js, server-side rendering, and testing environments.
  - Added more reliable handling for different PDF processing module formats, reducing failures when importing or extracting PDF content.

- **Maintenance**
  - Updated the PDF processing engine to a newer version for improved compatibility and ongoing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->