### PR TITLE
feat(curriculum): Matrices oficiales Lote C (UY, PY, BO) y trampas pedagógicas avanzadas

### DIFF
--- a/saberparatodos/src/components/preguntas/SubjectHubView.svelte
+++ b/saberparatodos/src/components/preguntas/SubjectHubView.svelte
@@ -111,45 +111,60 @@
     } else if (s.includes('cienc') || s.includes('fisi') || s.includes('quim') || s.includes('bio')) {
       return [
         {
+          title: '⚠️ Confusión entre Calor y Temperatura',
+          description: 'Tratar el calor (energía térmica en tránsito) y la temperatura (medida de la energía cinética promedio de las partículas) como sinónimos.',
+          remedy: 'El calor se transfiere entre cuerpos debido a una diferencia de temperatura; la temperatura mide el nivel térmico intrínseco.'
+        },
+        {
           title: '⚠️ Confusión entre Masa y Peso',
-          description: 'Tratar la masa (propiedad intrínseca en kg) y el peso (fuerza gravitacional en N) como equivalentes.',
-          remedy: 'Recuerda que el peso varía según la aceleración de la gravedad (W = m·g).'
+          description: 'Tratar la masa (propiedad intrínseca en kg) y el peso (fuerza gravitacional en N) como conceptos idénticos.',
+          remedy: 'La masa permanece constante en cualquier lugar; el peso varía proporcionalmente con la gravedad (W = m·g).'
+        },
+        {
+          title: '⚠️ Explicación Lamarckiana vs. Selección Natural Darwiniana',
+          description: 'Atribuir la evolución a modificaciones adquiridas por "necesidad u uso del individuo" (Lamarck) en lugar de la selección de variaciones fenotípicas preexistentes (Darwin).',
+          remedy: 'La selección natural actúa sobre variantes genéticas heredables en la población, no sobre cambios adquiridos individualmente durante la vida.'
         },
         {
           title: '⚠️ Aislamiento Incorrecto de Variables en Experimentos',
-          description: 'Atribuir cambios en un resultado a una variable sin controlar las demás variables independientes.',
-          remedy: 'En el método científico solo debe modificarse una variable independiente a la vez.'
-        },
-        {
-          title: '⚠️ Errores en Relaciones Tróficas y Ecosistémicas',
-          description: 'Interpretar el sentido de las flechas en redes alimentarias como "quien se come a quien" en lugar del flujo de energía.',
-          remedy: 'Las flechas van del organismo consumido hacia el consumidor que recibe la energía.'
+          description: 'Atribuir cambios en el resultado a una variable de estudio sin haber mantenido constantes las variables de control.',
+          remedy: 'En un experimento válido solo se altera una variable independiente a la vez mientras se controlan las demás.'
         }
       ];
     } else if (s.includes('soc') || s.includes('hist') || s.includes('ciudad')) {
       return [
         {
-          title: '⚠️ Confusión entre Causa y Correlación Histórica',
-          description: 'Asumir que un evento causó otro solo porque sucedieron en periodos cronológicos cercanos.',
-          remedy: 'Examina las causas estructurales y los factores multicausales de los hechos sociales.'
+          title: '⚠️ Anacronismo Histórico',
+          description: 'Juzgar hechos, valores o decisiones del pasado utilizando categorías, tecnologías o normas morales del presente.',
+          remedy: 'Contextualiza cada acontecimiento dentro del marco temporal, cultural e ideológico de su propia época.'
         },
         {
-          title: '⚠️ Desconocimiento de Mecanismos de Participación',
-          description: 'Confundir la Acción de Tutela (derechos fundamentales) con la Acción Popular (derechos colectivos).',
-          remedy: 'Revisa la escala de afectación: individual fundamental vs. derecho colectivo o ambiental.'
+          title: '⚠️ Sesgo de Causa Única (Monocausalidad)',
+          description: 'Reducir un proceso histórico, social o económico complejo a una sola causa simplificada.',
+          remedy: 'Analiza los factores multicausales (políticos, económicos, sociales y culturales) que interactúan en el proceso.'
+        },
+        {
+          title: '⚠️ Confusión de Poderes del Estado y Mecanismos Constitucionales',
+          description: 'Atribuir funciones legislativas o judiciales al poder ejecutivo, o confundir instrumentos de protección de derechos (ej: Acción de Tutela vs Acción Popular).',
+          remedy: 'Diferencia claramente las funciones constitucionales de cada rama y el ámbito de protección individual vs colectivo.'
         }
       ];
     } else {
       return [
         {
-          title: '⚠️ Confusión de Falsos Amigos y Vocabulario',
-          description: 'Interpretar palabras por su parecido ortográfico en español en lugar de su significado real.',
-          remedy: 'Practica el vocabulario contextualizado y lee la frase completa.'
+          title: '⚠️ Falsos Amigos Comunes (False Friends)',
+          description: 'Traducir literalmente falsos cognados comunes como "actually" (en realidad, no actualmente), "embarrassed" (avergonzado/a, no embarazada) o "library" (biblioteca, no librería).',
+          remedy: 'Verifica el significado contextual en inglés sin asumir la equivalencia morfológica directa con el español.'
         },
         {
-          title: '⚠️ Errores de Tiempos Verbales',
-          description: 'Confundir acciones terminadas en el pasado simple con estados conector con el presente.',
-          remedy: 'Presta atención a los marcadores temporales (yesterday, since, for, already).'
+          title: '⚠️ Errores de Tiempos y Aspectos Verbales',
+          description: 'Confundir acciones concluidas en el pasado simple (Past Simple) con acciones iniciadas en el pasado con relevancia en el presente (Present Perfect).',
+          remedy: 'Identifica las señales temporales del contexto (ej: "yesterday" o "in 2010" vs "since", "for", "already").'
+        },
+        {
+          title: '⚠️ Desatención a Conectores Discursivos y Cohesión Textual',
+          description: 'Malinterpretar la relación lógica entre oraciones al ignorar conectores de contraste, causa o consecuencia (however, despite, furthermore, therefore).',
+          remedy: 'Presta atención a las transiciones para identificar si la idea secundaria apoya, contradice o complementa la idea principal.'
         }
       ];
     }

--- a/saberparatodos/src/config/authority-guidelines.ts
+++ b/saberparatodos/src/config/authority-guidelines.ts
@@ -274,6 +274,143 @@ const guidelinesByCountry: Partial<Record<CountryCode, AuthorityGuidelines>> = {
         ]
       }
     ]
+  },
+  UY: {
+    authorityName: 'ANEP / DGES — UDELAR',
+    badgeLabel: 'Evaluación Nacional de Aprendizajes y Admisión UDELAR',
+    competencias: {
+      matematica: {
+        competencias: ['Resolución de problemas', 'Modelización matemática', 'Razonamiento y argumentación'],
+        componentes: ['Álgebra y Funciones', 'Geometría y Medida', 'Estadística y Probabilidad', 'Números y Operaciones'],
+        color: '#0038a8'
+      },
+      lengua: {
+        competencias: ['Comprensión lectora y análisis textual', 'Producción escrita y propiedad léxica', 'Reflexión sobre el lenguaje'],
+        componentes: ['Textos explicativos y argumentativos', 'Cohesión y coherencia', 'Vocabulario en contexto'],
+        color: '#8b5cf6'
+      },
+      ciencias: {
+        competencias: ['Explicación científica de fenómenos', 'Análisis crítico e indagación experimental', 'Uso responsable de tecnología'],
+        componentes: ['Física y Química', 'Biología y Ciencias de la Tierra', 'Ciencia, Tecnología y Sociedad'],
+        color: '#10b981'
+      },
+      sociales: {
+        competencias: ['Comprensión de procesos históricos y sociales', 'Análisis territorial y ambiental', 'Ciudadanía y derechos humanos'],
+        componentes: ['Historia nacional y contemporánea', 'Geografía humana y económica', 'Formación ciudadana'],
+        color: '#f59e0b'
+      }
+    },
+    subjectLabels: {
+      matematica: 'Matemática',
+      lengua: 'Lengua y Literatura',
+      ciencias: 'Ciencias Naturales',
+      sociales: 'Ciencias Sociales'
+    },
+    references: [
+      {
+        title: 'ANEP & DGES Uruguay',
+        description: 'Marcos curriculares nacionales y pruebas de egreso.',
+        tone: 'blue',
+        accent: '#0038a8',
+        open: true,
+        links: [
+          { label: 'Administración Nacional de Educación Pública (ANEP)', url: 'https://www.anep.edu.uy/' },
+          { label: 'Dirección General de Educación Secundaria (DGES)', url: 'https://www.ces.edu.uy/' },
+          { label: 'Universidad de la República (UDELAR) - Ingresos', url: 'https://udelar.edu.uy/' }
+        ]
+      }
+    ]
+  },
+  PY: {
+    authorityName: 'MEC — SNEPE',
+    badgeLabel: 'Sistema Nacional de Evaluación del Proceso Educativo (SNEPE)',
+    competencias: {
+      matematica: {
+        competencias: ['Comprensión de conceptos matemáticos', 'Procedimientos y cálculo', 'Resolución de problemas contextualizados'],
+        componentes: ['Número y Operaciones', 'Álgebra y Funciones', 'Geometría y Medida', 'Estadística'],
+        color: '#d52b1e'
+      },
+      lengua: {
+        competencias: ['Comprensión de lectura en castellano y guaraní', 'Expresión escrita y normativa', 'Análisis crítico de textos'],
+        componentes: ['Comprensión literal e inferencial', 'Estructura textual', 'Bilingüismo y sociolingüística'],
+        color: '#8b5cf6'
+      },
+      ciencias: {
+        competencias: ['Indagación científica', 'Comprensión de fenómenos naturales y de la salud', 'Conservación ambiental'],
+        componentes: ['Materia y Energía', 'Seres Vivos y Salud', 'Medio Ambiente y Sustentabilidad'],
+        color: '#10b981'
+      },
+      sociales: {
+        competencias: ['Interpretación histórica del Paraguay y América', 'Ubicación espacio-temporal', 'Formación ética y ciudadana'],
+        componentes: ['Historia Paraguaya y Universal', 'Geografía', 'Educación Cívica y Derechos'],
+        color: '#f59e0b'
+      }
+    },
+    subjectLabels: {
+      matematica: 'Matemática',
+      lengua: 'Lengua Castellana y Materna',
+      ciencias: 'Ciencias de la Naturaleza',
+      sociales: 'Ciencias Sociales'
+    },
+    references: [
+      {
+        title: 'Ministerio de Educación y Ciencias (MEC)',
+        description: 'Evaluaciones e informes del SNEPE.',
+        tone: 'red',
+        accent: '#d52b1e',
+        open: true,
+        links: [
+          { label: 'Portal Oficial del Ministerio de Educación y Ciencias (MEC)', url: 'https://www.mec.gov.py/' },
+          { label: 'Sistema Nacional de Evaluación del Proceso Educativo (SNEPE)', url: 'https://www.mec.gov.py/snepe/' }
+        ]
+      }
+    ]
+  },
+  BO: {
+    authorityName: 'Ministerio de Educación — UMSA / UAGRM',
+    badgeLabel: 'Sistema de Evaluación del Estado Plurinacional y Admisión Universitaria',
+    competencias: {
+      matematica: {
+        competencias: ['Razonamiento lógico-matemático', 'Modelado algebraico y geométrico', 'Resolución de problemas comunitarios'],
+        componentes: ['Álgebra y Trigonometría', 'Geometría Analítica y Cálculo', 'Aritmética y Estadística'],
+        color: '#007a3d'
+      },
+      comunicacion: {
+        competencias: ['Comprensión lectora y análisis discursivo', 'Redacción académica y técnica', 'Razonamiento verbal'],
+        componentes: ['Lenguaje y Literatura', 'Comprensión y Análisis de Textos', 'Ortografía y Gramática'],
+        color: '#8b5cf6'
+      },
+      ciencias: {
+        competencias: ['Explicación de principios físicos y químicos', 'Análisis biológico y ecológico', 'Investigación científica aplicada'],
+        componentes: ['Física', 'Química', 'Biología y Geografía'],
+        color: '#10b981'
+      },
+      sociales: {
+        competencias: ['Análisis sociohistórico plurinacional', 'Geografía y recursos estratégicos', 'Cosmovisiones y formación ciudadana'],
+        componentes: ['Historia de Bolivia y Universal', 'Geografía Política y Económica', 'Educación Ciudadana'],
+        color: '#f59e0b'
+      }
+    },
+    subjectLabels: {
+      matematica: 'Matemática',
+      comunicacion: 'Comunicación y Lenguajes',
+      ciencias: 'Ciencias Naturales (Física, Química, Biología)',
+      sociales: 'Ciencias Sociales e Historia'
+    },
+    references: [
+      {
+        title: 'Ministerio de Educación de Bolivia',
+        description: 'Leyes educativas y admisiones a universidades públicas (UMSA, UAGRM).',
+        tone: 'emerald',
+        accent: '#007a3d',
+        open: true,
+        links: [
+          { label: 'Ministerio de Educación del Estado Plurinacional de Bolivia', url: 'https://www.minedu.gob.bo/' },
+          { label: 'Universidad Mayor de San Andrés (UMSA) - Admisiones', url: 'https://www.umsa.bo/' },
+          { label: 'Universidad Autónoma Gabriel René Moreno (UAGRM)', url: 'https://www.uagrm.edu.bo/' }
+        ]
+      }
+    ]
   }
 };
 

--- a/saberparatodos/tests/unit/curriculum-subject-hub.test.ts
+++ b/saberparatodos/tests/unit/curriculum-subject-hub.test.ts
@@ -37,6 +37,27 @@ describe('Curriculum Subject Hub & Authority Guidelines', () => {
     expect(pe.competencias.comunicacion).toBeDefined();
   });
 
+  it('returns authority guidelines for Uruguay (UY)', () => {
+    const uy = getAuthorityGuidelines('UY');
+    expect(uy.authorityName).toContain('ANEP');
+    expect(uy.competencias.matematica).toBeDefined();
+    expect(uy.competencias.matematica.competencias).toContain('Resolución de problemas');
+  });
+
+  it('returns authority guidelines for Paraguay (PY)', () => {
+    const py = getAuthorityGuidelines('PY');
+    expect(py.authorityName).toContain('SNEPE');
+    expect(py.competencias.matematica).toBeDefined();
+    expect(py.competencias.lengua.componentes).toContain('Bilingüismo y sociolingüística');
+  });
+
+  it('returns authority guidelines for Bolivia (BO)', () => {
+    const bo = getAuthorityGuidelines('BO');
+    expect(bo.authorityName).toContain('Ministerio de Educación');
+    expect(bo.competencias.comunicacion).toBeDefined();
+    expect(bo.competencias.matematica.componentes).toContain('Álgebra y Trigonometría');
+  });
+
   it('returns safe fallback for unconfigured country codes', () => {
     const fallback = getAuthorityGuidelines('ZZ' as any);
     expect(fallback.authorityName).toBe('Autoridad Educativa Local');
@@ -89,6 +110,23 @@ describe('SubjectHubView.svelte Component Verification', () => {
     for (const btnTag of buttonMatches) {
       expect(btnTag).toContain('type="button"');
     }
+  });
+
+  it('contains advanced science, social studies, and language distractor traps in commonMisconceptions', () => {
+    const code = fs.readFileSync(hubPath, 'utf8');
+    // Science traps
+    expect(code).toContain('Confusión entre Calor y Temperatura');
+    expect(code).toContain('Confusión entre Masa y Peso');
+    expect(code).toContain('Explicación Lamarckiana vs. Selección Natural Darwiniana');
+    // Social Studies traps
+    expect(code).toContain('Anacronismo Histórico');
+    expect(code).toContain('Sesgo de Causa Única (Monocausalidad)');
+    expect(code).toContain('Confusión de Poderes del Estado y Mecanismos Constitucionales');
+    // Language / English traps
+    expect(code).toContain('Falsos Amigos Comunes (False Friends)');
+    expect(code).toContain('actually');
+    expect(code).toContain('embarrassed');
+    expect(code).toContain('library');
   });
 });
 


### PR DESCRIPTION
Adds Lot C (Uruguay, Paraguay, Bolivia) educational authority guidelines and reference links, expands SubjectHubView.svelte pedagogical misconception traps across science, social studies, and languages, and updates unit tests.

Fixes #1253

---
*PR created automatically by Jules for task [753347898077223585](https://jules.google.com/task/753347898077223585) started by @iberi22*