### PR TITLE
feat(neurogym): implement neuro-storage IndexedDB vault

### DIFF
--- a/saberparatodos/src/lib/neurogym/neuro-storage.test.ts
+++ b/saberparatodos/src/lib/neurogym/neuro-storage.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { saveNeuroSession, getNeuroSessionsHistory, getStreakInfo, clearNeuroHistory } from './neuro-storage';
+import {
+  saveNeuroSession,
+  getNeuroSessionsHistory,
+  getLatestCognitiveRadar,
+  getStreakInfo,
+  clearNeuroHistory
+} from './neuro-storage';
 import { computeCognitiveProfile, type RawCognitiveScores } from './scoring-cognitive';
 
 describe('NeuroGym Sovereign Local Storage Engine', () => {
@@ -7,7 +13,12 @@ describe('NeuroGym Sovereign Local Storage Engine', () => {
     await clearNeuroHistory();
   });
 
-  it('saves and retrieves neuro sessions locally', async () => {
+  it('returns null for getLatestCognitiveRadar when no sessions exist', async () => {
+    const radar = await getLatestCognitiveRadar();
+    expect(radar).toBeNull();
+  });
+
+  it('saves and retrieves neuro sessions locally and extracts radar data', async () => {
     const rawData: RawCognitiveScores = {
       fluidReasoningRaw: { correct: 15, total: 20, avgTimeMs: 10000 },
       workingMemorySpan: { maxNLevel: 3, corsiSpan: 6, accuracy: 0.88 },
@@ -26,6 +37,12 @@ describe('NeuroGym Sovereign Local Storage Engine', () => {
     expect(history.length).toBe(1);
     expect(history[0].id).toBe(sessionId);
     expect(history[0].profile.overallIQProxy.standardScore).toBe(profile.overallIQProxy.standardScore);
+
+    const radar = await getLatestCognitiveRadar();
+    expect(radar).not.toBeNull();
+    expect(radar?.labels).toContain('Razonamiento (IQ)');
+    expect(radar?.values.length).toBe(7);
+    expect(radar?.values[0]).toBe(profile.overallIQProxy.standardScore);
   });
 
   it('manages daily streak calculations without server leaks', () => {

--- a/saberparatodos/src/lib/neurogym/neuro-storage.ts
+++ b/saberparatodos/src/lib/neurogym/neuro-storage.ts
@@ -88,6 +88,42 @@ export async function saveNeuroSession(profile: FullCognitiveProfile): Promise<s
 /**
  * Obtiene el historial de sesiones almacenadas (hasta maxCount)
  */
+export interface CognitiveRadarData {
+  labels: string[];
+  values: number[];
+}
+
+/**
+ * Obtiene el último perfil psicométrico en formato simplificado para el gráfico Radar
+ */
+export async function getLatestCognitiveRadar(): Promise<CognitiveRadarData | null> {
+  const history = await getNeuroSessionsHistory(1);
+  if (!history || history.length === 0) {
+    return null;
+  }
+  const latest = history[0].profile;
+  return {
+    labels: [
+      'Razonamiento (IQ)',
+      'Memoria Trabajo',
+      'Velocidad (PSI)',
+      'Agilidad Motora',
+      'Flexibilidad',
+      'Comprensión Verbal',
+      'Razonamiento Cuantitativo'
+    ],
+    values: [
+      latest.overallIQProxy.standardScore,
+      latest.workingMemory.standardScore,
+      latest.processingSpeed.standardScore,
+      latest.motorAgility.standardScore,
+      latest.analyticalFlexibility.standardScore,
+      latest.verbalComprehension?.standardScore ?? 100,
+      latest.quantitativeReasoning?.standardScore ?? 100
+    ]
+  };
+}
+
 export async function getNeuroSessionsHistory(maxCount = 30): Promise<StoredNeuroSession[]> {
   const db = await openDB();
   if (!db) {


### PR DESCRIPTION
Implement local IndexedDB storage engine for NeuroGym profiles, training streak tracking, and cognitive radar extraction. Includes unit tests in saberparatodos/src/lib/neurogym/neuro-storage.test.ts.

Fixes #1214

---
*PR created automatically by Jules for task [8750541295117269772](https://jules.google.com/task/8750541295117269772) started by @iberi22*