### PR TITLE
[Wave 12.03] feat(seo): Enlaces contextuales a hilos y correcciones desde páginas estáticas de preguntas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9671,7 +9671,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"

--- a/saberparatodos/src/lib/questions/grade11-local-bank.ts
+++ b/saberparatodos/src/lib/questions/grade11-local-bank.ts
@@ -1,7 +1,7 @@
 import { countryConfig } from '../../config';
 import { isBundleQuarantined } from './quarantine-registry';
 
-type LocalBankQuestion = {
+export type LocalBankQuestion = {
   id: string;
   statement: string;
   subject: string;
@@ -11,6 +11,7 @@ type LocalBankQuestion = {
   correctOptionId?: string;
   explanation?: string;
   bundle_id: string;
+  bundle_path?: string;
   tema?: string;
   periodo?: number;
   protocol_version?: string;
@@ -18,7 +19,7 @@ type LocalBankQuestion = {
   bundleStatus?: string;
 };
 
-const rawGrade11Bundles = import.meta.glob('../../../../questions_data/colombia/**/grado-11/**/CO-*-W01-*.md', {
+const rawGrade11Bundles = import.meta.glob('../../../../questions_data/colombia/**/grado-11/**/*.md', {
   query: '?raw',
   import: 'default',
   eager: true,
@@ -171,6 +172,7 @@ function parseLocalBundle(filePath: string, raw: string): LocalBankQuestion[] {
         correctOptionId: correctOption.id,
         explanation: parseExplanation(section),
         bundle_id: bundleId,
+        bundle_path: relativeBundlePath,
         tema: topic,
         periodo: period,
         protocol_version: frontmatter.protocol_version || undefined,
@@ -193,4 +195,10 @@ export function getLocalGrade11Questions(subject?: string | null): LocalBankQues
   const questions = Array.from(parsedGrade11LocalBank.values());
   if (!normalizedSubject) return questions;
   return questions.filter((question) => question.subject === normalizedSubject);
+}
+
+export function getLocalGrade11QuestionById(id: string): LocalBankQuestion | undefined {
+  if (!id) return undefined;
+  const targetId = id.trim().toLowerCase();
+  return parsedGrade11LocalBank.get(targetId) || Array.from(parsedGrade11LocalBank.values()).find((q) => q.id.toLowerCase() === targetId);
 }

--- a/saberparatodos/src/pages/community/[question_id].astro
+++ b/saberparatodos/src/pages/community/[question_id].astro
@@ -1,12 +1,16 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import MathRenderer from '../../components/MathRenderer.svelte';
 import ThreadedExplanation from '../../components/community/ThreadedExplanation.svelte';
 import { resolveRuntimeCountryConfig } from '../../config';
+import { getLocalGrade11QuestionById } from '../../lib/questions/grade11-local-bank';
 
 export const prerender = false;
 
 const { question_id } = Astro.params;
 const questionId = question_id || 'co-math-11-001';
+
+const localQuestion = getLocalGrade11QuestionById(questionId);
 
 const runtimeCountry = resolveRuntimeCountryConfig(Astro.locals.country);
 ---
@@ -38,6 +42,64 @@ const runtimeCountry = resolveRuntimeCountryConfig(Astro.locals.country);
           Aportes, contraejemplos pedagógicos y desgloses paso a paso auditados por la red comunitaria.
         </p>
       </div>
+
+      <!-- Tarjeta del Enunciado Completo si está en el Banco Local -->
+      {localQuestion && (
+        <section class="bg-zinc-900/90 border border-zinc-800 rounded-2xl p-6 shadow-xl space-y-4">
+          <div class="flex items-center justify-between text-xs font-mono text-zinc-400 border-b border-zinc-800/80 pb-3">
+            <span class="bg-emerald-500/20 text-emerald-300 px-2.5 py-1 rounded-full font-semibold">
+              {localQuestion.subject.toUpperCase()} • Grado {localQuestion.grade}
+            </span>
+            <span>Dificultad: {localQuestion.difficulty}/10</span>
+          </div>
+
+          <div class="text-base sm:text-lg text-zinc-100 font-medium leading-relaxed pt-1">
+            <MathRenderer content={localQuestion.statement} client:load />
+          </div>
+
+          <div class="grid gap-2.5 pt-2">
+            {localQuestion.options.map((opt) => (
+              <div
+                class={`p-3.5 rounded-xl border text-sm flex items-center justify-between transition ${
+                  opt.isCorrect
+                    ? 'bg-emerald-950/40 border-emerald-500/50 text-emerald-200'
+                    : 'bg-zinc-950/60 border-zinc-800 text-zinc-300'
+                }`}
+              >
+                <span class="flex items-start gap-2">
+                  <strong class="text-zinc-100 font-bold">{opt.id}.</strong>
+                  <span><MathRenderer content={opt.text} client:load /></span>
+                </span>
+                {opt.isCorrect && (
+                  <span class="text-xs font-bold bg-emerald-500 text-slate-950 px-2 py-0.5 rounded-md shrink-0">
+                    Clave Correcta
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {localQuestion.explanation && (
+            <div class="pt-3 border-t border-zinc-800/80">
+              <span class="text-xs font-bold text-emerald-400 uppercase tracking-wider block mb-1">
+                💡 Explicación de Referencia
+              </span>
+              <div class="text-xs sm:text-sm text-zinc-300 leading-relaxed bg-zinc-950/80 p-3.5 rounded-xl border border-zinc-800/80">
+                <MathRenderer content={localQuestion.explanation} client:load />
+              </div>
+            </div>
+          )}
+
+          <div class="pt-2 flex justify-end">
+            <a
+              href={`/corrections?question_id=${encodeURIComponent(localQuestion.id)}&bundle_path=${encodeURIComponent(localQuestion.bundle_path || '')}`}
+              class="inline-flex items-center gap-1.5 text-xs text-amber-400 hover:text-amber-300 font-semibold transition"
+            >
+              <span>🛠️</span> Reportar inconsistencia en esta pregunta
+            </a>
+          </div>
+        </section>
+      )}
 
       <!-- Montaje del componente con client:load -->
       <section>

--- a/saberparatodos/src/pages/corrections/index.astro
+++ b/saberparatodos/src/pages/corrections/index.astro
@@ -6,6 +6,9 @@ import { resolveRuntimeCountryConfig } from '../../config';
 export const prerender = false;
 
 const runtimeCountry = resolveRuntimeCountryConfig(Astro.locals.country);
+
+const questionId = Astro.url.searchParams.get('question_id') || undefined;
+const bundlePath = Astro.url.searchParams.get('bundle_path') || undefined;
 ---
 
 <Layout
@@ -38,7 +41,7 @@ const runtimeCountry = resolveRuntimeCountryConfig(Astro.locals.country);
 
       <!-- Componente interactivo -->
       <section>
-        <CorrectionThread client:load />
+        <CorrectionThread client:load initialQuestionId={questionId} initialBundlePath={bundlePath} />
       </section>
     </div>
   </main>

--- a/saberparatodos/src/pages/preguntas/[...slug].astro
+++ b/saberparatodos/src/pages/preguntas/[...slug].astro
@@ -1,16 +1,13 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import MathRenderer from '../../components/MathRenderer.svelte';
 import {
   getCountryManifest,
-  getAllCountryManifests,
   getCountriesWithContent,
-  resolveCountryCode,
   type CountryManifest,
 } from '../../lib/country-manifest-loader';
 import {
-  getSubjectsForCountry,
   getBundlesForCountrySubject,
-  getBundleByWeek,
   toTitleCase,
   canonicalFor,
 } from './_helpers';
@@ -352,12 +349,12 @@ const questionSchemas = displayQuestions.map((q) => {
                   <span class="text-xs font-mono bg-emerald-500/20 text-emerald-300 px-2.5 py-1 rounded-full font-semibold">
                     Pregunta #{idx + 1} • {q.subject.toUpperCase()}
                   </span>
-                  <span class="text-xs text-slate-400">Dificultad: {q.difficulty}/10</span>
+                  <span class="text-xs text-slate-400 font-mono">ID: {q.id} • Dificultad: {q.difficulty}/10</span>
                 </div>
 
-                <p class="text-base md:text-lg text-white font-medium mb-5 leading-relaxed">
-                  {q.statement}
-                </p>
+                <div class="text-base md:text-lg text-white font-medium mb-5 leading-relaxed">
+                  <MathRenderer content={q.statement} client:visible />
+                </div>
 
                 <div class="grid gap-2.5 mb-4">
                   {q.options.map((opt) => (
@@ -368,11 +365,12 @@ const questionSchemas = displayQuestions.map((q) => {
                           : 'bg-slate-900/40 border-slate-700/50 text-slate-300'
                       }`}
                     >
-                      <span>
-                        <strong class="mr-2 text-white font-bold">{opt.id}.</strong> {opt.text}
+                      <span class="flex items-start gap-2">
+                        <strong class="text-white font-bold">{opt.id}.</strong>
+                        <span><MathRenderer content={opt.text} client:visible /></span>
                       </span>
                       {opt.isCorrect && (
-                        <span class="text-xs font-bold bg-emerald-500 text-slate-950 px-2 py-0.5 rounded-md">
+                        <span class="text-xs font-bold bg-emerald-500 text-slate-950 px-2 py-0.5 rounded-md shrink-0">
                           Correcta
                         </span>
                       )}
@@ -385,11 +383,26 @@ const questionSchemas = displayQuestions.map((q) => {
                     <summary class="cursor-pointer text-xs font-bold text-emerald-400 hover:text-emerald-300 transition flex items-center gap-1.5">
                       <span>💡</span> Ver Explicación Pedagógica
                     </summary>
-                    <p class="mt-2 text-xs md:text-sm text-slate-300 leading-relaxed bg-slate-900/60 p-3.5 rounded-xl border border-slate-700/40">
-                      {q.explanation}
-                    </p>
+                    <div class="mt-2 text-xs md:text-sm text-slate-300 leading-relaxed bg-slate-900/60 p-3.5 rounded-xl border border-slate-700/40">
+                      <MathRenderer content={q.explanation} client:visible />
+                    </div>
                   </details>
                 )}
+
+                <div class="mt-6 pt-4 border-t border-slate-700/60 flex flex-wrap items-center justify-between gap-3 text-xs">
+                  <a
+                    href={`/community/${encodeURIComponent(q.id)}`}
+                    class="inline-flex items-center gap-1.5 text-emerald-400 hover:text-emerald-300 font-semibold transition"
+                  >
+                    <span>💬</span> Ver debate e interpretaciones comunitarias
+                  </a>
+                  <a
+                    href={`/corrections?question_id=${encodeURIComponent(q.id)}&bundle_path=${encodeURIComponent(q.bundle_path || '')}`}
+                    class="inline-flex items-center gap-1.5 text-amber-400 hover:text-amber-300 font-semibold transition"
+                  >
+                    <span>🛠️</span> Reportar inconsistencia / sugerir parche
+                  </a>
+                </div>
               </article>
             ))}
           </div>


### PR DESCRIPTION
Adds contextual links for community discussion threads and correction reporting to static question pages (/preguntas/[...slug]), renders complete question context with KaTeX math rendering on /community/[question_id] when available in local question bank, and pre-fills correction forms from query parameters.

Fixes #1246

---
*PR created automatically by Jules for task [139441190657344813](https://jules.google.com/task/139441190657344813) started by @iberi22*