### PR TITLE
feat(exam): group shared reading context across consecutive questions

### DIFF
--- a/saberparatodos/src/components/ExamView.svelte
+++ b/saberparatodos/src/components/ExamView.svelte
@@ -12,6 +12,11 @@
   import { getNextAdaptiveQuestion } from '../lib/adaptive-engine';
   import SharedContextLayout from './SharedContextLayout.svelte';
   import {
+    groupQuestionsByContext,
+    shouldShowInlineBadge,
+    type ContextGroup
+  } from '../lib/context-groups';
+  import {
     isSupabaseMirrorEnabled,
     maybeGetPartySession,
     maybeUpdatePartySession,
@@ -137,10 +142,31 @@
   const STORAGE_KEY = 'saberparatodos_exam_progress';
 
   let question = $derived(activeQuestions[currentIdx] || MOCK_QUESTIONS[0]);
-  let isLongContext = $derived(
-    question?.context &&
-    (question.context.trim().length >= 140 || question.context.trim().includes('\n'))
-  );
+
+  let contextGroups = $derived(groupQuestionsByContext(activeQuestions));
+  let contextGroup = $derived.by(() => {
+    return contextGroups.find(g => g.questionIds.includes(question?.id)) || null;
+  });
+
+  let isLongContextGroup = $derived(contextGroup?.isLong ?? false);
+  let sharedContextTitle = $derived.by(() => {
+    if (contextGroup && contextGroup.isLong && contextGroup.questionIds.length >= 2) {
+      const startNum = contextGroup.startIndex + 1;
+      const endNum = contextGroup.startIndex + contextGroup.questionIds.length;
+      return `Lectura compartida · preguntas ${startNum}–${endNum}`;
+    }
+    return 'Contexto de Lectura';
+  });
+
+  let effectiveContext = $derived.by(() => {
+    if (!question?.context) return '';
+    if (isLongContextGroup) return question.context;
+    // For short contexts, show badge only on the first question of the group
+    if (shouldShowInlineBadge(contextGroup, currentIdx)) {
+      return question.context;
+    }
+    return '';
+  });
 
   // Options Logic
   const OPTION_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F'];
@@ -627,8 +653,9 @@
 
   <!-- Main Content Area - No scroll on desktop, optimized for mobile -->
   <div class="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6">
-    <div class="{isLongContext ? 'max-w-7xl' : 'max-w-4xl'} mx-auto min-h-full flex flex-col justify-center space-y-4 sm:space-y-6 py-4 transition-all duration-500">
-      <SharedContextLayout context={question.context}>
+    <div class="{isLongContextGroup ? 'max-w-7xl' : 'max-w-4xl'} mx-auto min-h-full flex flex-col justify-center space-y-4 sm:space-y-6 py-4 transition-all duration-500">
+      {#key contextGroup?.startIndex ?? currentIdx}
+        <SharedContextLayout context={effectiveContext} title={sharedContextTitle}>
         <div class="space-y-4 sm:space-y-6">
 
       <div class="bg-[#1E1E1E]/60 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[50vh] transition-all duration-300 relative overflow-hidden group">
@@ -687,7 +714,8 @@
         {/if}
       </div>
         </div>
-      </SharedContextLayout>
+        </SharedContextLayout>
+      {/key}
     </div>
   </div>
 

--- a/saberparatodos/src/lib/context-groups.ts
+++ b/saberparatodos/src/lib/context-groups.ts
@@ -1,0 +1,88 @@
+/**
+ * Utility functions for grouping questions with identical shared reading context in ExamView.
+ * Export groupQuestionsByContext definition and usage reference.
+ */
+
+export interface QuestionContextItem {
+  id: string | number;
+  context?: string;
+}
+
+export interface ContextGroup {
+  context: string;
+  questionIds: (string | number)[];
+  isLong: boolean;
+  startIndex: number;
+}
+
+/**
+ * Same threshold rule as SharedContextLayout.svelte:
+ * A context is long if trimmed length >= 140 or contains a newline character.
+ */
+export function isLongContextText(context?: string): boolean {
+  const cleanContext = (context || '').trim();
+  return cleanContext.length >= 140 || cleanContext.includes('\n');
+}
+
+/**
+ * Groups CONSECUTIVE questions with identical context.trim().
+ * Empty or whitespace-only context creates an individual single-question group.
+ * Non-consecutive repeated contexts break group boundaries into separate groups.
+ */
+export function groupQuestionsByContext(
+  questions: QuestionContextItem[]
+): ContextGroup[] {
+  // groupQuestionsByContext implementation
+  if (!questions || questions.length === 0) {
+    return [];
+  }
+
+  const groups: ContextGroup[] = [];
+  let currentGroup: ContextGroup | null = null;
+
+  questions.forEach((q, idx) => {
+    const rawContext = q.context || '';
+    const cleanContext = rawContext.trim();
+    const isLong = isLongContextText(cleanContext);
+
+    // Empty or whitespace-only contexts do not form shared groups
+    if (cleanContext.length === 0) {
+      groups.push({
+        context: '',
+        questionIds: [q.id],
+        isLong: false,
+        startIndex: idx
+      });
+      currentGroup = null;
+      return;
+    }
+
+    if (currentGroup && currentGroup.context === cleanContext) {
+      currentGroup.questionIds.push(q.id);
+    } else {
+      currentGroup = {
+        context: cleanContext,
+        questionIds: [q.id],
+        isLong,
+        startIndex: idx
+      };
+      groups.push(currentGroup);
+    }
+  });
+
+  return groups;
+}
+
+/**
+ * Determines if a short inline context badge should be displayed for a question.
+ * For short contexts, the badge is shown ONLY on the first question of the group.
+ */
+export function shouldShowInlineBadge(
+  group: ContextGroup | null | undefined,
+  indexInExam: number
+): boolean {
+  if (!group || !group.context || group.isLong) {
+    return false;
+  }
+  return indexInExam === group.startIndex;
+}

--- a/saberparatodos/tests/unit/context-groups.spec.ts
+++ b/saberparatodos/tests/unit/context-groups.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  groupQuestionsByContext,
+  shouldShowInlineBadge,
+  isLongContextText,
+  type QuestionContextItem
+} from '../../src/lib/context-groups';
+
+describe('context-groups.ts - Context Grouping Logic', () => {
+  it('identifies long context text correctly using threshold rule', () => {
+    expect(isLongContextText('Short text')).toBe(false);
+    expect(isLongContextText('A'.repeat(140))).toBe(true);
+    expect(isLongContextText('Short text\nwith newline')).toBe(true);
+    expect(isLongContextText('')).toBe(false);
+  });
+
+  it('groups 3 consecutive questions with long context into a single long group', () => {
+    const longPassage = 'Un extenso pasaje de lectura sobre la historia del arte contemporáneo en Latinoamérica. '.repeat(3);
+    expect(longPassage.length).toBeGreaterThanOrEqual(140);
+
+    const questions: QuestionContextItem[] = [
+      { id: 'q1', context: longPassage },
+      { id: 'q2', context: longPassage },
+      { id: 'q3', context: longPassage }
+    ];
+
+    const groups = groupQuestionsByContext(questions);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].context).toBe(longPassage.trim());
+    expect(groups[0].questionIds).toEqual(['q1', 'q2', 'q3']);
+    expect(groups[0].isLong).toBe(true);
+    expect(groups[0].startIndex).toBe(0);
+  });
+
+  it('handles 20 consecutive questions with short repeated context and shows inline badge only for the first', () => {
+    const shortText = 'Escenario de prueba.';
+    expect(shortText.length).toBeLessThan(140);
+
+    const questions: QuestionContextItem[] = Array.from({ length: 20 }, (_, i) => ({
+      id: `q${i + 1}`,
+      context: shortText
+    }));
+
+    const groups = groupQuestionsByContext(questions);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].questionIds).toHaveLength(20);
+    expect(groups[0].isLong).toBe(false);
+
+    // Badge should show ONLY on the first question (index 0 / startIndex)
+    expect(shouldShowInlineBadge(groups[0], 0)).toBe(true);
+
+    for (let i = 1; i < 20; i++) {
+      expect(shouldShowInlineBadge(groups[0], i)).toBe(false);
+    }
+  });
+
+  it('creates separate groups for different consecutive contexts', () => {
+    const questions: QuestionContextItem[] = [
+      { id: 1, context: 'Contexto A' },
+      { id: 2, context: 'Contexto A' },
+      { id: 3, context: 'Contexto B' },
+      { id: 4, context: 'Contexto C' }
+    ];
+
+    const groups = groupQuestionsByContext(questions);
+
+    expect(groups).toHaveLength(3);
+
+    expect(groups[0].questionIds).toEqual([1, 2]);
+    expect(groups[0].startIndex).toBe(0);
+
+    expect(groups[1].questionIds).toEqual([3]);
+    expect(groups[1].startIndex).toBe(2);
+
+    expect(groups[2].questionIds).toEqual([4]);
+    expect(groups[2].startIndex).toBe(3);
+  });
+
+  it('treats empty or whitespace-only contexts as separate individual empty groups', () => {
+    const questions: QuestionContextItem[] = [
+      { id: 'q1', context: '' },
+      { id: 'q2', context: '   ' },
+      { id: 'q3', context: undefined },
+      { id: 'q4', context: 'Texto válido' }
+    ];
+
+    const groups = groupQuestionsByContext(questions);
+
+    expect(groups).toHaveLength(4);
+    expect(groups[0].questionIds).toEqual(['q1']);
+    expect(groups[1].questionIds).toEqual(['q2']);
+    expect(groups[2].questionIds).toEqual(['q3']);
+    expect(groups[3].questionIds).toEqual(['q4']);
+
+    expect(shouldShowInlineBadge(groups[0], 0)).toBe(false);
+    expect(shouldShowInlineBadge(groups[1], 1)).toBe(false);
+    expect(shouldShowInlineBadge(groups[2], 2)).toBe(false);
+    expect(shouldShowInlineBadge(groups[3], 3)).toBe(true);
+  });
+
+  it('breaks group boundaries when repeated contexts are non-consecutive', () => {
+    const questions: QuestionContextItem[] = [
+      { id: 1, context: 'Lectura Compartida' },
+      { id: 2, context: 'Lectura Compartida' },
+      { id: 3, context: 'Otra Lectura Distinta' },
+      { id: 4, context: 'Lectura Compartida' }
+    ];
+
+    const groups = groupQuestionsByContext(questions);
+
+    expect(groups).toHaveLength(3);
+    expect(groups[0].questionIds).toEqual([1, 2]);
+    expect(groups[0].startIndex).toBe(0);
+
+    expect(groups[1].questionIds).toEqual([3]);
+    expect(groups[1].startIndex).toBe(2);
+
+    expect(groups[2].questionIds).toEqual([4]);
+    expect(groups[2].startIndex).toBe(3);
+  });
+});


### PR DESCRIPTION
Group consecutive questions with identical reading contexts in ExamView. Render shared long reading context once per group with persistent panel state across questions in the group, and render short context inline badges only on the first question of a group.

Fixes #1261

---
*PR created automatically by Jules for task [5142706431957608524](https://jules.google.com/task/5142706431957608524) started by @iberi22*