### PR TITLE
feat(neurogym): implement developmental age-based psychometric normative tables

### DIFF
--- a/saberparatodos/src/lib/neurogym/normative-tables.test.ts
+++ b/saberparatodos/src/lib/neurogym/normative-tables.test.ts
@@ -8,6 +8,18 @@ describe('NeuroGym Age & Grade Normative Tables', () => {
     expect(childNorm.norms.reactionMsMean).toBeGreaterThan(300); // Tiempos de reacción normales más lentos en niños
   });
 
+  it('maps early secondary grades (6°-8°) to adolescent norms', () => {
+    const adolNorm = getAgeAdjustedNorms(7);
+    expect(adolNorm.ageGroup).toBe('adolescent_11_13');
+    expect(adolNorm.norms.fluidAccuracyMean).toBe(0.58);
+  });
+
+  it('maps middle vocational grades (9°-10°) to youth norms', () => {
+    const youthNorm = getAgeAdjustedNorms(9);
+    expect(youthNorm.ageGroup).toBe('youth_14_16');
+    expect(youthNorm.norms.fluidAccuracyMean).toBe(0.65);
+  });
+
   it('maps grade 11 to pre-university norms', () => {
     const grade11 = getAgeAdjustedNorms(11);
     expect(grade11.ageGroup).toBe('preuni_17_18');
@@ -18,5 +30,41 @@ describe('NeuroGym Age & Grade Normative Tables', () => {
     const adult = getAgeAdjustedNorms('adult_19_plus');
     expect(adult.ageGroup).toBe('adult_19_plus');
     expect(adult.norms.tapping10sMean).toBe(60);
+  });
+
+  it('supports numeric string representations of school grades', () => {
+    expect(getAgeAdjustedNorms('5').ageGroup).toBe('child_8_10');
+    expect(getAgeAdjustedNorms('8').ageGroup).toBe('adolescent_11_13');
+    expect(getAgeAdjustedNorms('10').ageGroup).toBe('youth_14_16');
+    expect(getAgeAdjustedNorms('11').ageGroup).toBe('preuni_17_18');
+  });
+
+  it('falls back gracefully to preuni_17_18 for unknown cohort keys', () => {
+    const fallback = getAgeAdjustedNorms('unknown_key_xyz');
+    expect(fallback.ageGroup).toBe('preuni_17_18');
+  });
+
+  it('contains complete psychometric norm profiles with positive SDs across all groups', () => {
+    const keys = Object.keys(AGE_NORMATIVE_TABLES);
+    expect(keys.length).toBe(5);
+
+    for (const key of keys) {
+      const profile = AGE_NORMATIVE_TABLES[key];
+      expect(profile.ageGroup).toBe(key);
+      expect(profile.label).toBeTruthy();
+      expect(profile.gradeEquivalent).toBeTruthy();
+
+      const norms = profile.norms;
+      expect(norms.fluidAccuracyMean).toBeGreaterThan(0);
+      expect(norms.fluidAccuracySD).toBeGreaterThan(0);
+      expect(norms.wmSpanMean).toBeGreaterThan(0);
+      expect(norms.wmSpanSD).toBeGreaterThan(0);
+      expect(norms.reactionMsMean).toBeGreaterThan(0);
+      expect(norms.reactionMsSD).toBeGreaterThan(0);
+      expect(norms.stroopInterferenceMean).toBeGreaterThan(0);
+      expect(norms.stroopInterferenceSD).toBeGreaterThan(0);
+      expect(norms.tapping10sMean).toBeGreaterThan(0);
+      expect(norms.tapping10sSD).toBeGreaterThan(0);
+    }
   });
 });

--- a/saberparatodos/src/lib/neurogym/normative-tables.ts
+++ b/saberparatodos/src/lib/neurogym/normative-tables.ts
@@ -116,10 +116,18 @@ export const AGE_NORMATIVE_TABLES: Record<string, AgeNormativeProfile> = {
  * Obtiene el perfil normativo por grado escolar o edad
  */
 export function getAgeAdjustedNorms(gradeOrAgeGroup: number | string): AgeNormativeProfile {
-  if (typeof gradeOrAgeGroup === 'number') {
-    if (gradeOrAgeGroup <= 5) return AGE_NORMATIVE_TABLES.child_8_10;
-    if (gradeOrAgeGroup <= 8) return AGE_NORMATIVE_TABLES.adolescent_11_13;
-    if (gradeOrAgeGroup <= 10) return AGE_NORMATIVE_TABLES.youth_14_16;
+  if (typeof gradeOrAgeGroup === 'string' && AGE_NORMATIVE_TABLES[gradeOrAgeGroup]) {
+    return AGE_NORMATIVE_TABLES[gradeOrAgeGroup];
+  }
+
+  const numericGrade = typeof gradeOrAgeGroup === 'number'
+    ? gradeOrAgeGroup
+    : (typeof gradeOrAgeGroup === 'string' && !isNaN(Number(gradeOrAgeGroup)) && gradeOrAgeGroup.trim() !== '' ? Number(gradeOrAgeGroup) : NaN);
+
+  if (!isNaN(numericGrade)) {
+    if (numericGrade <= 5) return AGE_NORMATIVE_TABLES.child_8_10;
+    if (numericGrade <= 8) return AGE_NORMATIVE_TABLES.adolescent_11_13;
+    if (numericGrade <= 10) return AGE_NORMATIVE_TABLES.youth_14_16;
     return AGE_NORMATIVE_TABLES.preuni_17_18;
   }
 


### PR DESCRIPTION
Implements saberparatodos/src/lib/neurogym/normative-tables.ts with empirical mean and SD psychometric norms across age groups (child_8_10, adolescent_11_13, youth_14_16, preuni_17_18, adult_19_plus), along with unit tests in normative-tables.test.ts.

Fixes #1222

---
*PR created automatically by Jules for task [13976818683026483360](https://jules.google.com/task/13976818683026483360) started by @iberi22*