### PR TITLE
feat: detect redeploys by commit hash in VersionBadge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9680,7 +9680,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"

--- a/saberparatodos/src/components/VersionBadge.svelte
+++ b/saberparatodos/src/components/VersionBadge.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import packageInfo from '../../package.json';
+  import { isNewerVersion, isNewerBuild, type BuildInfo } from '../lib/build-version';
 
   // Props
   interface Props {
@@ -11,18 +12,19 @@
   let { position = 'bottom-left', showOnlyOnUpdate = false }: Props = $props();
 
   // State (Svelte 5 runes)
-  let buildInfo = $state<{ version: string; commit: string; buildTime: string; env: string } | null>(null);
+  let buildInfo = $state<BuildInfo | null>(null);
   let showUpdateNotification = $state(false);
   let newVersion = $state('');
   let isExpanded = $state(false);
   let isVisible = $state(!showOnlyOnUpdate);
 
   const LOCAL_VERSION = packageInfo.version;
+  let initialBuildInfo: BuildInfo | null = null;
 
   // Derived values
   let shortCommit = $derived(buildInfo?.commit?.substring(0, 7) || '');
-  let buildDate = $derived(buildInfo?.buildTime
-    ? new Date(buildInfo.buildTime).toLocaleDateString('es-CO', {
+  let buildDate = $derived(buildInfo?.buildTime || buildInfo?.timestamp
+    ? new Date(buildInfo.buildTime || buildInfo.timestamp || 0).toLocaleDateString('es-CO', {
         year: 'numeric',
         month: 'short',
         day: 'numeric',
@@ -37,20 +39,6 @@
       : 'bottom-4 left-4'
   );
 
-  // Compare semantic versions (returns true if v1 < v2)
-  function isNewerVersion(local: string, remote: string): boolean {
-    const localParts = local.split('.').map(Number);
-    const remoteParts = remote.split('.').map(Number);
-
-    for (let i = 0; i < Math.max(localParts.length, remoteParts.length); i++) {
-      const l = localParts[i] || 0;
-      const r = remoteParts[i] || 0;
-      if (r > l) return true;
-      if (r < l) return false;
-    }
-    return false;
-  }
-
   async function checkForUpdates() {
     try {
       const response = await fetch('/build-info.json?t=' + Date.now(), {
@@ -59,13 +47,20 @@
       });
 
       if (response.ok) {
-        const serverInfo = await response.json();
+        const serverInfo: BuildInfo = await response.json();
         buildInfo = serverInfo;
 
-        // Compare versions
-        if (serverInfo.version && isNewerVersion(LOCAL_VERSION, serverInfo.version)) {
-          console.log(`[Update] New version detected: ${LOCAL_VERSION} → ${serverInfo.version}`);
-          newVersion = serverInfo.version;
+        if (!initialBuildInfo) {
+          initialBuildInfo = { ...serverInfo, version: serverInfo.version || LOCAL_VERSION };
+        }
+
+        // Compare versions and build commit/timestamp
+        const semverNewer = serverInfo.version ? isNewerVersion(LOCAL_VERSION, serverInfo.version) : false;
+        const commitOrBuildNewer = isNewerBuild(initialBuildInfo, serverInfo);
+
+        if (semverNewer || commitOrBuildNewer) {
+          console.log(`[Update] New build detected: ${LOCAL_VERSION} (${initialBuildInfo?.commit || 'local'}) → ${serverInfo.version || LOCAL_VERSION} (${serverInfo.commit || 'remote'})`);
+          newVersion = serverInfo.version || LOCAL_VERSION;
           showUpdateNotification = true;
           isVisible = true;
         }
@@ -86,7 +81,7 @@
     if (!import.meta.env.DEV && 'serviceWorker' in navigator) {
       navigator.serviceWorker.addEventListener('message', (event) => {
         if (event.data.type === 'NEW_VERSION_AVAILABLE') {
-          newVersion = event.data.newVersion;
+          newVersion = event.data.newVersion || LOCAL_VERSION;
           showUpdateNotification = true;
           isVisible = true;
         }

--- a/saberparatodos/src/lib/build-version.ts
+++ b/saberparatodos/src/lib/build-version.ts
@@ -1,0 +1,70 @@
+export interface BuildInfo {
+  version?: string;
+  commit?: string;
+  timestamp?: number;
+  buildTime?: number;
+  iso?: string;
+  env?: string;
+}
+
+/**
+ * Compares two semantic version strings (e.g. "0.15.1" vs "0.15.2").
+ * Returns true if remote is strictly newer than local.
+ */
+export function isNewerVersion(local: string, remote: string): boolean {
+  if (!local || !remote) return false;
+
+  const localParts = local.split('.').map(Number);
+  const remoteParts = remote.split('.').map(Number);
+
+  for (let i = 0; i < Math.max(localParts.length, remoteParts.length); i++) {
+    const l = Number.isNaN(localParts[i]) ? 0 : localParts[i] || 0;
+    const r = Number.isNaN(remoteParts[i]) ? 0 : remoteParts[i] || 0;
+    if (r > l) return true;
+    if (r < l) return false;
+  }
+  return false;
+}
+
+/**
+ * Determines whether remote build info indicates a newer deployment than local build info.
+ * Priority:
+ * 1. Semantic version check (remote version > local version).
+ * 2. Commit hash check (if commits are provided and differ).
+ * 3. Timestamp check as fallback (remote build timestamp > local build timestamp).
+ */
+export function isNewerBuild(local: BuildInfo | null, remote: BuildInfo | null): boolean {
+  if (!local || !remote) return false;
+
+  // 1. Semver check
+  if (local.version && remote.version) {
+    if (isNewerVersion(local.version, remote.version)) {
+      return true;
+    }
+    // If remote version is older than local version, don't flag as newer
+    if (isNewerVersion(remote.version, local.version)) {
+      return false;
+    }
+  }
+
+  // 2. Commit hash check
+  const localCommit = local.commit?.trim();
+  const remoteCommit = remote.commit?.trim();
+
+  if (localCommit && remoteCommit && localCommit !== 'local-build' && remoteCommit !== 'local-build') {
+    if (localCommit !== remoteCommit) {
+      return true;
+    }
+    // If commits match, check timestamp as extra fallback in case commit string was identical
+  }
+
+  // 3. Timestamp / build time check (fallback)
+  const localTime = local.timestamp ?? local.buildTime ?? 0;
+  const remoteTime = remote.timestamp ?? remote.buildTime ?? 0;
+
+  if (localTime > 0 && remoteTime > 0 && remoteTime > localTime) {
+    return true;
+  }
+
+  return false;
+}

--- a/saberparatodos/tests/unit/build-version.spec.ts
+++ b/saberparatodos/tests/unit/build-version.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { isNewerVersion, isNewerBuild, type BuildInfo } from '../../src/lib/build-version';
+
+describe('build-version helpers', () => {
+  describe('isNewerVersion', () => {
+    it('returns true when remote semver is higher', () => {
+      expect(isNewerVersion('0.15.1', '0.15.2')).toBe(true);
+      expect(isNewerVersion('0.15.1', '0.16.0')).toBe(true);
+      expect(isNewerVersion('0.15.1', '1.0.0')).toBe(true);
+    });
+
+    it('returns false when remote semver is equal or lower', () => {
+      expect(isNewerVersion('0.15.1', '0.15.1')).toBe(false);
+      expect(isNewerVersion('0.15.1', '0.15.0')).toBe(false);
+      expect(isNewerVersion('1.0.0', '0.9.9')).toBe(false);
+    });
+
+    it('handles empty or invalid strings gracefully', () => {
+      expect(isNewerVersion('', '0.15.1')).toBe(false);
+      expect(isNewerVersion('0.15.1', '')).toBe(false);
+    });
+  });
+
+  describe('isNewerBuild', () => {
+    it('returns false when local and remote commits and versions match (same build)', () => {
+      const local: BuildInfo = {
+        version: '0.15.1',
+        commit: 'abc1234',
+        timestamp: 1000
+      };
+      const remote: BuildInfo = {
+        version: '0.15.1',
+        commit: 'abc1234',
+        timestamp: 1000
+      };
+
+      expect(isNewerBuild(local, remote)).toBe(false);
+    });
+
+    it('returns true when version is the same but commit hash is different (EL CASO DEL BUG)', () => {
+      const local: BuildInfo = {
+        version: '0.15.1',
+        commit: 'abc1234',
+        timestamp: 1000
+      };
+      const remote: BuildInfo = {
+        version: '0.15.1',
+        commit: 'def5678',
+        timestamp: 2000
+      };
+
+      expect(isNewerBuild(local, remote)).toBe(true);
+    });
+
+    it('returns true when remote has higher semver version regardless of commit', () => {
+      const local: BuildInfo = {
+        version: '0.15.1',
+        commit: 'abc1234',
+        timestamp: 1000
+      };
+      const remote: BuildInfo = {
+        version: '0.15.2',
+        commit: 'abc1234',
+        timestamp: 1000
+      };
+
+      expect(isNewerBuild(local, remote)).toBe(true);
+    });
+
+    it('falls back to timestamp/buildTime comparison when commit hashes match or are missing', () => {
+      const localNoCommit: BuildInfo = {
+        version: '0.15.1',
+        timestamp: 1000
+      };
+      const remoteNoCommit: BuildInfo = {
+        version: '0.15.1',
+        timestamp: 2000
+      };
+
+      expect(isNewerBuild(localNoCommit, remoteNoCommit)).toBe(true);
+    });
+
+    it('returns false when either local or remote info is null', () => {
+      const info: BuildInfo = { version: '0.15.1', commit: 'abc1234' };
+      expect(isNewerBuild(null, info)).toBe(false);
+      expect(isNewerBuild(info, null)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Enhances VersionBadge.svelte to detect new deployments based on commit hashes and build timestamps in addition to semver version comparisons. This ensures users receive update toasts when redeployments occur under the same version number.

Fixes #1262

---
*PR created automatically by Jules for task [13415721300539381589](https://jules.google.com/task/13415721300539381589) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved update detection to recognize newer application versions, builds, and deployment timestamps.
  - Version information now remains available when some server-provided details are missing.
  - The displayed build date uses an available timestamp when the primary build time is unavailable.

- **Tests**
  - Added coverage for version and build comparison scenarios, including missing, invalid, matching, and newer build information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->